### PR TITLE
Remove duplicate definitions from Package

### DIFF
--- a/src/export/FHIRExporter.ts
+++ b/src/export/FHIRExporter.ts
@@ -22,6 +22,13 @@ export class FHIRExporter {
     this.extensionExporter = new ExtensionExporter(this.FHIRDefs, tank);
     const profileDefs = this.profileExporter.export();
     const extensionDefs = this.extensionExporter.export();
-    return new Package(profileDefs, extensionDefs, tank.config);
+    // TODO: There is currently a bug in how we do exports that causes some duplicates in the
+    // Package.  More specifically, if a FSH Extension is resolved while exporting a Profile,
+    // then the resolved Extension will be put in the Profiles array.  The reverse is also
+    // true.  We need to determine how best to fix that bug, but in the meantime, we will
+    // just remove the duplicates here so the downstream processes don't have to deal with it.
+    const deduplicatedProfileDefs = profileDefs.filter(sd => tank.findProfile(sd.name));
+    const deduplicatedExtensionDefs = extensionDefs.filter(sd => tank.findExtension(sd.name));
+    return new Package(deduplicatedProfileDefs, deduplicatedExtensionDefs, tank.config);
   }
 }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -161,11 +161,18 @@ export class StructureDefinitionExporter {
         this.structDefs.find(sd => sd.name === type || sd.id === type || sd.url === type)
       );
       if (!structDef) {
-        // If we find a parent, then we can export and resolve for its type again
-        const parentDefinition = this.tank.findProfile(type) ?? this.tank.findExtension(type);
-        if (parentDefinition) {
-          this.exportStructDef(parentDefinition);
-          structDef = this.resolve(parentDefinition.name);
+        // If we find a FSH definition, then we can export and resolve for its type again
+        // TODO: This causes a problem because this instance of StructureDefinitionExporter is
+        // either a ProfileExporter or ExtensionExporter -- but we are resolving profiles and
+        // extensions here.  So the end result is that an Extension definition might end up in
+        // the ProfileExporter's structDefs array and/or a Profile definition might end up in the
+        // ExtensionExporter's array.  This causes duplicates in the final Package.  We need to
+        // fix this, but until we decide the best solution, we are just deduplicating in the
+        // FHIRExporter.
+        const fshDefinition = this.tank.findProfile(type) ?? this.tank.findExtension(type);
+        if (fshDefinition) {
+          this.exportStructDef(fshDefinition);
+          structDef = this.resolve(fshDefinition.name);
         }
       }
       return structDef;


### PR DESCRIPTION
There is currently a bug in how we do exports that causes some duplicates in the  Package.  More specifically, if a FSH Extension is resolved while exporting a Profile,  then the resolved Extension will be put in the Profiles array.  The reverse is also true.  We need to determine how best to fix that bug, but in the meantime, we will just remove the duplicates when we return a Package in FHIRExporter.