### PR TITLE
Fix value on Instance from Structure Definition

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -65,9 +65,7 @@ export class InstanceExporter {
     existingPath: PathPart[],
     instanceDef: InstanceDefinition
   ) {
-    const directChildren = element
-      .children()
-      .filter(c => c.path.split('.').length === element.path.split('.').length + 1);
+    const directChildren = element.children(true);
     for (const child of directChildren) {
       // Fixed values may be specified by the fixed[x] or pattern[x] fields
       const fixedValueKey = Object.keys(child).find(

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1298,11 +1298,16 @@ export class ElementDefinition {
    * Finds and returns all child elements of this element.  For example, the children of `Foo.bar` might be the
    * elements `Foo.bar.one`, `Foo.bar.two`, and `Foo.bar.two.a`.  This will not "expand" or "unroll" elements; it
    * only returns those child elements that already exist in the structure definition.
+   * @param {boolean} directOnly - If true, only direct children of the element are returned
    * @returns {ElementDefinition[]} the child elements of this element
    */
-  children(): ElementDefinition[] {
+  children(directOnly = false): ElementDefinition[] {
     return this.structDef.elements.filter(e => {
-      return e !== this && e.id.startsWith(`${this.id}.`);
+      return (
+        e !== this &&
+        e.id.startsWith(`${this.id}.`) &&
+        (!directOnly || e.path.split('.').length === this.path.split('.').length + 1)
+      );
     });
   }
 

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -308,17 +308,24 @@ export class ElementDefinition {
         diff[prop] = cloneDeep(this[prop]);
       }
     }
-    // If the id is a choice slice, we change the id/path in the differential to use a shortcut syntax
-    // described here https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/.
     // Path gets set automatically when setting id
-    diff.id = diff.id
+    diff.id = diff.diffId();
+    return diff;
+  }
+
+  /**
+   * Gets the id of an element on the differential using the shortcut syntax described here
+   * https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/
+   * @returns {string} the id for the differential
+   */
+  diffId(): string {
+    return this.id
       .split('.')
       .map(p => {
         const i = p.indexOf('[x]:');
         return i > -1 ? p.slice(i + 4) : p;
       })
       .join('.');
-    return diff;
   }
 
   /**

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -104,4 +104,52 @@ describe('InstanceExporter', () => {
     expect(exported.length).toBe(1);
     expect(exported[0].gender).toBe('foo');
   });
+
+  it('should fix values on an instance if the value is fixed on the Structure Definition', () => {
+    const patient = new Profile('TestPatient');
+    patient.parent = 'Patient';
+    doc.profiles.set(patient.name, patient);
+    const instance = new Instance('Bar');
+    instance.instanceOf = 'TestPatient';
+    doc.instances.set(instance.name, instance);
+    const fixedValRule = new FixedValueRule('active');
+    fixedValRule.fixedValue = true;
+    patient.rules.push(fixedValRule);
+    const exported = exporter.export();
+    expect(exported.length).toBe(1);
+    expect(exported[0].active).toBe(true);
+  });
+
+  it('should fix values on an instance if the value is fixed by a pattern on the Structure Definition', () => {
+    const patient = new Profile('TestPatient');
+    patient.parent = 'Patient';
+    doc.profiles.set(patient.name, patient);
+    const instance = new Instance('Bar');
+    instance.instanceOf = 'TestPatient';
+    doc.instances.set(instance.name, instance);
+    const fixedValRule = new FixedValueRule('maritalStatus');
+    const fixedFshCode = new FshCode('foo', 'http://foo.com');
+    fixedValRule.fixedValue = fixedFshCode;
+    patient.rules.push(fixedValRule);
+    const exported = exporter.export();
+    expect(exported.length).toBe(1);
+    expect(exported[0].maritalStatus).toEqual({
+      coding: [{ code: 'foo', system: 'http://foo.com' }]
+    });
+  });
+
+  it('should fix choice values on an instance if the value is fixed on the Structure Definition', () => {
+    const patient = new Profile('TestPatient');
+    patient.parent = 'Patient';
+    doc.profiles.set(patient.name, patient);
+    const instance = new Instance('Bar');
+    instance.instanceOf = 'TestPatient';
+    doc.instances.set(instance.name, instance);
+    const fixedValRule = new FixedValueRule('deceasedBoolean');
+    fixedValRule.fixedValue = true;
+    patient.rules.push(fixedValRule);
+    const exported = exporter.export();
+    expect(exported.length).toBe(1);
+    expect(exported[0].deceasedBoolean).toBe(true);
+  });
 });


### PR DESCRIPTION
This addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-189: Automatically set fixed values on instance from profile.

The desired behavior is that fixed values are set on an instance for one of two reasons:
*  If a top level (aka the element is not nested within some other element) element in the SD that we are making an instance of has a fixed value.
* If the direct parent of a nested element is created by the user within the instance, and the nested element has a fixed value.

For example, let's say we made a profile of Patient, https://www.hl7.org/fhir/patient.html, and `active` was fixed to `true` on this profile. Then when making an instance of Patient, `active` is auto set to true since it is top level. If on the profile of patient we set `communication.preferred` to `true`, then `communication.preferred` is only auto set to `true` on the instance if the user writes a rule on the instance that creates the `communication` object. So this would be any rule that fixes a value on `communication` or a child of `communication`.