### PR TITLE
Unfold children of slices directly from SD

### DIFF
--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -319,6 +319,53 @@ describe('ElementDefinition', () => {
       expect(observation.elements[codeIdx + 5].id).toBe('Observation.subject');
     });
 
+    it('should add children from the Structure Definition when they exist', () => {
+      const numOriginalElements = observation.elements.length;
+      const component = observation.elements.find(e => e.path === 'Observation.component');
+      component.slicing = {
+        ordered: false,
+        rules: 'open',
+        discriminator: [{ type: 'value', path: 'code' }]
+      };
+      const componentSlice = component.addSlice('FooSlice');
+      const componentSliceIdx = observation.elements.findIndex(e => e.id === componentSlice.id);
+      const newElements = componentSlice.unfold(resolve);
+      expect(newElements).toHaveLength(8);
+      expect(newElements[0].id).toBe('Observation.component:FooSlice.id');
+      expect(newElements[1].id).toBe('Observation.component:FooSlice.extension');
+      expect(newElements[2].id).toBe('Observation.component:FooSlice.modifierExtension');
+      expect(newElements[3].id).toBe('Observation.component:FooSlice.code');
+      expect(newElements[4].id).toBe('Observation.component:FooSlice.value[x]');
+      expect(newElements[5].id).toBe('Observation.component:FooSlice.dataAbsentReason');
+      expect(newElements[6].id).toBe('Observation.component:FooSlice.interpretation');
+      expect(newElements[7].id).toBe('Observation.component:FooSlice.referenceRange');
+      expect(observation.elements).toHaveLength(numOriginalElements + 9);
+      expect(observation.elements[componentSliceIdx + 1].id).toBe(
+        'Observation.component:FooSlice.id'
+      );
+      expect(observation.elements[componentSliceIdx + 2].id).toBe(
+        'Observation.component:FooSlice.extension'
+      );
+      expect(observation.elements[componentSliceIdx + 3].id).toBe(
+        'Observation.component:FooSlice.modifierExtension'
+      );
+      expect(observation.elements[componentSliceIdx + 4].id).toBe(
+        'Observation.component:FooSlice.code'
+      );
+      expect(observation.elements[componentSliceIdx + 5].id).toBe(
+        'Observation.component:FooSlice.value[x]'
+      );
+      expect(observation.elements[componentSliceIdx + 6].id).toBe(
+        'Observation.component:FooSlice.dataAbsentReason'
+      );
+      expect(observation.elements[componentSliceIdx + 7].id).toBe(
+        'Observation.component:FooSlice.interpretation'
+      );
+      expect(observation.elements[componentSliceIdx + 8].id).toBe(
+        'Observation.component:FooSlice.referenceRange'
+      );
+    });
+
     it('should not add any children when an element has multiple types', () => {
       const numOriginalElements = observation.elements.length;
       const valueIdx = observation.elements.findIndex(e => e.path === 'Observation.value[x]');

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -307,6 +307,22 @@ describe('StructureDefinition', () => {
       expect(codeText.short).toBe('Plain text representation of the concept');
       expect(observation.elements.length).toBe(originalLength + 4);
     });
+
+    it('should find an element that must be unfolded from the Structure Definition by path', () => {
+      const originalLength = observation.elements.length;
+      const component = observation.elements.find(e => e.id === 'Observation.component');
+      component.slicing = {
+        ordered: false,
+        rules: 'open',
+        discriminator: [{ type: 'value', path: 'code' }]
+      };
+      component.addSlice('FooSlice');
+      const componentCode = observation.findElementByPath('component[FooSlice].code', resolve);
+      expect(componentCode).toBeDefined();
+      expect(componentCode.id).toBe('Observation.component:FooSlice.code');
+      expect(componentCode.path).toBe('Observation.component.code');
+      expect(observation.elements.length).toBe(originalLength + 9);
+    });
   });
 
   describe('#setInstancePropertyByPath', () => {


### PR DESCRIPTION
This addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-206, unable to find inline children of slices.

When an element is sliced, and that element has children that are on the SD, we should unfold those children onto slices of the element. Previously we were unfolding the element from the FHIR definition of the type of the element. Now we will first check if the sliced element has children on the SD, and if it does, we unfold with those children. If the sliced element does not have children, then we revert to the old behavior where we unfold from the FHIR definition of the type.

If you want to test this further, checkout master on fsh-mcode https://github.com/standardhealth/fsh-mcode, but go into CancerGenomics.fsh and uncomment lines 45 through 80, which deal with setting slices on `component`. When you run SUSHI on master against fsh-mcode, you should see a bunch of errors coming from these lines. When you run SUSHI on this branch against fsh-mcode, these errors should go away, and you should see these lines accurately reflected in the output StructureDefinition-CancerGeneticVariant.json file.