### PR TITLE
Import CodeSystem

### DIFF
--- a/src/errors/CodeSystemDuplicateCodeError.ts
+++ b/src/errors/CodeSystemDuplicateCodeError.ts
@@ -1,0 +1,8 @@
+import { Annotated } from './Annotated';
+
+export class CodeSystemDuplicateCodeError extends Error implements Annotated {
+  specReferences = ['http://hl7.org/fhir/codesystem.html#invs'];
+  constructor(system: string, code: string) {
+    super(`CodeSystem ${system} already contains code ${code}.`);
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -6,6 +6,7 @@ export * from './NoSingleTypeError';
 export * from './MismatchedTypeError';
 export * from './CodeAndSystemMismatchError';
 export * from './CodedTypeNotFoundError';
+export * from './CodeSystemDuplicateCodeError';
 export * from './DisableFlagError';
 export * from './InvalidCardinalityError';
 export * from './InvalidDateTimeError';

--- a/src/fshtypes/CodeSystem.ts
+++ b/src/fshtypes/CodeSystem.ts
@@ -1,5 +1,6 @@
 import { FshEntity } from './FshEntity';
 import { FshConcept } from './FshConcept';
+import { CodeSystemDuplicateCodeError } from '../errors/CodeSystemDuplicateCodeError';
 
 /**
  * For more information about a CodeSystem in FHIR,
@@ -17,7 +18,10 @@ export class CodeSystem extends FshEntity {
     this.concepts = [];
   }
 
-  addConcept(code: string, display?: string, definition?: string) {
-    this.concepts.push(new FshConcept(code, display, definition));
+  addConcept(newConcept: FshConcept) {
+    if (this.concepts.find(existingConcept => existingConcept.code == newConcept.code)) {
+      throw new CodeSystemDuplicateCodeError(this.id, newConcept.code);
+    }
+    this.concepts.push(newConcept);
   }
 }

--- a/src/fshtypes/index.ts
+++ b/src/fshtypes/index.ts
@@ -3,6 +3,7 @@ export * from './Config';
 export * from './Extension';
 export * from './Instance';
 export * from './FshCode';
+export * from './FshConcept';
 export * from './FshEntity';
 export * from './FshQuantity';
 export * from './FshRatio';

--- a/src/import/FSHDocument.ts
+++ b/src/import/FSHDocument.ts
@@ -1,4 +1,4 @@
-import { Profile, Extension, Instance, FshValueSet } from '../fshtypes';
+import { Profile, Extension, Instance, FshValueSet, CodeSystem } from '../fshtypes';
 
 export class FSHDocument {
   readonly aliases: Map<string, string>;
@@ -6,6 +6,7 @@ export class FSHDocument {
   readonly extensions: Map<string, Extension>;
   readonly instances: Map<string, Instance>;
   readonly valueSets: Map<string, FshValueSet>;
+  readonly codeSystems: Map<string, CodeSystem>;
 
   constructor(public readonly file: string) {
     this.aliases = new Map();
@@ -13,5 +14,6 @@ export class FSHDocument {
     this.extensions = new Map();
     this.instances = new Map();
     this.valueSets = new Map();
+    this.codeSystems = new Map();
   }
 }

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -9,6 +9,7 @@ import {
   Profile,
   Extension,
   FshCode,
+  FshConcept,
   FshQuantity,
   FshRatio,
   FshReference,
@@ -21,7 +22,8 @@ import {
   ValueSetComponentFrom,
   ValueSetFilter,
   VsOperator,
-  ValueSetFilterValue
+  ValueSetFilterValue,
+  CodeSystem
 } from '../fshtypes';
 import {
   Rule,
@@ -62,6 +64,13 @@ enum InstanceMetadataKey {
 }
 
 enum VsMetadataKey {
+  Id = 'Id',
+  Title = 'Title',
+  Description = 'Description',
+  Unknown = 'Unknown'
+}
+
+enum CsMetadataKey {
   Id = 'Id',
   Title = 'Title',
   Description = 'Description',
@@ -156,6 +165,10 @@ export class FSHImporter extends FSHVisitor {
 
     if (ctx.valueSet()) {
       this.visitValueSet(ctx.valueSet());
+    }
+
+    if (ctx.codeSystem()) {
+      this.visitCodeSystem(ctx.codeSystem());
     }
   }
 
@@ -324,6 +337,47 @@ export class FSHImporter extends FSHVisitor {
       });
   }
 
+  visitCodeSystem(ctx: pc.CodeSystemContext) {
+    const codeSystem = new CodeSystem(ctx.SEQUENCE().getText())
+      .withLocation(this.extractStartStop(ctx))
+      .withFile(this.currentFile);
+    this.parseCodeSystem(codeSystem, ctx.csMetadata(), ctx.concept());
+    this.currentDoc.codeSystems.set(codeSystem.name, codeSystem);
+  }
+
+  private parseCodeSystem(
+    codeSystem: CodeSystem,
+    metaCtx: pc.CsMetadataContext[] = [],
+    conceptCtx: pc.ConceptContext[] = []
+  ) {
+    const seenPairs: Map<CsMetadataKey, string> = new Map();
+    metaCtx
+      .map(csMetadata => ({
+        ...this.visitCsMetadata(csMetadata),
+        context: csMetadata
+      }))
+      .forEach(pair => {
+        if (seenPairs.has(pair.key)) {
+          logger.error(
+            `Metadata field '${pair.key}' already declared with value '${seenPairs.get(
+              pair.key
+            )}'.`,
+            { file: this.currentFile, location: this.extractStartStop(pair.context) }
+          );
+          return;
+        }
+        seenPairs.set(pair.key, pair.value);
+        if (pair.key === CsMetadataKey.Id) {
+          codeSystem.id = pair.value;
+        } else if (pair.key === CsMetadataKey.Title) {
+          codeSystem.title = pair.value;
+        } else if (pair.key === CsMetadataKey.Description) {
+          codeSystem.description = pair.value;
+        }
+      });
+    codeSystem.concepts = conceptCtx.map(conceptCtx => this.visitConcept(conceptCtx));
+  }
+
   visitSdMetadata(ctx: pc.SdMetadataContext): { key: SdMetadataKey; value: string } {
     if (ctx.id()) {
       return { key: SdMetadataKey.Id, value: this.visitId(ctx.id()) };
@@ -357,6 +411,17 @@ export class FSHImporter extends FSHVisitor {
       return { key: VsMetadataKey.Description, value: this.visitDescription(ctx.description()) };
     }
     return { key: VsMetadataKey.Unknown, value: ctx.getText() };
+  }
+
+  visitCsMetadata(ctx: pc.CsMetadataContext): { key: CsMetadataKey; value: string } {
+    if (ctx.id()) {
+      return { key: CsMetadataKey.Id, value: this.visitId(ctx.id()) };
+    } else if (ctx.title()) {
+      return { key: CsMetadataKey.Title, value: this.visitTitle(ctx.title()) };
+    } else if (ctx.description()) {
+      return { key: CsMetadataKey.Description, value: this.visitDescription(ctx.description()) };
+    }
+    return { key: CsMetadataKey.Unknown, value: ctx.getText() };
   }
 
   visitId(ctx: pc.IdContext): string {
@@ -585,6 +650,17 @@ export class FSHImporter extends FSHVisitor {
     }
     if (ctx.STRING()) {
       concept.display = this.extractString(ctx.STRING());
+    }
+    return concept;
+  }
+
+  visitConcept(ctx: pc.ConceptContext): FshConcept {
+    const codePart = this.visitCode(ctx.code());
+    const concept = new FshConcept(codePart.code, codePart.display)
+      .withLocation(this.extractStartStop(ctx))
+      .withFile(this.currentFile);
+    if (ctx.STRING()) {
+      concept.definition = this.extractString(ctx.STRING());
     }
     return concept;
   }

--- a/test/import/FSHImporter.CodeSystem.test.ts
+++ b/test/import/FSHImporter.CodeSystem.test.ts
@@ -1,0 +1,137 @@
+import { importSingleText } from '../testhelpers/importSingleText';
+import { loggerSpy } from '../testhelpers/loggerSpy';
+
+describe('FSHImporter', () => {
+  describe('CodeSystem', () => {
+    describe('#csMetadata', () => {
+      it('should parse the simplest possible code system', () => {
+        const input = `
+        CodeSystem: ZOO
+        `;
+        const result = importSingleText(input, 'Zoo.fsh');
+        expect(result.codeSystems.size).toBe(1);
+        const codeSystem = result.codeSystems.get('ZOO');
+        expect(codeSystem.name).toBe('ZOO');
+        expect(codeSystem.id).toBe('ZOO');
+        expect(codeSystem.concepts).toEqual([]);
+        expect(codeSystem.sourceInfo.location).toEqual({
+          startLine: 2,
+          startColumn: 9,
+          endLine: 2,
+          endColumn: 23
+        });
+        expect(codeSystem.sourceInfo.file).toBe('Zoo.fsh');
+      });
+
+      it('should parse a code system with additional metadata', () => {
+        const input = `
+        CodeSystem: ZOO
+        Id: zoo-codes
+        Title: "Zoo Animals"
+        Description: "Animals and cryptids that may be at a zoo."
+        `;
+        const result = importSingleText(input, 'Zoo.fsh');
+        expect(result.codeSystems.size).toBe(1);
+        const codeSystem = result.codeSystems.get('ZOO');
+        expect(codeSystem.name).toBe('ZOO');
+        expect(codeSystem.id).toBe('zoo-codes');
+        expect(codeSystem.title).toBe('Zoo Animals');
+        expect(codeSystem.description).toBe('Animals and cryptids that may be at a zoo.');
+        expect(codeSystem.concepts).toEqual([]);
+        expect(codeSystem.sourceInfo.location).toEqual({
+          startLine: 2,
+          startColumn: 9,
+          endLine: 5,
+          endColumn: 65
+        });
+      });
+
+      it('should parse a code system with a multi-line description', () => {
+        const input = `
+        CodeSystem: ZOO
+        Id: zoo-codes
+        Title: "Zoo Animals"
+        Description: """
+        Animals that may be present at the zoo. This includes
+        animals that have been classified by biologists, as
+        well as certain cryptids, such as:
+        * quadrapedal cryptids
+          * jackalope
+          * hodag
+        * bipedal cryptids
+          * swamp ape
+          * hopkinsville goblin
+        """
+        `;
+        const result = importSingleText(input, 'Zoo.fsh');
+        expect(result.codeSystems.size).toBe(1);
+        const codeSystem = result.codeSystems.get('ZOO');
+        const expectedDescription = [
+          'Animals that may be present at the zoo. This includes',
+          'animals that have been classified by biologists, as',
+          'well as certain cryptids, such as:',
+          '* quadrapedal cryptids',
+          '  * jackalope',
+          '  * hodag',
+          '* bipedal cryptids',
+          '  * swamp ape',
+          '  * hopkinsville goblin'
+        ].join('\n');
+        expect(codeSystem.name).toBe('ZOO');
+        expect(codeSystem.id).toBe('zoo-codes');
+        expect(codeSystem.title).toBe('Zoo Animals');
+        expect(codeSystem.description).toBe(expectedDescription);
+        expect(codeSystem.concepts).toEqual([]);
+      });
+
+      it('should only apply each metadata attribute the first time it is declared', () => {
+        const input = `
+        CodeSystem: ZOO
+        Id: zoo-codes
+        Title: "Zoo Animals"
+        Description: "Animals and cryptids that may be at a zoo."
+        Title: "Duplicate Animals"
+        Id: zoo-codes-again
+        Description: "Lions and tigers and bears!"
+        `;
+        const result = importSingleText(input, 'Zoo.fsh');
+        expect(result.codeSystems.size).toBe(1);
+        const codeSystem = result.codeSystems.get('ZOO');
+        expect(codeSystem.name).toBe('ZOO');
+        expect(codeSystem.id).toBe('zoo-codes');
+        expect(codeSystem.title).toBe('Zoo Animals');
+        expect(codeSystem.description).toBe('Animals and cryptids that may be at a zoo.');
+        expect(codeSystem.concepts).toEqual([]);
+        expect(codeSystem.sourceInfo.location).toEqual({
+          startLine: 2,
+          startColumn: 9,
+          endLine: 8,
+          endColumn: 50
+        });
+      });
+
+      it('should log an error when encountering a duplicate metadata attribute', () => {
+        const input = `
+        CodeSystem: ZOO
+        Id: zoo-codes
+        Title: "Zoo Animals"
+        Description: "Animals and cryptids that may be at a zoo."
+        Title: "Duplicate Animals"
+        Id: zoo-codes-again
+        Description: "Lions and tigers and bears!"
+        `;
+        importSingleText(input, 'Zoo.fsh');
+        expect(loggerSpy.getMessageAtIndex(-3)).toMatch(/File: Zoo\.fsh.*Line: 6\D/s);
+        expect(loggerSpy.getMessageAtIndex(-2)).toMatch(/File: Zoo\.fsh.*Line: 7\D/s);
+        expect(loggerSpy.getLastMessage()).toMatch(/File: Zoo\.fsh.*Line: 8\D/s);
+      });
+    });
+    describe('#concept', () => {
+      it.todo('should parse a code system with one concept');
+      it.todo('should parse a code system with one concept with a display string');
+      it.todo('should parse a code system with one concept with display and definition strings');
+      it.todo('should parse a code system with more than one concept');
+      it.todo('should log an error when encountering a duplicate code');
+    });
+  });
+});


### PR DESCRIPTION
This pull request adds functionality to create `CodeSystem` instances from FSH. CodeSystems are relatively simple entities that hold a list of `FshConcept` instances, but there are two conditions that will result in error messages being emitted:
- If a listed concept includes a system, an error message is produced. Specifying a system isn't necessary, because the concept necessarily belongs to the CodeSystem being defined. The concept is still added to the CodeSystem.
- If a concept is listed more than once, only the first instance is used. This enforces `csd-1` on http://hl7.org/fhir/codesystem.html#invs.

Test cases exist to demonstrate each of these scenarios.

This pull request addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-197.