### PR TITLE
Code System Exporter

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -91,7 +91,8 @@ async function app() {
       ...outPackage.profiles,
       ...outPackage.extensions,
       ...outPackage.instances,
-      ...outPackage.valueSets
+      ...outPackage.valueSets,
+      ...outPackage.codeSystems
     ]) {
       fs.writeFileSync(
         path.join(program.out, sd.getFileName()),
@@ -106,6 +107,7 @@ async function app() {
   Extensions:  ${outPackage.extensions.length}
   Instances:   ${outPackage.instances.length}
   ValueSets:   ${outPackage.valueSets.length}
+  CodeSystems: ${outPackage.codeSystems.length}
   Errors:      ${stats.numError}
   Warnings:    ${stats.numWarn}`);
 }

--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -26,7 +26,7 @@ export class CodeSystemExporter {
     }
   }
 
-  exportCodeSystem(fshDefinition: FshCodeSystem) {
+  exportCodeSystem(fshDefinition: FshCodeSystem): void {
     if (this.codeSystems.some(cs => cs.name === fshDefinition.name)) {
       return;
     }
@@ -38,14 +38,14 @@ export class CodeSystemExporter {
 
   // TODO Get rid of argument once codesystems are on the tank
   export(curCodeSystems: FshCodeSystem[]): CodeSystem[] {
-    // this.tank.getAllCodeSystems().forEach(cs => {
-    curCodeSystems.forEach(cs => {
+    // for (const cs of this.tank.getAllCodeSystems()) {
+    for (const cs of curCodeSystems) {
       try {
         this.exportCodeSystem(cs);
       } catch (e) {
         logger.error(e.message, cs.sourceInfo);
       }
-    });
+    }
     return this.codeSystems;
   }
 }

--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -36,10 +36,8 @@ export class CodeSystemExporter {
     this.codeSystems.push(codeSystem);
   }
 
-  // TODO Get rid of argument once codesystems are on the tank
-  export(curCodeSystems: FshCodeSystem[]): CodeSystem[] {
-    // for (const cs of this.tank.getAllCodeSystems()) {
-    for (const cs of curCodeSystems) {
+  export(): CodeSystem[] {
+    for (const cs of this.tank.getAllCodeSystems()) {
       try {
         this.exportCodeSystem(cs);
       } catch (e) {

--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -1,0 +1,51 @@
+import { FSHTank } from '../import/FSHTank';
+import { CodeSystem, CodeSystemConcept } from '../fhirtypes';
+import { FshCodeSystem } from '../fshtypes';
+import { logger } from '../utils/FSHLogger';
+
+export class CodeSystemExporter {
+  public readonly codeSystems: CodeSystem[] = [];
+  constructor(public readonly tank: FSHTank) {}
+
+  private setMetadata(codeSystem: CodeSystem, fshDefinition: FshCodeSystem): void {
+    codeSystem.name = fshDefinition.name;
+    codeSystem.id = fshDefinition.id;
+    if (fshDefinition.title) codeSystem.title = fshDefinition.title;
+    if (fshDefinition.description) codeSystem.description = fshDefinition.description;
+    codeSystem.url = `${this.tank.config.canonical}/CodeSystem/${codeSystem.id}`;
+  }
+
+  private setConcepts(codeSystem: CodeSystem, fshDefinition: FshCodeSystem): void {
+    if (fshDefinition.concepts.length > 0) {
+      codeSystem.concept = fshDefinition.concepts.map(concept => {
+        const codeSystemConcept: CodeSystemConcept = { code: concept.code };
+        if (concept.display) codeSystemConcept.display = concept.display;
+        if (concept.definition) codeSystemConcept.definition = concept.definition;
+        return codeSystemConcept;
+      });
+    }
+  }
+
+  exportCodeSystem(fshDefinition: FshCodeSystem) {
+    if (this.codeSystems.some(cs => cs.name === fshDefinition.name)) {
+      return;
+    }
+    const codeSystem = new CodeSystem();
+    this.setMetadata(codeSystem, fshDefinition);
+    this.setConcepts(codeSystem, fshDefinition);
+    this.codeSystems.push(codeSystem);
+  }
+
+  // TODO Get rid of argument once codesystems are on the tank
+  export(curCodeSystems: FshCodeSystem[]): CodeSystem[] {
+    // this.tank.getAllCodeSystems().forEach(cs => {
+    curCodeSystems.forEach(cs => {
+      try {
+        this.exportCodeSystem(cs);
+      } catch (e) {
+        logger.error(e.message, cs.sourceInfo);
+      }
+    });
+    return this.codeSystems;
+  }
+}

--- a/src/export/FHIRExporter.ts
+++ b/src/export/FHIRExporter.ts
@@ -36,7 +36,7 @@ export class FHIRExporter {
     const { profileDefs, extensionDefs } = this.structureDefinitionExporter.export();
     const instanceDefs = this.instanceExporter.export();
     const valueSets = this.valueSetExporter.export();
-    const codeSystems = this.codeSystemExporter.export([]);
+    const codeSystems = this.codeSystemExporter.export();
 
     return new Package(
       profileDefs,

--- a/src/export/FHIRExporter.ts
+++ b/src/export/FHIRExporter.ts
@@ -36,7 +36,7 @@ export class FHIRExporter {
     const { profileDefs, extensionDefs } = this.structureDefinitionExporter.export();
     const instanceDefs = this.instanceExporter.export();
     const valueSets = this.valueSetExporter.export();
-    const codeSystems = this.codeSystemExporter.export();
+    const codeSystems = this.codeSystemExporter.export([]);
 
     return new Package(
       profileDefs,

--- a/src/export/FHIRExporter.ts
+++ b/src/export/FHIRExporter.ts
@@ -1,9 +1,12 @@
 import { FSHTank } from '../import/FSHTank';
 import { Package } from './Package';
-import { StructureDefinitionExporter } from './StructureDefinitionExporter';
+import {
+  CodeSystemExporter,
+  InstanceExporter,
+  StructureDefinitionExporter,
+  ValueSetExporter
+} from '.';
 import { FHIRDefinitions } from '../fhirdefs';
-import { InstanceExporter } from './InstanceExporter';
-import { ValueSetExporter } from './ValueSetExporter';
 /**
  * FHIRExporter handles the processing of FSH documents, storing the FSH types within them as FHIR types.
  * FHIRExporter takes the Profiles and Extensions within the FSHDocuments of a FSHTank and returns them
@@ -14,6 +17,7 @@ export class FHIRExporter {
   private structureDefinitionExporter: StructureDefinitionExporter;
   private instanceExporter: InstanceExporter;
   private valueSetExporter: ValueSetExporter;
+  private codeSystemExporter: CodeSystemExporter;
 
   constructor(FHIRDefs: FHIRDefinitions) {
     this.FHIRDefs = FHIRDefs;
@@ -27,11 +31,20 @@ export class FHIRExporter {
       this.structureDefinitionExporter.resolve.bind(this.structureDefinitionExporter)
     );
     this.valueSetExporter = new ValueSetExporter(tank);
+    this.codeSystemExporter = new CodeSystemExporter(tank);
 
     const { profileDefs, extensionDefs } = this.structureDefinitionExporter.export();
     const instanceDefs = this.instanceExporter.export();
     const valueSets = this.valueSetExporter.export();
+    const codeSystems = this.codeSystemExporter.export();
 
-    return new Package(profileDefs, extensionDefs, instanceDefs, valueSets, tank.config);
+    return new Package(
+      profileDefs,
+      extensionDefs,
+      instanceDefs,
+      valueSets,
+      codeSystems,
+      tank.config
+    );
   }
 }

--- a/src/export/Package.ts
+++ b/src/export/Package.ts
@@ -1,4 +1,4 @@
-import { StructureDefinition, InstanceDefinition, ValueSet } from '../fhirtypes';
+import { StructureDefinition, InstanceDefinition, ValueSet, CodeSystem } from '../fhirtypes';
 import { Config } from '../fshtypes';
 
 export class Package {
@@ -7,6 +7,7 @@ export class Package {
     public readonly extensions: StructureDefinition[],
     public readonly instances: InstanceDefinition[],
     public readonly valueSets: ValueSet[],
+    public readonly codeSystems: CodeSystem[],
     public readonly config: Config
   ) {}
 }

--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -2,5 +2,6 @@ export * from './FHIRExporter';
 export * from './StructureDefinitionExporter';
 export * from './InstanceExporter';
 export * from './ValueSetExporter';
+export * from './CodeSystemExporter';
 export * from './exportFHIR';
 export * from './Package';

--- a/src/fhirtypes/CodeSystem.ts
+++ b/src/fhirtypes/CodeSystem.ts
@@ -1,0 +1,87 @@
+import { Meta } from './specialTypes';
+import { Extension } from '../fshtypes';
+import { Narrative, Resource, Identifier, CodeableConcept, Coding } from './dataTypes';
+import { ContactDetail, UsageContext } from './metaDataTypes';
+import { ValueSet } from './ValueSet';
+
+/**
+ * Class representing a FHIR R4 CodeSystem
+ * @see {@link https://www.hl7.org/fhir/codesystem.html}
+ */
+export class CodeSystem {
+  id?: string;
+  meta?: Meta;
+  implicitRules?: string;
+  language?: string;
+  text?: Narrative;
+  contained?: Resource[];
+  extension?: Extension[];
+  modifierExtension?: Extension[];
+  url?: string;
+  identifier?: Identifier[];
+  version?: string;
+  name?: string;
+  title?: string;
+  status = 'active';
+  experimental?: boolean;
+  date?: string;
+  publisher?: string;
+  contact?: ContactDetail[];
+  description?: string;
+  useContext?: UsageContext[];
+  jurisdiction?: CodeableConcept[];
+  purpose?: string;
+  copyright?: string;
+  caseSensitive?: boolean;
+  valueSet?: ValueSet;
+  hierarchyMeaning?: string;
+  compositional?: boolean;
+  versionNeeded?: boolean;
+  content = 'complete';
+  supplements?: CodeSystem;
+  count?: number;
+  filter?: CodeSystemFilter[];
+  property?: CodeSystemProperty[];
+  concept?: CodeSystemConcept[];
+}
+
+export type CodeSystemFilter = {
+  code: string;
+  description?: string;
+  operator: string[];
+  value: string;
+};
+
+export type CodeSystemProperty = {
+  code: string;
+  uri?: string;
+  description?: string;
+  type: string;
+};
+
+export type CodeSystemConcept = {
+  code: string;
+  display?: string;
+  definition?: string;
+  designation?: CodeSystemConceptDesignation[];
+  property?: CodeSystemConceptProperty[];
+  concept?: CodeSystemConcept[];
+};
+
+export type CodeSystemConceptDesignation = {
+  language?: string;
+  use?: Coding;
+  value: string;
+};
+
+export type CodeSystemConceptProperty = {
+  code: string;
+  // value[x] is 1..1, but can be any one of the following names/types:
+  valueCode?: string;
+  valueCoding?: Coding;
+  valueString?: string;
+  valueInteger?: number;
+  valueBoolean?: boolean;
+  valueDateTime?: string;
+  valueDecimal?: number;
+};

--- a/src/fhirtypes/CodeSystem.ts
+++ b/src/fhirtypes/CodeSystem.ts
@@ -2,7 +2,6 @@ import { Meta } from './specialTypes';
 import { Extension } from '../fshtypes';
 import { Narrative, Resource, Identifier, CodeableConcept, Coding } from './dataTypes';
 import { ContactDetail, UsageContext } from './metaDataTypes';
-import { ValueSet } from './ValueSet';
 
 /**
  * Class representing a FHIR R4 CodeSystem
@@ -33,12 +32,12 @@ export class CodeSystem {
   purpose?: string;
   copyright?: string;
   caseSensitive?: boolean;
-  valueSet?: ValueSet;
+  valueSet?: string;
   hierarchyMeaning?: string;
   compositional?: boolean;
   versionNeeded?: boolean;
   content = 'complete';
-  supplements?: CodeSystem;
+  supplements?: string;
   count?: number;
   filter?: CodeSystemFilter[];
   property?: CodeSystemProperty[];

--- a/src/fhirtypes/CodeSystem.ts
+++ b/src/fhirtypes/CodeSystem.ts
@@ -43,6 +43,25 @@ export class CodeSystem {
   filter?: CodeSystemFilter[];
   property?: CodeSystemProperty[];
   concept?: CodeSystemConcept[];
+
+  /**
+   * Get the file name for serializing to disk.
+   * @returns {string} the filename
+   */
+  getFileName(): string {
+    return `CodeSystem-${this.id}.json`;
+  }
+
+  /**
+   * Exports the CodeSystem to a properly formatted FHIR JSON representation.
+   * @returns {any} the FHIR JSON representation of the CodeSystem
+   */
+  toJSON(): any {
+    return {
+      resourceType: 'CodeSystem',
+      ...this
+    };
+  }
 }
 
 export type CodeSystemFilter = {

--- a/src/fhirtypes/index.ts
+++ b/src/fhirtypes/index.ts
@@ -2,6 +2,7 @@ export * from './dataTypes';
 export * from './metaDataTypes';
 export * from './primitiveTypes';
 export * from './specialTypes';
+export * from './CodeSystem';
 export * from './ElementDefinition';
 export * from './ImplementationGuide';
 export * from './InstanceDefinition';

--- a/src/fshtypes/FshCodeSystem.ts
+++ b/src/fshtypes/FshCodeSystem.ts
@@ -6,7 +6,7 @@ import { CodeSystemDuplicateCodeError } from '../errors/CodeSystemDuplicateCodeE
  * For more information about a CodeSystem in FHIR,
  * @see {@link http://hl7.org/fhir/codesystem-definitions.html}
  */
-export class CodeSystem extends FshEntity {
+export class FshCodeSystem extends FshEntity {
   id: string;
   title?: string;
   description?: string;

--- a/src/fshtypes/index.ts
+++ b/src/fshtypes/index.ts
@@ -1,4 +1,4 @@
-export * from './CodeSystem';
+export * from './FshCodeSystem';
 export * from './Config';
 export * from './Extension';
 export * from './Instance';

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -193,6 +193,15 @@ export class IGExporter {
         description: valueSet.description
       });
     });
+    sortBy(this.pkg.codeSystems, codeSystem => codeSystem.name).forEach(codeSystem => {
+      const codeSystemPath = path.join(igPath, 'input', 'resources', codeSystem.getFileName());
+      outputJSONSync(codeSystemPath, codeSystem.toJSON(), { spaces: 2 });
+      this.ig.definition.resource.push({
+        reference: { reference: `CodeSystem/${codeSystem.id}` },
+        name: codeSystem.title ?? codeSystem.name,
+        description: codeSystem.description
+      });
+    });
   }
 
   /**

--- a/src/import/FSHDocument.ts
+++ b/src/import/FSHDocument.ts
@@ -1,4 +1,4 @@
-import { Profile, Extension, Instance, FshValueSet, CodeSystem } from '../fshtypes';
+import { Profile, Extension, Instance, FshValueSet, FshCodeSystem } from '../fshtypes';
 
 export class FSHDocument {
   readonly aliases: Map<string, string>;
@@ -6,7 +6,7 @@ export class FSHDocument {
   readonly extensions: Map<string, Extension>;
   readonly instances: Map<string, Instance>;
   readonly valueSets: Map<string, FshValueSet>;
-  readonly codeSystems: Map<string, CodeSystem>;
+  readonly codeSystems: Map<string, FshCodeSystem>;
 
   constructor(public readonly file: string) {
     this.aliases = new Map();

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -23,7 +23,7 @@ import {
   ValueSetFilter,
   VsOperator,
   ValueSetFilterValue,
-  CodeSystem
+  FshCodeSystem
 } from '../fshtypes';
 import {
   Rule,
@@ -338,7 +338,7 @@ export class FSHImporter extends FSHVisitor {
   }
 
   visitCodeSystem(ctx: pc.CodeSystemContext) {
-    const codeSystem = new CodeSystem(ctx.SEQUENCE().getText())
+    const codeSystem = new FshCodeSystem(ctx.SEQUENCE().getText())
       .withLocation(this.extractStartStop(ctx))
       .withFile(this.currentFile);
     this.parseCodeSystem(codeSystem, ctx.csMetadata(), ctx.concept());
@@ -346,7 +346,7 @@ export class FSHImporter extends FSHVisitor {
   }
 
   private parseCodeSystem(
-    codeSystem: CodeSystem,
+    codeSystem: FshCodeSystem,
     metaCtx: pc.CsMetadataContext[] = [],
     conceptCtx: pc.ConceptContext[] = []
   ) {

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -1,5 +1,5 @@
 import { FSHDocument } from './FSHDocument';
-import { Profile, Extension, Instance, FshValueSet } from '../fshtypes';
+import { Profile, Extension, Instance, FshValueSet, FshCodeSystem } from '../fshtypes';
 import flatMap from 'lodash/flatMap';
 import { Config } from '../fshtypes/Config';
 
@@ -48,6 +48,14 @@ export class FSHTank {
    */
   public getAllValueSets(): FshValueSet[] {
     return flatMap(this.docs, doc => Array.from(doc.valueSets.values()));
+  }
+
+  /**
+   * Gets all code systems in the tank
+   * @returns {FshCodeSystem[]}
+   */
+  public getAllCodeSystems(): FshCodeSystem[] {
+    return flatMap(this.docs, doc => Array.from(doc.codeSystems.values()));
   }
 
   /**

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -15,14 +15,14 @@ describe('CodeSystemExporter', () => {
   });
 
   it('should output empty results with empty input', () => {
-    const exported = exporter.export([]);
+    const exported = exporter.export();
     expect(exported).toEqual([]);
   });
 
   it('should export a single code system', () => {
     const codeSystem = new FshCodeSystem('MyCodeSystem');
-    // doc.codeSystems.set(codeSystem.name, codeSystem); // TODO Add this and remove the argument
-    const exported = exporter.export([codeSystem]);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export();
     expect(exported.length).toBe(1);
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
@@ -37,8 +37,8 @@ describe('CodeSystemExporter', () => {
     const codeSystem = new FshCodeSystem('MyCodeSystem');
     codeSystem.title = 'My Fancy Code System';
     codeSystem.description = 'Lots of important details about my fancy code system';
-    // doc.codeSystems.set(codeSystem.name, codeSystem); // TODO add this and remove arg
-    const exported = exporter.export([codeSystem]);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export();
     expect(exported.length).toBe(1);
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
@@ -51,13 +51,12 @@ describe('CodeSystemExporter', () => {
     });
   });
 
-  // TODO does this equivalent pass for instance export?? Probably not - maybe yes because not a global variable that's exported!
   it('should export each code system once, even if export is called more than once', () => {
     const codeSystem = new FshCodeSystem('MyCodeSystem');
-    // doc.codeSystems.set(codeSystem.name, codeSystem); // TODO add this and remove arg
-    const exported = exporter.export([codeSystem]);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export();
     expect(exported.length).toBe(1);
-    const exportedAgain = exporter.export([codeSystem]); // TODO remove this arg too
+    const exportedAgain = exporter.export();
     expect(exportedAgain.length).toBe(1);
   });
 
@@ -65,8 +64,8 @@ describe('CodeSystemExporter', () => {
     const codeSystem = new FshCodeSystem('MyCodeSystem');
     const concept = new FshConcept('myCode');
     codeSystem.concepts = [concept];
-    // doc.codeSystems.set(codeSystem.name, codeSystem); // TODO add this and remove arg
-    const exported = exporter.export([codeSystem]);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export();
     expect(exported.length).toBe(1);
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
@@ -82,8 +81,8 @@ describe('CodeSystemExporter', () => {
     const codeSystem = new FshCodeSystem('MyCodeSystem');
     const concept = new FshConcept('myCode', 'My code', 'This is the formal definition of my code');
     codeSystem.concepts = [concept];
-    // doc.codeSystems.set(codeSystem.name, codeSystem); // TODO add this and remove arg
-    const exported = exporter.export([codeSystem]);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export();
     expect(exported.length).toBe(1);
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -1,0 +1,99 @@
+import { CodeSystemExporter } from '../../src/export';
+import { FSHDocument, FSHTank } from '../../src/import';
+import { FshCodeSystem } from '../../src/fshtypes';
+import { FshConcept } from '../../src/fshtypes/FshConcept';
+
+describe('CodeSystemExporter', () => {
+  let doc: FSHDocument;
+  let input: FSHTank;
+  let exporter: CodeSystemExporter;
+
+  beforeEach(() => {
+    doc = new FSHDocument('fileName');
+    input = new FSHTank([doc], { name: 'test', version: '0.0.1', canonical: 'http://example.com' });
+    exporter = new CodeSystemExporter(input);
+  });
+
+  it('should output empty results with empty input', () => {
+    const exported = exporter.export([]);
+    expect(exported).toEqual([]);
+  });
+
+  it('should export a single code system', () => {
+    const codeSystem = new FshCodeSystem('MyCodeSystem');
+    // doc.codeSystems.set(codeSystem.name, codeSystem); // TODO Add this and remove the argument
+    const exported = exporter.export([codeSystem]);
+    expect(exported.length).toBe(1);
+    expect(exported[0]).toEqual({
+      name: 'MyCodeSystem',
+      id: 'MyCodeSystem',
+      status: 'active',
+      url: 'http://example.com/CodeSystem/MyCodeSystem'
+    });
+  });
+
+  it('should export a code system with additional metadata', () => {
+    const codeSystem = new FshCodeSystem('MyCodeSystem');
+    codeSystem.title = 'My Fancy Code System';
+    codeSystem.description = 'Lots of important details about my fancy code system';
+    // doc.codeSystems.set(codeSystem.name, codeSystem); // TODO add this and remove arg
+    const exported = exporter.export([codeSystem]);
+    expect(exported.length).toBe(1);
+    expect(exported[0]).toEqual({
+      name: 'MyCodeSystem',
+      id: 'MyCodeSystem',
+      status: 'active',
+      url: 'http://example.com/CodeSystem/MyCodeSystem',
+      title: 'My Fancy Code System',
+      description: 'Lots of important details about my fancy code system'
+    });
+  });
+
+  // TODO does this equivalent pass for instance export?? Probably not - maybe yes because not a global variable that's exported!
+  it('should export each code system once, even if export is called more than once', () => {
+    const codeSystem = new FshCodeSystem('MyCodeSystem');
+    // doc.codeSystems.set(codeSystem.name, codeSystem); // TODO add this and remove arg
+    const exported = exporter.export([codeSystem]);
+    expect(exported.length).toBe(1);
+    const exportedAgain = exporter.export([codeSystem]); // TODO remove this arg too
+    expect(exportedAgain.length).toBe(1);
+  });
+
+  it('should export a code system with a concept with only a code', () => {
+    const codeSystem = new FshCodeSystem('MyCodeSystem');
+    const concept = new FshConcept('myCode');
+    codeSystem.concepts = [concept];
+    // doc.codeSystems.set(codeSystem.name, codeSystem); // TODO add this and remove arg
+    const exported = exporter.export([codeSystem]);
+    expect(exported.length).toBe(1);
+    expect(exported[0]).toEqual({
+      name: 'MyCodeSystem',
+      id: 'MyCodeSystem',
+      status: 'active',
+      url: 'http://example.com/CodeSystem/MyCodeSystem',
+      concept: [{ code: 'myCode' }]
+    });
+  });
+
+  it('should export a code system with a concept with a code, display, and definition', () => {
+    const codeSystem = new FshCodeSystem('MyCodeSystem');
+    const concept = new FshConcept('myCode', 'My code', 'This is the formal definition of my code');
+    codeSystem.concepts = [concept];
+    // doc.codeSystems.set(codeSystem.name, codeSystem); // TODO add this and remove arg
+    const exported = exporter.export([codeSystem]);
+    expect(exported.length).toBe(1);
+    expect(exported[0]).toEqual({
+      name: 'MyCodeSystem',
+      id: 'MyCodeSystem',
+      status: 'active',
+      url: 'http://example.com/CodeSystem/MyCodeSystem',
+      concept: [
+        {
+          code: 'myCode',
+          display: 'My code',
+          definition: 'This is the formal definition of my code'
+        }
+      ]
+    });
+  });
+});

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -28,6 +28,7 @@ describe('CodeSystemExporter', () => {
       name: 'MyCodeSystem',
       id: 'MyCodeSystem',
       status: 'active',
+      content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem'
     });
   });
@@ -43,6 +44,7 @@ describe('CodeSystemExporter', () => {
       name: 'MyCodeSystem',
       id: 'MyCodeSystem',
       status: 'active',
+      content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
       title: 'My Fancy Code System',
       description: 'Lots of important details about my fancy code system'
@@ -70,6 +72,7 @@ describe('CodeSystemExporter', () => {
       name: 'MyCodeSystem',
       id: 'MyCodeSystem',
       status: 'active',
+      content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
       concept: [{ code: 'myCode' }]
     });
@@ -86,6 +89,7 @@ describe('CodeSystemExporter', () => {
       name: 'MyCodeSystem',
       id: 'MyCodeSystem',
       status: 'active',
+      content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
       concept: [
         {

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -35,6 +35,7 @@ describe('CodeSystemExporter', () => {
 
   it('should export a code system with additional metadata', () => {
     const codeSystem = new FshCodeSystem('MyCodeSystem');
+    codeSystem.id = 'CodeSystem1';
     codeSystem.title = 'My Fancy Code System';
     codeSystem.description = 'Lots of important details about my fancy code system';
     doc.codeSystems.set(codeSystem.name, codeSystem);
@@ -42,10 +43,10 @@ describe('CodeSystemExporter', () => {
     expect(exported.length).toBe(1);
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
-      id: 'MyCodeSystem',
+      id: 'CodeSystem1',
       status: 'active',
       content: 'complete',
-      url: 'http://example.com/CodeSystem/MyCodeSystem',
+      url: 'http://example.com/CodeSystem/CodeSystem1',
       title: 'My Fancy Code System',
       description: 'Lots of important details about my fancy code system'
     });
@@ -62,8 +63,9 @@ describe('CodeSystemExporter', () => {
 
   it('should export a code system with a concept with only a code', () => {
     const codeSystem = new FshCodeSystem('MyCodeSystem');
-    const concept = new FshConcept('myCode');
-    codeSystem.concepts = [concept];
+    const myCode = new FshConcept('myCode');
+    const anotherCode = new FshConcept('anotherCode');
+    codeSystem.concepts = [myCode, anotherCode];
     doc.codeSystems.set(codeSystem.name, codeSystem);
     const exported = exporter.export();
     expect(exported.length).toBe(1);
@@ -73,14 +75,19 @@ describe('CodeSystemExporter', () => {
       status: 'active',
       content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
-      concept: [{ code: 'myCode' }]
+      concept: [{ code: 'myCode' }, { code: 'anotherCode' }]
     });
   });
 
   it('should export a code system with a concept with a code, display, and definition', () => {
     const codeSystem = new FshCodeSystem('MyCodeSystem');
-    const concept = new FshConcept('myCode', 'My code', 'This is the formal definition of my code');
-    codeSystem.concepts = [concept];
+    const myCode = new FshConcept('myCode', 'My code', 'This is the formal definition of my code');
+    const anotherCode = new FshConcept(
+      'anotherCode',
+      'A second code',
+      'More details about this code'
+    );
+    codeSystem.concepts = [myCode, anotherCode];
     doc.codeSystems.set(codeSystem.name, codeSystem);
     const exported = exporter.export();
     expect(exported.length).toBe(1);
@@ -95,6 +102,11 @@ describe('CodeSystemExporter', () => {
           code: 'myCode',
           display: 'My code',
           definition: 'This is the formal definition of my code'
+        },
+        {
+          code: 'anotherCode',
+          display: 'A second code',
+          definition: 'More details about this code'
         }
       ]
     });

--- a/test/export/FHIRExporter.test.ts
+++ b/test/export/FHIRExporter.test.ts
@@ -11,7 +11,7 @@ describe('FHIRExporter', () => {
     });
     const result = exportFHIR(input, new FHIRDefinitions());
     expect(result).toEqual(
-      new Package([], [], [], [], {
+      new Package([], [], [], [], [], {
         name: 'test',
         version: '0.0.1',
         canonical: 'http://example.com'

--- a/test/fshtypes/CodeSystem.test.ts
+++ b/test/fshtypes/CodeSystem.test.ts
@@ -1,10 +1,10 @@
 import 'jest-extended';
-import { CodeSystem } from '../../src/fshtypes/CodeSystem';
+import { FshCodeSystem } from '../../src/fshtypes/FshCodeSystem';
 
 describe('CodeSystem', () => {
   describe('#constructor', () => {
     it('should set initial properties correctly', () => {
-      const cs = new CodeSystem('MyCodeSystem');
+      const cs = new FshCodeSystem('MyCodeSystem');
       expect(cs.name).toBe('MyCodeSystem');
       expect(cs.id).toBe('MyCodeSystem');
       expect(cs.title).toBeUndefined();

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -20,7 +20,7 @@ describe('IGExporter', () => {
     beforeAll(() => {
       const fixtures = path.join(__dirname, 'fixtures', 'simple-ig');
       const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package([], [], [], [], config);
+      pkg = new Package([], [], [], [], [], config);
       const resources = path.join(fixtures, 'resources');
       const instances = path.join(fixtures, 'instances');
       fs.readdirSync(resources).forEach(f => {
@@ -233,7 +233,7 @@ describe('IGExporter', () => {
     beforeAll(() => {
       const fixtures = path.join(__dirname, 'fixtures', 'customized-ig');
       const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package([], [], [], [], config);
+      pkg = new Package([], [], [], [], [], config);
       exporter = new IGExporter(pkg, path.resolve(fixtures, 'ig-data'));
       tempOut = temp.mkdirSync('sushi-test');
       // No need to regenerate the IG on every test -- generate it once and inspect what you
@@ -319,7 +319,7 @@ describe('IGExporter', () => {
     beforeAll(() => {
       const fixtures = path.join(__dirname, 'fixtures', 'invalid-data-ig');
       const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package([], [], [], [], config);
+      pkg = new Package([], [], [], [], [], config);
       exporter = new IGExporter(pkg, path.resolve(fixtures, 'ig-data'));
       tempOut = temp.mkdirSync('sushi-test');
       // No need to regenerate the IG on every test -- generate it once and inspect what you


### PR DESCRIPTION
This PR adds support for exporting Code Systems (https://standardhealthrecord.atlassian.net/browse/CIMPL-198).

It supports exporting FshCodeSystems to a FHIR Code System. The CodeSystem class, similar to the ValueSet class, has many fields that are unused by FSH, but are included to match the specification at http://hl7.org/fhir/R4/codesystem.html.