### PR TITLE
Apply version from package.json file

### DIFF
--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -12,6 +12,8 @@ export class CodeSystemExporter {
     codeSystem.id = fshDefinition.id;
     if (fshDefinition.title) codeSystem.title = fshDefinition.title;
     if (fshDefinition.description) codeSystem.description = fshDefinition.description;
+    // Version is set to value provided in config, will be overriden if reset by rules
+    codeSystem.version = this.tank.config.version;
     codeSystem.url = `${this.tank.config.canonical}/CodeSystem/${codeSystem.id}`;
   }
 

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -40,6 +40,8 @@ export class StructureDefinitionExporter {
     structDef.id = fshDefinition.id;
     if (fshDefinition.title) structDef.title = fshDefinition.title;
     if (fshDefinition.description) structDef.description = fshDefinition.description;
+    // Version is set to value provided in config, will be overriden if reset by rules
+    structDef.version = this.tank.config.version;
     // Assuming the starting StructureDefinition was a clone of the parent,
     // set the baseDefinition to the parent url before re-assiging the url
     structDef.baseDefinition = structDef.url;

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -24,6 +24,8 @@ export class ValueSetExporter {
     if (fshDefinition.description) {
       valueSet.description = fshDefinition.description;
     }
+    // Version is set to value provided in config, will be overriden if reset by rules
+    valueSet.version = this.tank.config.version;
     valueSet.url = `${this.tank.config.canonical}/ValueSet/${valueSet.id}`;
   }
 

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -29,7 +29,8 @@ describe('CodeSystemExporter', () => {
       id: 'MyCodeSystem',
       status: 'active',
       content: 'complete',
-      url: 'http://example.com/CodeSystem/MyCodeSystem'
+      url: 'http://example.com/CodeSystem/MyCodeSystem',
+      version: '0.0.1'
     });
   });
 
@@ -48,7 +49,8 @@ describe('CodeSystemExporter', () => {
       content: 'complete',
       url: 'http://example.com/CodeSystem/CodeSystem1',
       title: 'My Fancy Code System',
-      description: 'Lots of important details about my fancy code system'
+      description: 'Lots of important details about my fancy code system',
+      version: '0.0.1'
     });
   });
 
@@ -75,6 +77,7 @@ describe('CodeSystemExporter', () => {
       status: 'active',
       content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
+      version: '0.0.1',
       concept: [{ code: 'myCode' }, { code: 'anotherCode' }]
     });
   });
@@ -97,6 +100,7 @@ describe('CodeSystemExporter', () => {
       status: 'active',
       content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
+      version: '0.0.1',
       concept: [
         {
           code: 'myCode',

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -56,6 +56,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.title).toBe('Foo Profile');
     expect(exported.description).toBe('foo bar foobar');
     expect(exported.url).toBe('http://example.com/StructureDefinition/foo');
+    expect(exported.version).toBe('0.0.1');
     expect(exported.type).toBe('Observation');
     expect(exported.baseDefinition).toBe('http://hl7.org/fhir/StructureDefinition/Observation');
     expect(exported.derivation).toBe('constraint');
@@ -71,6 +72,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.title).toBeUndefined();
     expect(exported.description).toBe('This is the base resource type for everything.');
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo');
+    expect(exported.version).toBe('0.0.1');
     expect(exported.type).toBe('Resource');
     expect(exported.baseDefinition).toBe('http://hl7.org/fhir/StructureDefinition/Resource');
     expect(exported.derivation).toBe('constraint');
@@ -99,6 +101,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.title).toBe('Foo Profile');
     expect(exported.description).toBe('foo bar foobar');
     expect(exported.url).toBe('http://example.com/StructureDefinition/foo');
+    expect(exported.version).toBe('0.0.1');
     // NOTE: For now, we always set context to everything, but this will be user-specified in
     // the future
     expect(exported.context).toEqual([
@@ -124,6 +127,7 @@ describe('StructureDefinitionExporter', () => {
       'Base StructureDefinition for Extension Type: Optional Extension Element - found in all resources.'
     );
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo');
+    expect(exported.version).toBe('0.0.1');
     // NOTE: For now, we always set context to everything, but this will be user-specified in
     // the future
     expect(exported.context).toEqual([

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -34,7 +34,8 @@ describe('ValueSetExporter', () => {
       name: 'BreakfastVS',
       id: 'BreakfastVS',
       status: 'active',
-      url: 'http://example.com/ValueSet/BreakfastVS'
+      url: 'http://example.com/ValueSet/BreakfastVS',
+      version: '0.0.1'
     });
   });
 
@@ -60,7 +61,8 @@ describe('ValueSetExporter', () => {
       status: 'active',
       title: 'Breakfast Values',
       description: 'A value set for breakfast items',
-      url: 'http://example.com/ValueSet/BreakfastVS'
+      url: 'http://example.com/ValueSet/BreakfastVS',
+      version: '0.0.1'
     });
   });
 
@@ -86,6 +88,7 @@ describe('ValueSetExporter', () => {
       id: 'DinnerVS',
       status: 'active',
       url: 'http://example.com/ValueSet/DinnerVS',
+      version: '0.0.1',
       compose: {
         include: [{ system: 'http://food.org/food' }]
       }
@@ -109,6 +112,7 @@ describe('ValueSetExporter', () => {
       id: 'DinnerVS',
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
+      version: '0.0.1',
       status: 'active',
       compose: {
         include: [
@@ -142,6 +146,7 @@ describe('ValueSetExporter', () => {
       id: 'DinnerVS',
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
+      version: '0.0.1',
       status: 'active',
       compose: {
         include: [
@@ -175,6 +180,7 @@ describe('ValueSetExporter', () => {
       id: 'BreakfastVS',
       name: 'BreakfastVS',
       url: 'http://example.com/ValueSet/BreakfastVS',
+      version: '0.0.1',
       status: 'active',
       compose: {
         include: [
@@ -210,6 +216,7 @@ describe('ValueSetExporter', () => {
       id: 'BreakfastVS',
       name: 'BreakfastVS',
       url: 'http://example.com/ValueSet/BreakfastVS',
+      version: '0.0.1',
       status: 'active',
       compose: {
         include: [
@@ -245,6 +252,7 @@ describe('ValueSetExporter', () => {
       id: 'BreakfastVS',
       name: 'BreakfastVS',
       url: 'http://example.com/ValueSet/BreakfastVS',
+      version: '0.0.1',
       status: 'active',
       compose: {
         include: [
@@ -284,6 +292,7 @@ describe('ValueSetExporter', () => {
       id: 'DinnerVS',
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
+      version: '0.0.1',
       status: 'active',
       compose: {
         include: [


### PR DESCRIPTION
We weren't applying the `version` that is set in the package.json file to the FHIR artifacts that we were producing. All this PR does is apply `version` to SDs, ValueSets, and CodeSystems, and update the tests accordingly.

This addresses https://github.com/FHIR/sushi/issues/81