### PR TITLE
Add meta.profile to Instance

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -119,9 +119,11 @@ export class InstanceExporter {
     instanceDef.resourceType = instanceOfStructureDefinition.type; // ResourceType is determined by the StructureDefinition of the type
     instanceDef.instanceName = fshDefinition.id; // This is name of the instance in the FSH
 
-    // Add the profile we are making an instance of to meta.profile
+    // Add the SD we are making an instance of to meta.profile, as long as SD is not a base FHIR resource
     // If we end up adding more metadata, we should wrap this in a setMetadata function
-    instanceDef.meta = { profile: [instanceOfStructureDefinition.url] };
+    if (instanceOfStructureDefinition.derivation === 'constraint') {
+      instanceDef.meta = { profile: [instanceOfStructureDefinition.url] };
+    }
     // Set Fixed values based on the FSH rules and the Structure Definition
     instanceDef = this.setFixedValues(fshDefinition, instanceDef, instanceOfStructureDefinition);
 

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -119,6 +119,9 @@ export class InstanceExporter {
     instanceDef.resourceType = instanceOfStructureDefinition.type; // ResourceType is determined by the StructureDefinition of the type
     instanceDef.instanceName = fshDefinition.id; // This is name of the instance in the FSH
 
+    // Add the profile we are making an instance of to meta.profile
+    // If we end up adding more metadata, we should wrap this in a setMetadata function
+    instanceDef.meta = { profile: [instanceOfStructureDefinition.url] };
     // Set Fixed values based on the FSH rules and the Structure Definition
     instanceDef = this.setFixedValues(fshDefinition, instanceDef, instanceOfStructureDefinition);
 

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -141,6 +141,13 @@ describe('InstanceExporter', () => {
       });
     });
 
+    it('should not set meta.profile when we are making an instance of a base resource', () => {
+      const boo = new Instance('Boo');
+      boo.instanceOf = 'Patient';
+      const exported = exporter.exportInstance(boo);
+      expect(exported.meta).toBeUndefined();
+    });
+
     // Fixing top level elements
     it('should fix top level elements that are fixed on the Structure Definition', () => {
       const fixedValRule = new FixedValueRule('active');

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -133,6 +133,14 @@ describe('InstanceExporter', () => {
       doc.instances.set(lipidInstance.name, lipidInstance);
     });
 
+    // Setting Metadata
+    it('should set meta.profile to the defining URL we are making an instance of', () => {
+      const exported = exporter.exportInstance(instance);
+      expect(exported.meta).toEqual({
+        profile: ['http://example.com/StructureDefinition/TestPatient']
+      });
+    });
+
     // Fixing top level elements
     it('should fix top level elements that are fixed on the Structure Definition', () => {
       const fixedValRule = new FixedValueRule('active');


### PR DESCRIPTION
This addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-210.

An instance will now have a meta.profile field, which will contain the name of the profile that we are making an instance of.