### PR TITLE
Fix e.type is not iterable error

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -472,7 +472,7 @@ export class StructureDefinition {
     let matchingType: ElementDefinitionType;
     const matchingXElements = elements.filter(e => {
       if (e.path.endsWith('[x]')) {
-        for (const t of e.type) {
+        for (const t of e.type ?? []) {
           if (`${e.path.slice(0, -3)}${upperFirst(t.code)}` === fhirPath) {
             matchingType = t;
             return true;
@@ -529,7 +529,7 @@ export class StructureDefinition {
         pathPart.brackets.length === 1 ||
         e.sliceName === pathPart.brackets.slice(0, -1).join('/')
       ) {
-        for (const t of e.type) {
+        for (const t of e.type ?? []) {
           return (
             t.code === 'Reference' &&
             t.targetProfile &&

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -238,6 +238,12 @@ describe('StructureDefinition', () => {
       expect(emailWorkEmail.sliceName).toBe('email/workEmail');
     });
 
+    it('should not crash when trying to find a non-existent slice containing elements without a type', () => {
+      // component.referenceRange does not have a type, this test verifies that this does not cause a crash
+      const componentFooSlice = observation.findElementByPath('component[FooSlice]', fisher);
+      expect(componentFooSlice).toBeUndefined();
+    });
+
     // Choices
     it('should make explicit a non-existent choice element by path', () => {
       const originalLength = observation.elements.length;


### PR DESCRIPTION
I noticed when running SUSHI that an error would pop up sometimes saying "e.type is not iterable". On an ElementDefinition, type is technically not required, and there were some places we were assuming type would exist as an array. This PR fixes the places where we made those assumptions so that the error doesn't happen.