### PR TITLE
Place output in build/input/resources by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ sushi --help
 Usage: sushi <path-to-fsh-defs> [options]
 
 Options:
-  -o, --out <out>  the path to the output folder (default: "build")
+  -o, --out <out>  the path to the output folder (default: "build/input/resources")
   -h, --help       output usage information
 ```
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,11 @@ async function app() {
   program
     .name('sushi')
     .usage('<path-to-fsh-defs> [options]')
-    .option('-o, --out <out>', 'the path to the output folder', path.join('.', 'build'))
+    .option(
+      '-o, --out <out>',
+      'the path to the output folder',
+      path.join('.', 'build', 'input', 'resources')
+    )
     .option('-d, --debug', 'output extra debugging information')
     .arguments('<path-to-fsh-defs>')
     .action(function(pathToFshDefs) {


### PR DESCRIPTION
This addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-229, which is also #104 

The old default was to place output in a `build` folder, but we have decided to place output by default in `build/input/resources` to make it work better with the IG publisher.