### PR TITLE
Remove resource-level extensions

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -59,6 +59,8 @@ export class StructureDefinitionExporter implements Fishable {
         ];
       }
     }
+    // Remove the base-level extensions as they may not be valid in this context
+    delete structDef.extension;
   }
 
   /**

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -88,6 +88,14 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.derivation).toBe('constraint');
   });
 
+  it('should remove the base-level extensions from the parent resource', () => {
+    const profile = new Profile('Foo');
+    doc.profiles.set(profile.name, profile);
+    exporter.exportStructDef(profile);
+    const exported = pkg.profiles[0];
+    expect(exported.extension).toBeUndefined();
+  });
+
   it('should throw ParentNotDefinedError when parent resource is not found', () => {
     const profile = new Profile('Foo');
     profile.parent = 'Bar';


### PR DESCRIPTION
Resources have extensions indicating their ballot status, maturity, workgroup, etc -- most of which is probably not appropriate for the profile.  Remove these extensions from the profile.  Addresses #116.