### PR TITLE
Report duplicate aliases w/ different values

### DIFF
--- a/test/import/FSHImporter.Alias.test.ts
+++ b/test/import/FSHImporter.Alias.test.ts
@@ -73,7 +73,7 @@ describe('FSHImporter', () => {
       );
     });
 
-    it('should not report an error when the same alias is defined twice w/ different values in different files', () => {
+    it('should not report an error when the same alias is defined multiple times w/ the same values', () => {
       const input = `
       Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
       Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race

--- a/test/import/FSHImporter.Alias.test.ts
+++ b/test/import/FSHImporter.Alias.test.ts
@@ -1,11 +1,14 @@
 import { importText, RawFSH } from '../../src/import';
 import { ValueSetRule } from '../../src/fshtypes/rules';
 import { importSingleText } from '../testhelpers/importSingleText';
+import { loggerSpy } from '../testhelpers';
 
 // Aliases are tested as part of the other entity tests where aliases are allowed
 // but these tests ensure that aliases work generally and can be in any order
 
 describe('FSHImporter', () => {
+  beforeEach(() => loggerSpy.reset());
+
   describe('Alias', () => {
     it('should collect and return aliases in result', () => {
       const input = `
@@ -29,6 +32,70 @@ describe('FSHImporter', () => {
       expect(result.aliases.get('SCT')).toBe('http://snomed.info/sct');
       expect(result.aliases.get('RXNORM')).toBe('http://www.nlm.nih.gov/research/umls/rxnorm');
       expect(result.aliases.get('UCUM')).toBe('http://unitsofmeasure.org');
+    });
+
+    it('should report when the same alias is defined twice w/ different values in the same file', () => {
+      const input = `
+      Alias: USCoreRace = http://hl7.org/fhir/us/core/ValueSet/omb-race-category
+      Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
+      `;
+
+      const result = importSingleText(input);
+      expect(result.aliases.size).toBe(1);
+      expect(result.aliases.get('USCoreRace')).toBe(
+        'http://hl7.org/fhir/us/core/ValueSet/omb-race-category'
+      );
+      expect(loggerSpy.getLastMessage()).toMatch(
+        /Alias USCoreRace cannot be redefined to http:\/\/hl7.org\/fhir\/us\/core\/StructureDefinition\/us-core-race; it is already defined as http:\/\/hl7.org\/fhir\/us\/core\/ValueSet\/omb-race-category\..*Line: 3\D/s
+      );
+    });
+
+    it('should report when the same alias is defined twice w/ different values in different files', () => {
+      const input = `
+      Alias: USCoreRace = http://hl7.org/fhir/us/core/ValueSet/omb-race-category
+      `;
+      const input2 = `
+      Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
+      `;
+
+      const results = importText([
+        new RawFSH(input, 'Alias1.fsh'),
+        new RawFSH(input2, 'Alias2.fsh')
+      ]);
+      expect(results).toHaveLength(2);
+      expect(results[0].aliases.size).toBe(1);
+      expect(results[0].aliases.get('USCoreRace')).toBe(
+        'http://hl7.org/fhir/us/core/ValueSet/omb-race-category'
+      );
+      expect(results[1].aliases.size).toBe(0);
+      expect(loggerSpy.getLastMessage()).toMatch(
+        /Alias USCoreRace cannot be redefined to http:\/\/hl7.org\/fhir\/us\/core\/StructureDefinition\/us-core-race; it is already defined as http:\/\/hl7.org\/fhir\/us\/core\/ValueSet\/omb-race-category\..*File: Alias2\.fsh.*Line: 2\D/s
+      );
+    });
+
+    it('should not report an error when the same alias is defined twice w/ different values in different files', () => {
+      const input = `
+      Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
+      Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
+      `;
+      const input2 = `
+      Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
+      `;
+
+      const results = importText([
+        new RawFSH(input, 'Alias1.fsh'),
+        new RawFSH(input2, 'Alias2.fsh')
+      ]);
+      expect(results).toHaveLength(2);
+      expect(results[0].aliases.size).toBe(1);
+      expect(results[0].aliases.get('USCoreRace')).toBe(
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
+      );
+      expect(results[1].aliases.size).toBe(1);
+      expect(results[1].aliases.get('USCoreRace')).toBe(
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
+      );
+      expect(loggerSpy.getLastLog()).toBeUndefined();
     });
 
     it('should translate an alias when the alias is defined before its use', () => {

--- a/test/testhelpers/loggerSpy.ts
+++ b/test/testhelpers/loggerSpy.ts
@@ -26,7 +26,7 @@ class LoggerSpy {
   }
 
   getMessageAtIndex(index: number): string {
-    return this.getLogAtIndex(index).message;
+    return this.getLogAtIndex(index)?.message;
   }
 
   getFirstMessage(): string {
@@ -35,6 +35,10 @@ class LoggerSpy {
 
   getLastMessage(): string {
     return this.getMessageAtIndex(-1);
+  }
+
+  reset(): void {
+    this.mockWriter.mockReset();
   }
 }
 


### PR DESCRIPTION
If a FSHTank contains duplicate aliases with different values, only keep the first one and report the others as errors.  Addresses #124.