### PR TITLE
Bump to 0.6.1 plus surprise feature ooh la la

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Usage: sushi <path-to-fsh-defs> [options]
 
 Options:
   -o, --out <out>  the path to the output folder (default: "build/input/resources")
+  -d, --debug      output extra debugging information
+  -v, --version    print SUSHI version
   -h, --help       output usage information
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Sushi Unshortens Short Hand Inputs (FSH Compiler)",
   "scripts": {
     "build": "rm -rf dist && tsc && cp -r src/ig/files dist/ig/files",

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ async function app() {
       path.join('.', 'build', 'input', 'resources')
     )
     .option('-d, --debug', 'output extra debugging information')
+    .version(getVersion(), '-v, --version', 'print SUSHI version')
     .arguments('<path-to-fsh-defs>')
     .action(function(pathToFshDefs) {
       input = pathToFshDefs;
@@ -117,4 +118,13 @@ async function app() {
   CodeSystems: ${outPackage.codeSystems.length}
   Errors:      ${stats.numError}
   Warnings:    ${stats.numWarn}`);
+}
+
+function getVersion(): string {
+  const packageJSONPath = path.join(__dirname, '..', 'package.json');
+  if (fs.existsSync(packageJSONPath)) {
+    const packageJSON = fs.readJSONSync(packageJSONPath);
+    return `v${packageJSON.version}`;
+  }
+  return 'unknown';
 }


### PR DESCRIPTION
Now supports:
```
$ sushi -v
v0.6.1
```

EDIT: and bumps version to 0.6.1.  Almost forgot!
