### PR TITLE
Add exampleCanonical field to instances that are examples

### DIFF
--- a/src/fhirtypes/InstanceDefinition.ts
+++ b/src/fhirtypes/InstanceDefinition.ts
@@ -10,6 +10,7 @@ export class InstanceDefinition {
   resourceType: string;
   instanceName: string;
   id?: string;
+  meta?: any;
   [key: string]: any; // Allow any key value pair on InstanceDefinition due to the high number of potential properties that can be set on a FHIR instance
 
   /**

--- a/src/fhirtypes/InstanceDefinition.ts
+++ b/src/fhirtypes/InstanceDefinition.ts
@@ -1,4 +1,5 @@
 import cloneDeep = require('lodash/cloneDeep');
+import { Meta } from './specialTypes';
 
 /**
  * A class representing a FHIR Instance.
@@ -10,7 +11,7 @@ export class InstanceDefinition {
   resourceType: string;
   instanceName: string;
   id?: string;
-  meta?: any;
+  meta?: Meta;
   [key: string]: any; // Allow any key value pair on InstanceDefinition due to the high number of potential properties that can be set on a FHIR instance
 
   /**

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -4,7 +4,11 @@ import ini from 'ini';
 import sortBy from 'lodash/sortBy';
 import { ensureDirSync, copySync, outputJSONSync, outputFileSync } from 'fs-extra';
 import { Package } from '../export';
-import { ContactDetail, ImplementationGuide, ImplementationGuideDefinitionResource } from '../fhirtypes';
+import {
+  ContactDetail,
+  ImplementationGuide,
+  ImplementationGuideDefinitionResource
+} from '../fhirtypes';
 import { logger, Type } from '../utils';
 import { FHIRDefinitions } from '../fhirdefs';
 

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -5,7 +5,7 @@ import sortBy from 'lodash/sortBy';
 import { ensureDirSync, copySync, outputJSONSync, outputFileSync } from 'fs-extra';
 import { Package } from '../export';
 import { ContactDetail, ImplementationGuide } from '../fhirtypes';
-import { logger } from '../utils/FSHLogger';
+import { logger, Type } from '../utils';
 import { FHIRDefinitions } from '../fhirdefs';
 
 /**
@@ -209,7 +209,9 @@ export class IGExporter {
             reference: `${instance.resourceType}/${instance.id ?? instance.instanceName}`
           },
           name: instance.getFileName().slice(0, -5), // Slice off the .json of the file name
-          exampleBoolean: true
+          exampleCanonical:
+            instance.meta?.profile?.[0] ??
+            this.fhirDefs.fishForMetadata(instance.resourceType, Type.Resource, Type.Type)?.url
         });
       }
     );

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -195,7 +195,7 @@ describe('IGExporter', () => {
                 reference: 'Patient/example'
               },
               name: 'Patient-example',
-              exampleCanonical: 'http://hl7.org/fhir/StructureDefinition/Patient'
+              exampleBoolean: true
             },
             {
               reference: {

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -195,7 +195,7 @@ describe('IGExporter', () => {
                 reference: 'Patient/example'
               },
               name: 'Patient-example',
-              exampleBoolean: true
+              exampleCanonical: 'http://hl7.org/fhir/StructureDefinition/Patient'
             },
             {
               reference: {


### PR DESCRIPTION
Fixes #127 

This adds an exampleCanonical field to example instances, in order to allow examples to display in their tab for profiles.

To test, verify that the IG build with `master` doesn't have examples on their tab for a given profile, even if that example exists in the table of contents.

Then, build the IG with this branch, and verify that they show up.