### PR TITLE
Add validateValueAtPath before setting properties

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -1,5 +1,5 @@
 import { FSHTank } from '../import/FSHTank';
-import { StructureDefinition, InstanceDefinition, ElementDefinition, PathPart } from '../fhirtypes';
+import { StructureDefinition, InstanceDefinition, ElementDefinition } from '../fhirtypes';
 import { Instance } from '../fshtypes';
 import { logger, Fishable, Type } from '../utils';
 import { setPropertyOnInstance, replaceReferences, replaceField } from '../fhirtypes/common';
@@ -37,7 +37,19 @@ export class InstanceExporter {
           // Add back non-numeric (slice) brackets
           pathPart.brackets?.forEach(b => (path += /^[-+]?\d+$/.test(b) ? '' : `[${b}]`));
           const element = instanceOfStructureDefinition.findElementByPath(path, this.fisher);
-          this.setFixedValuesForDirectChildren(element, pathParts.slice(0, i + 1), instanceDef);
+          // Reconstruct the part of the rule's path that we just got the element for
+          let rulePathPart = rule.path
+            .split('.')
+            .slice(0, i + 1)
+            .join('.');
+          rulePathPart += '.';
+
+          this.setFixedValuesForDirectChildren(
+            element,
+            rulePathPart,
+            instanceDef,
+            instanceOfStructureDefinition
+          );
         }
       } catch (e) {
         logger.error(e.message, rule.sourceInfo);
@@ -47,8 +59,9 @@ export class InstanceExporter {
     // Fix values from the SD for all elements at the top level of the SD
     this.setFixedValuesForDirectChildren(
       instanceOfStructureDefinition.findElement(instanceDef.resourceType),
-      [],
-      instanceDef
+      '',
+      instanceDef,
+      instanceOfStructureDefinition
     );
 
     // Remove all _sliceName fields
@@ -76,8 +89,9 @@ export class InstanceExporter {
    */
   private setFixedValuesForDirectChildren(
     element: ElementDefinition,
-    existingPath: PathPart[],
-    instanceDef: InstanceDefinition
+    existingPath: string,
+    instanceDef: InstanceDefinition,
+    instanceOfStructureDefinition: StructureDefinition
   ) {
     const directChildren = element.children(true);
     for (const child of directChildren) {
@@ -87,17 +101,17 @@ export class InstanceExporter {
       );
       if (fixedValueKey) {
         // Get the end of the child path, this is the part that differs from existingPath
-        const childPathPart = {
-          base: child
-            .diffId()
-            .split('.')
-            .slice(-1)[0]
-        };
-        setPropertyOnInstance(
-          instanceDef,
-          [...existingPath, childPathPart],
-          child[fixedValueKey as keyof ElementDefinition]
+        const childPathPart = child
+          .diffId()
+          .split('.')
+          .slice(-1)[0];
+
+        const { fixedValue, pathParts } = instanceOfStructureDefinition.validateValueAtPath(
+          existingPath + childPathPart,
+          child[fixedValueKey as keyof ElementDefinition],
+          this.fisher
         );
+        setPropertyOnInstance(instanceDef, pathParts, fixedValue);
       }
     }
   }
@@ -143,14 +157,12 @@ export class InstanceExporter {
    * @returns {Package}
    */
   export(): Package {
-    for (const doc of this.tank.docs) {
-      for (const instance of doc.instances.values()) {
-        try {
-          const instanceDef = this.exportInstance(instance);
-          this.pkg.instances.push(instanceDef);
-        } catch (e) {
-          logger.error(e.message, e.sourceInfo);
-        }
+    for (const instance of this.tank.getAllInstances()) {
+      try {
+        const instanceDef = this.exportInstance(instance);
+        this.pkg.instances.push(instanceDef);
+      } catch (e) {
+        logger.error(e.message, e.sourceInfo);
       }
     }
     return this.pkg;

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -106,12 +106,16 @@ export class InstanceExporter {
           .split('.')
           .slice(-1)[0];
 
-        const { fixedValue, pathParts } = instanceOfStructureDefinition.validateValueAtPath(
-          existingPath + childPathPart,
-          child[fixedValueKey as keyof ElementDefinition],
-          this.fisher
-        );
-        setPropertyOnInstance(instanceDef, pathParts, fixedValue);
+        try {
+          const { fixedValue, pathParts } = instanceOfStructureDefinition.validateValueAtPath(
+            existingPath + childPathPart,
+            child[fixedValueKey as keyof ElementDefinition],
+            this.fisher
+          );
+          setPropertyOnInstance(instanceDef, pathParts, fixedValue);
+        } catch (e) {
+          logger.error(e.message);
+        }
       }
     }
   }

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -84,7 +84,7 @@ export class InstanceExporter {
    * Given an ElementDefinition, set fixed values for the direct children of that element
    * according to the ElementDefinitions of the children
    * @param {ElementDefinition} element - The element whose children we will fix
-   * @param {PathPart[]} existingPath - The path to the element whose children we will fix
+   * @param {string} existingPath - The path to the element whose children we will fix
    * @param {InstanceDefinition} instanceDef - The InstanceDefinition to fix values on
    */
   private setFixedValuesForDirectChildren(

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -19,6 +19,14 @@ export class InstanceExporter {
     instanceDef: InstanceDefinition,
     instanceOfStructureDefinition: StructureDefinition
   ): InstanceDefinition {
+    // Fix values from the SD for all elements at the top level of the SD
+    this.setFixedValuesForDirectChildren(
+      instanceOfStructureDefinition.findElement(instanceDef.resourceType),
+      '',
+      instanceDef,
+      instanceOfStructureDefinition
+    );
+
     // All rules will be FixValueRule
     fshInstanceDef.rules.forEach(rule => {
       rule = replaceReferences(rule, this.tank, this.fisher);
@@ -29,7 +37,6 @@ export class InstanceExporter {
           this.fisher
         );
 
-        setPropertyOnInstance(instanceDef, pathParts, fixedValue);
         // For each part of that path, we add fixed values from the SD
         let path = '';
         for (const [i, pathPart] of pathParts.entries()) {
@@ -51,18 +58,13 @@ export class InstanceExporter {
             instanceOfStructureDefinition
           );
         }
+
+        // Fix value fom the rule
+        setPropertyOnInstance(instanceDef, pathParts, fixedValue);
       } catch (e) {
         logger.error(e.message, rule.sourceInfo);
       }
     });
-
-    // Fix values from the SD for all elements at the top level of the SD
-    this.setFixedValuesForDirectChildren(
-      instanceOfStructureDefinition.findElement(instanceDef.resourceType),
-      '',
-      instanceDef,
-      instanceOfStructureDefinition
-    );
 
     // Remove all _sliceName fields
     replaceField(
@@ -86,6 +88,7 @@ export class InstanceExporter {
    * @param {ElementDefinition} element - The element whose children we will fix
    * @param {string} existingPath - The path to the element whose children we will fix
    * @param {InstanceDefinition} instanceDef - The InstanceDefinition to fix values on
+   * @param {StructureDefinition} instanceOfStructureDefinition - The structure definition the instance instantiates
    */
   private setFixedValuesForDirectChildren(
     element: ElementDefinition,

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -188,6 +188,10 @@ describe('InstanceExporter', () => {
     it('should fix top level elements to an array even if constrained on the Structure Definition', () => {
       const condition = new Profile('TestCondition');
       condition.parent = 'Condition';
+      const cardRule = new CardRule('category');
+      cardRule.min = 1;
+      cardRule.max = '1';
+      condition.rules.push(cardRule);
       doc.profiles.set(condition.name, condition);
       const conditionInstance = new Instance('Bar');
       conditionInstance.instanceOf = 'TestCondition';

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -326,7 +326,7 @@ describe('InstanceExporter', () => {
     });
 
     it('should fix a nested element that has parents defined in the instance and fixed on the SD to an array even if constrained', () => {
-      const cardRule = new CardRule('communication');
+      const cardRule = new CardRule('contact');
       cardRule.min = 1;
       cardRule.max = '1';
       patient.rules.push(cardRule);


### PR DESCRIPTION
Fixes #114 

The functionality for putting properties into arrays even if they are constrained is in the `validateValueAtPath` function. We call that before setting properties on instances that are defined by rules. However, we also set properties on instances based on the structure definition. I updated the function `setFixedValuesForDirectChildren` to also call `validateValueAtPath`. This will check the base cardinality and should fix the bug. I added two tests to check the two places the `setFixedValuesForDirectChildren` is called and check that the arrays are properly set.