### PR TITLE
Fix differentials related to choice type slices

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -314,8 +314,14 @@ export class ElementDefinition {
         diff[prop] = cloneDeep(this[prop]);
       }
     }
-    // Path gets set automatically when setting id
+    // Set the diff id, which may be different than snapshot id in the case of choices (e.g., value[x] -> valueString)
+    // NOTE: The path also gets set automatically when setting id
     diff.id = diff.diffId();
+    // If the snapshot is a choice (e.g., value[x]), but the diff is a specific choice (e.g., valueString), then
+    // remove the slicename property from the diff (it is implied and not required in the diff)
+    if (this.path.endsWith('[x]') && !diff.path.endsWith('[x]')) {
+      delete diff.sliceName;
+    }
     return diff;
   }
 

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -1,6 +1,10 @@
 import upperFirst from 'lodash/upperFirst';
 import cloneDeep from 'lodash/cloneDeep';
-import { ElementDefinition, ElementDefinitionType } from './ElementDefinition';
+import {
+  ElementDefinition,
+  ElementDefinitionType,
+  ElementDefinitionSlicing
+} from './ElementDefinition';
 import { Meta } from './specialTypes';
 import { Identifier, CodeableConcept, Coding, Narrative, Resource, Extension } from './dataTypes';
 import { ContactDetail, UsageContext } from './metaDataTypes';
@@ -313,6 +317,29 @@ export class StructureDefinition {
     j.differential = {
       element: this.elements.filter(e => e.hasDiff()).map(e => e.calculateDiff().toJSON())
     };
+
+    // Post-process the differential to remove any choice[x] elements if the only thing they do is establish the type
+    // slicing.  In this case, the type slicing can be inferred and does not need to be explicitly added.
+    // See: https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/
+    j.differential.element = j.differential.element.filter(
+      (e: { id: string; path: string; slicing: ElementDefinitionSlicing }) => {
+        return (
+          // not a choice, or
+          !e.id.endsWith('[x]') ||
+          // is a choice but not one whose only diff is the standard type slicing
+          !(
+            Object.keys(e).length === 3 &&
+            e.id &&
+            e.path &&
+            e.slicing?.discriminator?.length === 1 &&
+            e.slicing.discriminator[0].type === 'type' &&
+            e.slicing.discriminator[0].path === '$this' &&
+            e.slicing.rules === 'open' &&
+            (e.slicing.ordered == null || e.slicing.ordered === false)
+          )
+        );
+      }
+    );
 
     // If the StructureDefinition is in progress, we want to persist that in the JSON so that when
     // the Fisher retrieves it from a package and converts to JSON, the inProgress state will be

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -244,11 +244,14 @@ describe('ElementDefinition', () => {
       valueX.sliceIt('type', '$this', false, 'open');
       const valueString = valueX.addSlice('valueString', new ElementDefinitionType('string'));
       const diff = valueString.calculateDiff();
+      // snapshot should retain formal syntax and slicename
       expect(valueString.id).toBe('Observation.value[x]:valueString');
       expect(valueString.path).toBe('Observation.value[x]');
+      expect(valueString.sliceName).toBe('valueString');
+      // differential should use shortcut syntax and remove slicename
       expect(diff.id).toBe('Observation.valueString');
       expect(diff.path).toBe('Observation.valueString');
-      expect(Object.keys(diff.toJSON()).length).toBe(Object.keys(valueString.toJSON()).length);
+      expect(diff.sliceName).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
1. Remove slicename from renamed choice type differential elements
2. Return root choice element ([x]) from differential when it's only there to introduce the type slice

This addresses #99.  Note that when you build the IG, you will often still see both `value[x]` and the specific choice (e.g., `valueString`) -- but you won't see the weird duplicate slice names anymore.  The reason you will usually still see `value[x]` is because we still must include `value[x]` in the differential if we constrained the choice to a smaller set of choices.  The only time we can exclude `value[x]` from the differential is if we _keep_ all the same types as valid choices.  See: https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/

If you build fsh-mcode, `CancerDiseaseStatus` shows instances of both cases.  

(a) The `EvidenceType` extension in `CancerDiseaseStatus` binds its `valueCodeableConcept` to a value set.  See the before and after in this screenshot.
![image](https://user-images.githubusercontent.com/2278253/73144945-761bad80-4078-11ea-92a2-b341f80dfd01.png)

(b) The `valueCodeableConcept` of `CancerDiseaseObservation` also binds to a value set.  Before and after here:
![image](https://user-images.githubusercontent.com/2278253/73144992-d6125400-4078-11ea-85c1-37a6a84a77de.png)

Note -- the after still looks weird (in a different way), but I believe it it actually technically correct based on the documentation.