### PR TITLE
Start with cleaner plate

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,7 +3,7 @@
 # build artefacts
 dist/*
 coverage/*
-build/*
+build*/*
 # data definition files
 **/*.d.ts
 # 3rd party libs

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,6 @@
 .vscode
 coverage
 dist
-build
+build*
 node_modules
 **/generated

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -27,33 +27,70 @@ export class StructureDefinitionExporter implements Fishable {
   ) {}
 
   /**
-   * Sets the metadata for the StructureDefinition
+   * Sets the metadata for the StructureDefinition.  This includes clearing metadata that was copied from the parent
+   * but may not be relevant to the child StructureDefinition.
    * @param {StructureDefinition} structDef - The StructureDefinition to set metadata on
    * @param {Profile | Extension} fshDefinition - The Profile or Extension we are exporting
    */
   private setMetadata(structDef: StructureDefinition, fshDefinition: Profile | Extension): void {
-    structDef.setName(fshDefinition.name, fshDefinition.sourceInfo);
+    // following general approach outlined here:
+    // https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Bad.20links.20on.20Detailed.20Description.20tab/near/186460459
+
+    // First save the original URL, as that is the URL we'll want to set as the baseDefinition
+    const parentURL = structDef.url;
+
+    // Now set/clear elements in order of their appearance in Resource/DomainResource/StructureDefinition definitions
     structDef.setId(fshDefinition.id, fshDefinition.sourceInfo);
-    if (fshDefinition.title) structDef.title = fshDefinition.title;
-    if (fshDefinition.description) structDef.description = fshDefinition.description;
-    // Version is set to value provided in config, will be overriden if reset by rules
-    structDef.version = this.tank.config.version;
-    // Assuming the starting StructureDefinition was a clone of the parent,
-    // set the baseDefinition to the parent url before re-assiging the url
-    structDef.baseDefinition = structDef.url;
-    // Now re-assign the URL based on canonical and id
+    delete structDef.meta;
+    delete structDef.implicitRules;
+    delete structDef.language;
+    delete structDef.text;
+    // keep structDef.contained since existing elements may refer to contained items (although not likely)
+    delete structDef.extension; // see https://github.com/FHIR/sushi/issues/116
+    delete structDef.modifierExtension;
     structDef.url = `${this.tank.config.canonical}/StructureDefinition/${structDef.id}`;
-    // Set the derivation as appropriate
-    if (fshDefinition instanceof Profile) {
-      structDef.derivation = 'constraint';
-    } else if (fshDefinition instanceof Extension) {
+    delete structDef.identifier;
+    structDef.version = this.tank.config.version; // can be overridden using a rule
+    structDef.setName(fshDefinition.name, fshDefinition.sourceInfo);
+    if (fshDefinition.title) {
+      structDef.title = fshDefinition.title;
+    } else {
+      delete structDef.title;
+    }
+    structDef.status = 'active'; // it's 1..1 so we have to set it to something; can be overridden w/ rule
+    delete structDef.experimental;
+    delete structDef.date;
+    delete structDef.publisher;
+    delete structDef.contact;
+    if (fshDefinition.description) {
+      structDef.description = fshDefinition.description;
+    } else {
+      delete structDef.description;
+    }
+    delete structDef.useContext;
+    delete structDef.jurisdiction;
+    delete structDef.purpose;
+    delete structDef.copyright;
+    delete structDef.keyword;
+    // keep structDef.fhirVersion as that ought not change from parent to child
+    // keep mapping since existing elements refer to the mapping and we're not removing those
+    // keep kind since it should not change
+    structDef.abstract = false; // always reset to false, assuming most children of abstracts aren't abstract
+    // keep context, assuming context is still valid for child extensions
+    // keep contextInvariant, assuming context is still valid for child extensions
+    // keep type since this should not change for profiles or extensions
+    structDef.baseDefinition = parentURL;
+    structDef.derivation = 'constraint'; // always constraint since SUSHI only supports profiles/extensions right now
+
+    if (fshDefinition instanceof Extension) {
       // Automatically set url.fixedUri on Extensions
       const url = structDef.findElement('Extension.url');
       url.fixedUri = structDef.url;
-      structDef.derivation = 'constraint';
       if (structDef.context == null) {
-        // NOTE: For now, we always set context to everything, but this will be user-specified
-        // in the future
+        // Set context to everything by default, but users can override w/ rules, e.g.
+        // ^context[0].type = #element
+        // ^context[0].expression = "Patient"
+        // TODO: Consider introducing metadata keywords for this
         structDef.context = [
           {
             type: 'element',
@@ -62,8 +99,6 @@ export class StructureDefinitionExporter implements Fishable {
         ];
       }
     }
-    // Remove the base-level extensions as they may not be valid in this context
-    delete structDef.extension;
   }
 
   /**

--- a/src/fhirtypes/CodeSystem.ts
+++ b/src/fhirtypes/CodeSystem.ts
@@ -23,7 +23,7 @@ export class CodeSystem {
   version?: string;
   // name?: string; // provided by HasName mixin
   title?: string;
-  status = 'active';
+  status: 'draft' | 'active' | 'retired' | 'unknown' = 'draft';
   experimental?: boolean;
   date?: string;
   publisher?: string;
@@ -38,7 +38,7 @@ export class CodeSystem {
   hierarchyMeaning?: string;
   compositional?: boolean;
   versionNeeded?: boolean;
-  content = 'complete';
+  content: 'not-present' | 'example' | 'fragment' | 'complete' | 'supplement' = 'complete';
   supplements?: string;
   count?: number;
   filter?: CodeSystemFilter[];

--- a/src/fhirtypes/ValueSet.ts
+++ b/src/fhirtypes/ValueSet.ts
@@ -27,7 +27,7 @@ export class ValueSet {
   version: string;
   // name: string; // provided by HasName mixin
   title: string;
-  status = 'active';
+  status: 'draft' | 'active' | 'retired' | 'unknown' = 'draft';
   experimental: boolean;
   date: string;
   publisher: string;

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -32,7 +32,7 @@ describe('CodeSystemExporter', () => {
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
       id: 'MyCodeSystem',
-      status: 'active',
+      status: 'draft',
       content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
       version: '0.0.1'
@@ -50,7 +50,7 @@ describe('CodeSystemExporter', () => {
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
       id: 'CodeSystem1',
-      status: 'active',
+      status: 'draft',
       content: 'complete',
       url: 'http://example.com/CodeSystem/CodeSystem1',
       title: 'My Fancy Code System',
@@ -79,7 +79,7 @@ describe('CodeSystemExporter', () => {
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
       id: 'MyCodeSystem',
-      status: 'active',
+      status: 'draft',
       content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
       version: '0.0.1',
@@ -102,7 +102,7 @@ describe('CodeSystemExporter', () => {
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
       id: 'MyCodeSystem',
-      status: 'active',
+      status: 'draft',
       content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
       version: '0.0.1',

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -91,7 +91,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.version).toBe('0.0.1'); // provided by config
     expect(exported.name).toBe('Foo'); // provided by user
     expect(exported.title).toBeUndefined();
-    expect(exported.status).toBe('active'); // always active
+    expect(exported.status).toBe('draft'); // always active
     expect(exported.experimental).toBeUndefined();
     expect(exported.date).toBeUndefined();
     expect(exported.publisher).toBeUndefined();
@@ -197,7 +197,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.version).toBe('0.0.1'); // provided by config
     expect(exported.name).toBe('Foo'); // provided by user
     expect(exported.title).toBeUndefined();
-    expect(exported.status).toBe('active'); // always active
+    expect(exported.status).toBe('draft'); // always active
     expect(exported.experimental).toBeUndefined();
     expect(exported.date).toBeUndefined();
     expect(exported.publisher).toBeUndefined();

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -83,7 +83,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.implicitRules).toBeUndefined();
     expect(exported.language).toBeUndefined();
     expect(exported.text).toBeUndefined();
-    expect(exported.contained).toBeUndefined; // inherited from Observation
+    expect(exported.contained).toBeUndefined(); // inherited from Observation
     expect(exported.extension).toBeUndefined();
     expect(exported.modifierExtension).toBeUndefined();
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo'); // constructed from canonical and id
@@ -121,8 +121,8 @@ describe('StructureDefinitionExporter', () => {
     ]); // inherited from Observation
     expect(exported.kind).toBe('resource'); // inherited from Observation
     expect(exported.abstract).toBe(false); // always abstract
-    expect(exported.context).toBeUndefined; // inherited from Observation
-    expect(exported.contextInvariant).toBeUndefined; // inherited from Observation
+    expect(exported.context).toBeUndefined(); // inherited from Observation
+    expect(exported.contextInvariant).toBeUndefined(); // inherited from Observation
     expect(exported.type).toBe('Observation'); // inherited from Observation
     expect(exported.baseDefinition).toBe('http://hl7.org/fhir/StructureDefinition/Observation'); // url for Observation
     expect(exported.derivation).toBe('constraint'); // always constraint
@@ -189,7 +189,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.implicitRules).toBeUndefined();
     expect(exported.language).toBeUndefined();
     expect(exported.text).toBeUndefined();
-    expect(exported.contained).toBeUndefined; // inherited from patient-mothersMaidenName
+    expect(exported.contained).toBeUndefined(); // inherited from patient-mothersMaidenName
     expect(exported.extension).toBeUndefined();
     expect(exported.modifierExtension).toBeUndefined();
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo'); // constructed from canonical and id
@@ -216,7 +216,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.kind).toBe('complex-type'); // inherited from patient-mothersMaidenName
     expect(exported.abstract).toBe(false); // always abstract
     expect(exported.context).toEqual([{ type: 'element', expression: 'Patient' }]); // inherited from patient-mothersMaidenName
-    expect(exported.contextInvariant).toBeUndefined; // inherited from patient-mothersMaidenName
+    expect(exported.contextInvariant).toBeUndefined(); // inherited from patient-mothersMaidenName
     expect(exported.type).toBe('Extension'); // inherited from patient-mothersMaidenName
     expect(exported.baseDefinition).toBe(
       'http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName'

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -144,6 +144,20 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.derivation).toBe('constraint');
   });
 
+  it('should allow metadata to be overwritten with caret rule', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+    const rule = new CaretValueRule('');
+    rule.caretPath = 'status';
+    rule.value = new FshCode('active');
+    profile.rules.push(rule);
+    doc.profiles.set(profile.name, profile);
+    exporter.exportStructDef(profile);
+    const exported = pkg.profiles[0];
+    expect(exported.name).toBe('Foo');
+    expect(exported.status).toBe('active');
+  });
+
   it('should throw ParentNotDefinedError when parent resource is not found', () => {
     const profile = new Profile('Foo');
     profile.parent = 'Bar';
@@ -267,6 +281,31 @@ describe('StructureDefinitionExporter', () => {
       {
         type: 'element',
         expression: 'Patient'
+      }
+    ]);
+  });
+
+  it('should allow metadata to be overwritten with caret rule', () => {
+    const extension = new Extension('Foo');
+    const rule1 = new CaretValueRule('');
+    rule1.caretPath = 'status';
+    rule1.value = new FshCode('active');
+    const rule2 = new CaretValueRule('');
+    rule2.caretPath = 'context[0].type';
+    rule2.value = new FshCode('element');
+    const rule3 = new CaretValueRule('');
+    rule3.caretPath = 'context[0].expression';
+    rule3.value = 'Observation';
+    extension.rules.push(rule1, rule2, rule3);
+    doc.extensions.set(extension.name, extension);
+    exporter.exportStructDef(extension);
+    const exported = pkg.extensions[0];
+    expect(exported.name).toBe('Foo');
+    expect(exported.status).toBe('active');
+    expect(exported.context).toEqual([
+      {
+        type: 'element',
+        expression: 'Observation'
       }
     ]);
   });

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -52,7 +52,7 @@ describe('ValueSetExporter', () => {
     expect(exported[0]).toEqual({
       name: 'BreakfastVS',
       id: 'BreakfastVS',
-      status: 'active',
+      status: 'draft',
       url: 'http://example.com/ValueSet/BreakfastVS',
       version: '0.0.1'
     });
@@ -77,7 +77,7 @@ describe('ValueSetExporter', () => {
     expect(exported[0]).toEqual({
       name: 'BreakfastVS',
       id: 'BreakfastVS',
-      status: 'active',
+      status: 'draft',
       title: 'Breakfast Values',
       description: 'A value set for breakfast items',
       url: 'http://example.com/ValueSet/BreakfastVS',
@@ -130,7 +130,7 @@ describe('ValueSetExporter', () => {
     expect(exported[0]).toEqual({
       name: 'DinnerVS',
       id: 'DinnerVS',
-      status: 'active',
+      status: 'draft',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
       compose: {
@@ -153,7 +153,7 @@ describe('ValueSetExporter', () => {
     expect(exported[0]).toEqual({
       name: 'DinnerVS',
       id: 'DinnerVS',
-      status: 'active',
+      status: 'draft',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
       compose: {
@@ -180,7 +180,7 @@ describe('ValueSetExporter', () => {
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
-      status: 'active',
+      status: 'draft',
       compose: {
         include: [
           {
@@ -215,7 +215,7 @@ describe('ValueSetExporter', () => {
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
-      status: 'active',
+      status: 'draft',
       compose: {
         include: [
           {
@@ -249,7 +249,7 @@ describe('ValueSetExporter', () => {
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
-      status: 'active',
+      status: 'draft',
       compose: {
         include: [
           {
@@ -283,7 +283,7 @@ describe('ValueSetExporter', () => {
       name: 'BreakfastVS',
       url: 'http://example.com/ValueSet/BreakfastVS',
       version: '0.0.1',
-      status: 'active',
+      status: 'draft',
       compose: {
         include: [
           {
@@ -319,7 +319,7 @@ describe('ValueSetExporter', () => {
       name: 'BreakfastVS',
       url: 'http://example.com/ValueSet/BreakfastVS',
       version: '0.0.1',
-      status: 'active',
+      status: 'draft',
       compose: {
         include: [
           {
@@ -355,7 +355,7 @@ describe('ValueSetExporter', () => {
       name: 'BreakfastVS',
       url: 'http://example.com/ValueSet/BreakfastVS',
       version: '0.0.1',
-      status: 'active',
+      status: 'draft',
       compose: {
         include: [
           {
@@ -395,7 +395,7 @@ describe('ValueSetExporter', () => {
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
-      status: 'active',
+      status: 'draft',
       compose: {
         include: [
           {


### PR DESCRIPTION
When creating a profile, start from a cleaner slate, clearing potentially irrelevant metadata from the parent.  This PR fixes #157.

The unit tests show the basic functionality.  You can also verify by generating profiles/extensions using the `master` branch and then generating them with this branch.  A file compare will show the differences.