### PR TITLE
Replace references to local code system with url

### DIFF
--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -7,7 +7,8 @@ import {
   FshCode,
   FshReference,
   Instance,
-  FshValueSet
+  FshValueSet,
+  FshCodeSystem
 } from '../../src/fshtypes';
 import {
   CardRule,
@@ -1066,6 +1067,27 @@ describe('StructureDefinitionExporter', () => {
     expect(fixedSubject.patternReference).toEqual({
       reference: 'Patient/bar-id'
     });
+  });
+
+  it('should apply a Code FixedValueRule and replace the local code system name with its url', () => {
+    const profile = new Profile('LightObservation');
+    profile.parent = 'Observation';
+    const rule = new FixedValueRule('valueCodeableConcept');
+    rule.fixedValue = new FshCode('bright', 'Visible');
+    profile.rules.push(rule);
+
+    const visibleSystem = new FshCodeSystem('Visible');
+    doc.codeSystems.set(visibleSystem.name, visibleSystem);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+    const fixedElement = sd.findElement('Observation.value[x]:valueCodeableConcept');
+    expect(fixedElement.patternCodeableConcept.coding).toEqual([
+      {
+        code: 'bright',
+        system: 'http://example.com/CodeSystem/Visible'
+      }
+    ]);
   });
 
   it('should not apply an incorrect FixedValueRule', () => {


### PR DESCRIPTION
Fixes #149 by way of task https://standardhealthrecord.atlassian.net/browse/CIMPL-247.

When an Instance or Structure Definition refers to a code system by name, and that code system is defined locally, replace the code system's name with the code system's url.

I didn't manage to exactly replicate every error mentioned in #149, but this pull request addresses a main portion of it. There may be further work required relating to references to locally defined code systems.