### PR TITLE
Revert default status back to active

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -57,7 +57,7 @@ export class StructureDefinitionExporter implements Fishable {
     } else {
       delete structDef.title;
     }
-    structDef.status = 'draft'; // it's 1..1 so we have to set it to something; can be overridden w/ rule
+    structDef.status = 'active'; // it's 1..1 so we have to set it to something; can be overridden w/ rule
     delete structDef.experimental;
     delete structDef.date;
     delete structDef.publisher;

--- a/src/fhirtypes/CodeSystem.ts
+++ b/src/fhirtypes/CodeSystem.ts
@@ -23,7 +23,7 @@ export class CodeSystem {
   version?: string;
   // name?: string; // provided by HasName mixin
   title?: string;
-  status: 'draft' | 'active' | 'retired' | 'unknown' = 'draft';
+  status: 'draft' | 'active' | 'retired' | 'unknown' = 'active';
   experimental?: boolean;
   date?: string;
   publisher?: string;

--- a/src/fhirtypes/ImplementationGuide.ts
+++ b/src/fhirtypes/ImplementationGuide.ts
@@ -8,7 +8,7 @@ export type ImplementationGuide = {
   version?: string;
   name: string;
   title?: string;
-  status: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'active' | 'active' | 'retired' | 'unknown';
   experimental?: boolean;
   date?: string;
   publisher?: string;

--- a/src/fhirtypes/ImplementationGuide.ts
+++ b/src/fhirtypes/ImplementationGuide.ts
@@ -8,7 +8,7 @@ export type ImplementationGuide = {
   version?: string;
   name: string;
   title?: string;
-  status: 'active' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
   experimental?: boolean;
   date?: string;
   publisher?: string;

--- a/src/fhirtypes/ValueSet.ts
+++ b/src/fhirtypes/ValueSet.ts
@@ -27,7 +27,7 @@ export class ValueSet {
   version: string;
   // name: string; // provided by HasName mixin
   title: string;
-  status: 'draft' | 'active' | 'retired' | 'unknown' = 'draft';
+  status: 'draft' | 'active' | 'retired' | 'unknown' = 'active';
   experimental: boolean;
   date: string;
   publisher: string;

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -60,7 +60,7 @@ export class IGExporter {
       // name must be alphanumeric (allowing underscore as well)
       name: (config.title ?? config.name).replace(/[^A-Za-z0-9_]/g, ''),
       title: config.title ?? config.name,
-      status: 'draft', // TODO: make user-configurable
+      status: 'active', // TODO: make user-configurable
       publisher: config.author,
       contact: config.maintainers?.map(m => {
         const contact: ContactDetail = {};

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -32,7 +32,7 @@ describe('CodeSystemExporter', () => {
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
       id: 'MyCodeSystem',
-      status: 'draft',
+      status: 'active',
       content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
       version: '0.0.1'
@@ -50,7 +50,7 @@ describe('CodeSystemExporter', () => {
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
       id: 'CodeSystem1',
-      status: 'draft',
+      status: 'active',
       content: 'complete',
       url: 'http://example.com/CodeSystem/CodeSystem1',
       title: 'My Fancy Code System',
@@ -79,7 +79,7 @@ describe('CodeSystemExporter', () => {
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
       id: 'MyCodeSystem',
-      status: 'draft',
+      status: 'active',
       content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
       version: '0.0.1',
@@ -102,7 +102,7 @@ describe('CodeSystemExporter', () => {
     expect(exported[0]).toEqual({
       name: 'MyCodeSystem',
       id: 'MyCodeSystem',
-      status: 'draft',
+      status: 'active',
       content: 'complete',
       url: 'http://example.com/CodeSystem/MyCodeSystem',
       version: '0.0.1',

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -92,7 +92,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.version).toBe('0.0.1'); // provided by config
     expect(exported.name).toBe('Foo'); // provided by user
     expect(exported.title).toBeUndefined();
-    expect(exported.status).toBe('draft'); // always active
+    expect(exported.status).toBe('active'); // always active
     expect(exported.experimental).toBeUndefined();
     expect(exported.date).toBeUndefined();
     expect(exported.publisher).toBeUndefined();
@@ -212,7 +212,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.version).toBe('0.0.1'); // provided by config
     expect(exported.name).toBe('Foo'); // provided by user
     expect(exported.title).toBeUndefined();
-    expect(exported.status).toBe('draft'); // always active
+    expect(exported.status).toBe('active'); // always active
     expect(exported.experimental).toBeUndefined();
     expect(exported.date).toBeUndefined();
     expect(exported.publisher).toBeUndefined();

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -52,7 +52,7 @@ describe('ValueSetExporter', () => {
     expect(exported[0]).toEqual({
       name: 'BreakfastVS',
       id: 'BreakfastVS',
-      status: 'draft',
+      status: 'active',
       url: 'http://example.com/ValueSet/BreakfastVS',
       version: '0.0.1'
     });
@@ -77,7 +77,7 @@ describe('ValueSetExporter', () => {
     expect(exported[0]).toEqual({
       name: 'BreakfastVS',
       id: 'BreakfastVS',
-      status: 'draft',
+      status: 'active',
       title: 'Breakfast Values',
       description: 'A value set for breakfast items',
       url: 'http://example.com/ValueSet/BreakfastVS',
@@ -130,7 +130,7 @@ describe('ValueSetExporter', () => {
     expect(exported[0]).toEqual({
       name: 'DinnerVS',
       id: 'DinnerVS',
-      status: 'draft',
+      status: 'active',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
       compose: {
@@ -153,7 +153,7 @@ describe('ValueSetExporter', () => {
     expect(exported[0]).toEqual({
       name: 'DinnerVS',
       id: 'DinnerVS',
-      status: 'draft',
+      status: 'active',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
       compose: {
@@ -180,7 +180,7 @@ describe('ValueSetExporter', () => {
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
-      status: 'draft',
+      status: 'active',
       compose: {
         include: [
           {
@@ -215,7 +215,7 @@ describe('ValueSetExporter', () => {
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
-      status: 'draft',
+      status: 'active',
       compose: {
         include: [
           {
@@ -249,7 +249,7 @@ describe('ValueSetExporter', () => {
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
-      status: 'draft',
+      status: 'active',
       compose: {
         include: [
           {
@@ -283,7 +283,7 @@ describe('ValueSetExporter', () => {
       name: 'BreakfastVS',
       url: 'http://example.com/ValueSet/BreakfastVS',
       version: '0.0.1',
-      status: 'draft',
+      status: 'active',
       compose: {
         include: [
           {
@@ -319,7 +319,7 @@ describe('ValueSetExporter', () => {
       name: 'BreakfastVS',
       url: 'http://example.com/ValueSet/BreakfastVS',
       version: '0.0.1',
-      status: 'draft',
+      status: 'active',
       compose: {
         include: [
           {
@@ -355,7 +355,7 @@ describe('ValueSetExporter', () => {
       name: 'BreakfastVS',
       url: 'http://example.com/ValueSet/BreakfastVS',
       version: '0.0.1',
-      status: 'draft',
+      status: 'active',
       compose: {
         include: [
           {
@@ -395,7 +395,7 @@ describe('ValueSetExporter', () => {
       name: 'DinnerVS',
       url: 'http://example.com/ValueSet/DinnerVS',
       version: '0.0.1',
-      status: 'draft',
+      status: 'active',
       compose: {
         include: [
           {

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -128,7 +128,7 @@ describe('IGExporter', () => {
         version: '0.1.0',
         name: 'FSHTestIG',
         title: 'FSH Test IG',
-        status: 'draft',
+        status: 'active',
         publisher: 'James Tuna',
         contact: [
           {


### PR DESCRIPTION
Until we've discussed default status w/ the community, keep default status as active since this is what it was in previous versions of SUSHI.

Fixes #162 