### PR TITLE
Add basic default differential

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -315,8 +315,16 @@ export class StructureDefinition {
 
     // Now handle snapshot and differential
     j.snapshot = { element: this.elements.map(e => e.toJSON()) };
+
+    const differentialElements = this.elements
+      .filter(e => e.hasDiff())
+      .map(e => e.calculateDiff().toJSON());
+
     j.differential = {
-      element: this.elements.filter(e => e.hasDiff()).map(e => e.calculateDiff().toJSON())
+      element:
+        differentialElements.length > 0
+          ? differentialElements
+          : [{ id: 'Observation', path: 'Observation' }]
     };
 
     // Post-process the differential to remove any choice[x] elements if the only thing they do is establish the type

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -122,6 +122,11 @@ describe('StructureDefinition', () => {
       });
     });
 
+    it('should reflect basic differential for structure definitions with no changes', () => {
+      const json = observation.toJSON();
+      expect(json.differential).toEqual({ element: [{ id: 'Observation', path: 'Observation' }] });
+    });
+
     it('should properly serialize snapshot and differential for constrained choice type with constraints on specific choices', () => {
       // constrain value[x] to only a Quantity or string and give each its own short
       const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');


### PR DESCRIPTION
Fixes #153 

Adds in a basic entry into the `differential.element` even if there are no changes made to a profile/extension, like @cmoesel suggested in the issue. The IG publisher seems to be happy with this fix.