### PR TITLE
Add show-inherited-invariants parameter

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -105,6 +105,10 @@ export class IGExporter {
           {
             code: 'releaselabel',
             value: 'CI Build' // TODO: Make this configurable
+          },
+          {
+            code: 'show-inherited-invariants',
+            value: 'false' // TODO: Make this configurable
           }
         ]
       }

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -232,6 +232,10 @@ describe('IGExporter', () => {
             {
               code: 'releaselabel',
               value: 'CI Build'
+            },
+            {
+              code: 'show-inherited-invariants',
+              value: 'false'
             }
           ]
         }


### PR DESCRIPTION
Adds the `show-inherited-invariants` parameter.

There was an update to the IG publisher yesterday, so if you update to the newest version, this parameter should work. An example to make sure it works it to look at the `CancerPatient` profile. You should no longer see the long list of constraints that you can see here: http://build.fhir.org/ig/HL7/fhir-mCODE-ig/branches/master/StructureDefinition-CancerPatient.html.