### PR TITLE
Fix values in instances from parent patterns

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -20,18 +20,18 @@ export class InstanceExporter {
     instanceOfStructureDefinition: StructureDefinition
   ): InstanceDefinition {
     // Fix values from the SD for all elements at the top level of the SD
-    this.setFixedValuesForDirectChildren(
+    this.setFixedValuesFromStructureDefinition(
       instanceOfStructureDefinition.findElement(instanceDef.resourceType),
       '',
       instanceDef,
       instanceOfStructureDefinition
     );
 
-    // All rules will be FixValueRule
+    // Fix all values from the SD
     fshInstanceDef.rules.forEach(rule => {
       rule = replaceReferences(rule, this.tank, this.fisher);
       try {
-        const { fixedValue, pathParts } = instanceOfStructureDefinition.validateValueAtPath(
+        const validated = instanceOfStructureDefinition.validateValueAtPath(
           rule.path,
           rule.fixedValue,
           this.fisher
@@ -39,7 +39,7 @@ export class InstanceExporter {
 
         // For each part of that path, we add fixed values from the SD
         let path = '';
-        for (const [i, pathPart] of pathParts.entries()) {
+        for (const [i, pathPart] of validated.pathParts.entries()) {
           path += `${path ? '.' : ''}${pathPart.base}`;
           // Add back non-numeric (slice) brackets
           pathPart.brackets?.forEach(b => (path += /^[-+]?\d+$/.test(b) ? '' : `[${b}]`));
@@ -51,14 +51,27 @@ export class InstanceExporter {
             .join('.');
           rulePathPart += '.';
 
-          this.setFixedValuesForDirectChildren(
+          this.setFixedValuesFromStructureDefinition(
             element,
             rulePathPart,
             instanceDef,
             instanceOfStructureDefinition
           );
         }
+      } catch (e) {
+        logger.error(e.message, rule.sourceInfo);
+      }
+    });
 
+    // All rules will be FixValueRule
+    fshInstanceDef.rules.forEach(rule => {
+      rule = replaceReferences(rule, this.tank, this.fisher);
+      try {
+        const { fixedValue, pathParts } = instanceOfStructureDefinition.validateValueAtPath(
+          rule.path,
+          rule.fixedValue,
+          this.fisher
+        );
         // Fix value fom the rule
         setPropertyOnInstance(instanceDef, pathParts, fixedValue);
       } catch (e) {
@@ -90,45 +103,48 @@ export class InstanceExporter {
    * @param {InstanceDefinition} instanceDef - The InstanceDefinition to fix values on
    * @param {StructureDefinition} instanceOfStructureDefinition - The structure definition the instance instantiates
    */
-  private setFixedValuesForDirectChildren(
+  private setFixedValuesFromStructureDefinition(
     element: ElementDefinition,
     existingPath: string,
     instanceDef: InstanceDefinition,
     instanceOfStructureDefinition: StructureDefinition
   ) {
-    const directChildren = element.children(true);
-    for (const child of directChildren) {
+    // We will fix values on the element, or its direct 1..n children
+    const fixableElements = [element, ...element.children(true)];
+    for (const fixableElement of fixableElements) {
       // Fixed values may be specified by the fixed[x] or pattern[x] fields
-      const fixedValueKey = Object.keys(child).find(
+      const fixedValueKey = Object.keys(fixableElement).find(
         k => k.startsWith('fixed') || k.startsWith('pattern')
       );
-      if (fixedValueKey && child.min > 0) {
-        // Get the end of the child path, this is the part that differs from existingPath
-        const childPath = child
-          .diffId()
-          .split('.')
-          .slice(-1)[0];
+      const foundFixedValue =
+        fixableElement[fixedValueKey as keyof ElementDefinition] ?? fixableElement.fixedByParent();
+      if (foundFixedValue && (fixableElement.id === element.id || fixableElement.min > 0)) {
+        // Get the end of the path, this is the part that differs from existingPath
+        let fixablePath = fixableElement.diffId().replace(`${element.diffId()}`, '');
+        if (fixablePath.startsWith('.')) fixablePath = fixablePath.slice(1);
+
         // Turn FHIR slicing (element:slicName/resliceName) into FSH slicing (element[sliceName][resliceName])
-        const colonSplitPath = childPath.split(':');
-        let fshChildPath = colonSplitPath[0];
+        const colonSplitPath = fixablePath.split(':');
+        let fshElementPath = colonSplitPath[0];
         const slicePathSection = colonSplitPath[1];
         const sliceNames = slicePathSection?.split('/');
         sliceNames?.forEach(s => {
-          fshChildPath += `[${s}]`;
+          fshElementPath += `[${s}]`;
         });
+        // Fix the value if we validly can
         try {
           const { fixedValue, pathParts } = instanceOfStructureDefinition.validateValueAtPath(
-            existingPath + fshChildPath,
-            child[fixedValueKey as keyof ElementDefinition],
+            fshElementPath === '' ? existingPath.slice(0, -1) : existingPath + fshElementPath,
+            foundFixedValue,
             this.fisher
           );
           setPropertyOnInstance(instanceDef, pathParts, fixedValue);
         } catch (e) {
           logger.error(e.message);
         }
-      } else if (fixedValueKey) {
+      } else if (foundFixedValue) {
         logger.debug(
-          `Element ${child.id} is optional with min cardinality 0, so fixed value for optional element is not set on instance ${instanceDef.instanceName}`
+          `Element ${fixableElement.id} is optional with min cardinality 0, so fixed value for optional element is not set on instance ${instanceDef.instanceName}`
         );
       }
     }

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -27,9 +27,10 @@ export class InstanceExporter {
       instanceOfStructureDefinition
     );
 
-    // Fix all values from the SD
-    fshInstanceDef.rules.forEach(rule => {
-      rule = replaceReferences(rule, this.tank, this.fisher);
+    const rules = fshInstanceDef.rules.map(r => replaceReferences(r, this.tank, this.fisher));
+
+    // Fix all values from the SD that are exposed when processing the instance rules
+    rules.forEach(rule => {
       try {
         const validated = instanceOfStructureDefinition.validateValueAtPath(
           rule.path,
@@ -63,9 +64,8 @@ export class InstanceExporter {
       }
     });
 
-    // All rules will be FixValueRule
-    fshInstanceDef.rules.forEach(rule => {
-      rule = replaceReferences(rule, this.tank, this.fisher);
+    // Fix all values explicitly set in the instance rules (all rules will be FixValueRule)
+    rules.forEach(rule => {
       try {
         const { fixedValue, pathParts } = instanceOfStructureDefinition.validateValueAtPath(
           rule.path,

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -847,6 +847,19 @@ export class ElementDefinition {
   }
 
   /**
+   * Checks if an element is fixed by a pattern[x] on its direct parent
+   * @returns {any} the value the element is fixed to by its parent, undefined if value is not fixed
+   */
+  fixedByParent(): any {
+    const parent = this.parent();
+    const patternKey = parent ? Object.keys(parent).find(k => k.startsWith('pattern')) : null;
+    if (patternKey) {
+      const patternValue: any = parent[patternKey as keyof ElementDefinition];
+      return patternValue[this.path.replace(`${parent.path}.`, '')];
+    }
+  }
+
+  /**
    * Fixes a boolean to this element.
    * @see {@link fixValue}
    * @see {@link https://www.hl7.org/fhir/datatypes.html#primitive}

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -470,6 +470,115 @@ describe('InstanceExporter', () => {
       ]);
     });
 
+    // Fixing with pattern[x]
+    it('should fix a nested element that is fixed by pattern[x] from a parent on the SD', () => {
+      const fixedValRule = new FixedValueRule('maritalStatus.coding');
+      fixedValRule.fixedValue = new FshCode('foo', 'http://foo.com');
+      patient.rules.push(fixedValRule);
+      const instanceFixedValRule = new FixedValueRule('maritalStatus.coding[0].version');
+      instanceFixedValRule.fixedValue = '1.2.3';
+      instance.rules.push(instanceFixedValRule);
+      const exported = exportInstance(instance);
+      expect(exported.maritalStatus).toEqual({
+        coding: [
+          {
+            code: 'foo',
+            system: 'http://foo.com',
+            version: '1.2.3'
+          }
+        ]
+      });
+    });
+
+    it('should fix multiple nested elements that are fixed by pattern[x] from a parent on the SD', () => {
+      const fixedValRule = new FixedValueRule('maritalStatus.coding');
+      fixedValRule.fixedValue = new FshCode('foo', 'http://foo.com');
+      patient.rules.push(fixedValRule);
+      const instanceFixedValRule = new FixedValueRule('maritalStatus.coding[0].version');
+      instanceFixedValRule.fixedValue = '1.2.3';
+      instance.rules.push(instanceFixedValRule);
+      const instanceFixedValRule2 = new FixedValueRule('maritalStatus.coding[1].version');
+      instanceFixedValRule2.fixedValue = '3.2.1';
+      instance.rules.push(instanceFixedValRule2);
+      const exported = exportInstance(instance);
+      expect(exported.maritalStatus).toEqual({
+        coding: [
+          {
+            code: 'foo',
+            system: 'http://foo.com',
+            version: '1.2.3'
+          },
+          {
+            code: 'foo',
+            system: 'http://foo.com',
+            version: '3.2.1'
+          }
+        ]
+      });
+    });
+
+    it('should fix a nested element that is fixed by array pattern[x] from a parent on the SD', () => {
+      const fixedValRule = new FixedValueRule('maritalStatus');
+      fixedValRule.fixedValue = new FshCode('foo', 'http://foo.com');
+      patient.rules.push(fixedValRule);
+      const instanceFixedValRule = new FixedValueRule('maritalStatus.coding[0].version');
+      instanceFixedValRule.fixedValue = '1.2.3';
+      instance.rules.push(instanceFixedValRule);
+      const exported = exportInstance(instance);
+      expect(exported.maritalStatus).toEqual({
+        coding: [
+          {
+            code: 'foo',
+            system: 'http://foo.com',
+            version: '1.2.3'
+          }
+        ]
+      });
+    });
+
+    it('should fix multiple nested elements that are fixed by array pattern[x] from a parent on the SD', () => {
+      const fixedValRule = new FixedValueRule('maritalStatus');
+      fixedValRule.fixedValue = new FshCode('foo', 'http://foo.com');
+      patient.rules.push(fixedValRule);
+      const instanceFixedValRule1 = new FixedValueRule('maritalStatus.coding[0].version');
+      instanceFixedValRule1.fixedValue = '1.2.3';
+      instance.rules.push(instanceFixedValRule1);
+      const instanceFixedValRule2 = new FixedValueRule('maritalStatus.coding[1].version');
+      instanceFixedValRule2.fixedValue = '3.2.1';
+      instance.rules.push(instanceFixedValRule2);
+      const exported = exportInstance(instance);
+      expect(exported.maritalStatus).toEqual({
+        coding: [
+          {
+            code: 'foo',
+            system: 'http://foo.com',
+            version: '1.2.3'
+          },
+          {
+            version: '3.2.1'
+          }
+        ]
+      });
+    });
+
+    it('should fix cardinality 1..n elements that are fixed by array pattern[x] from a parent on the SD', () => {
+      const fixedValRule = new FixedValueRule('maritalStatus');
+      fixedValRule.fixedValue = new FshCode('foo', 'http://foo.com');
+      patient.rules.push(fixedValRule);
+      const cardRule = new CardRule('maritalStatus');
+      cardRule.min = 1;
+      patient.rules.push(cardRule);
+      const exported = exportInstance(instance);
+      expect(exported.maritalStatus).toEqual({
+        coding: [
+          {
+            code: 'foo',
+            system: 'http://foo.com'
+          }
+        ]
+      });
+    });
+
     // TODO: The fixValue functions should be updated to not fix a value when a parent element sets
     // the value to something different using a pattern
     it.skip('should not fix an element to a value different than a parent pattern value on the Structure Definition', () => {

--- a/test/fhirtypes/ElementDefinition.fixValue.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixValue.test.ts
@@ -101,4 +101,27 @@ describe('ElementDefinition', () => {
       });
     });
   });
+  describe('#fixedByParent', () => {
+    it('should find a pattern value from the parent when it exists', () => {
+      const statusReason = medicationRequest.elements.find(
+        e => e.id === 'MedicationRequest.statusReason'
+      );
+      statusReason.fixValue(new FshCode('foo'));
+      const statusReasonCoding = medicationRequest.findElementByPath('statusReason.coding', fisher);
+      const patternValue = statusReasonCoding.fixedByParent();
+      expect(patternValue).toEqual([{ code: 'foo' }]);
+    });
+
+    it('should not find a pattern value from the parent when none is present', () => {
+      const statusReasonCoding = medicationRequest.findElementByPath('statusReason.coding', fisher);
+      const patternValue = statusReasonCoding.fixedByParent();
+      expect(patternValue).toBeUndefined();
+    });
+
+    it('should return undefined when being run on the root element', () => {
+      const root = medicationRequest.elements.find(e => e.id === 'MedicationRequest');
+      const patternValue = root.fixedByParent();
+      expect(patternValue).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
This fixes #160 

Values are now fixed on an instance if they are fixed by a pattern[x] element in their parent. One possible way to test this is to build fsh-mcode using SUSHI on master. Then, in Examples.fsh, you should be able to comment out the lines that are labeled as part of a workaround. Then you can build fsh-mcode using SUSHI on this branch. You should get the same result, down to the ordering of the elements in the output. Additionally, you should notice that you do not see the problem that is described in #160

Note that this does not yet add validation to check if an element is fixed by pattern from its parent. This is only adding functionality to set values on an instance according to patterns on parent elements. I am open to adding validation to this PR if the reviewers think I should, but I felt like this could stand on its own.

Whoever reviews, if you can give a good look at the tests, I would appreciate that. I had trouble thinking through different possible test cases. As far as I could think of, my tests cases cover what we need, but I want to make sure this is well tested.