### PR TITLE
Support CRLF line breaks in multiline strings, clean up blank lines

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1043,6 +1043,7 @@ export class FSHImporter extends FSHVisitor {
    * Multiline strings receive special handling:
    * - if the first line contains only whitespace (including newline), toss it
    * - if the last line contains only whitespace (including newline), toss it
+   * - if another line contains only whitespace, truncate it
    * - for all other non-whitespace lines, detect the shortest number of leading spaces and always trim that off;
    *   this allows authors to indent a whole block of text, but not have it indented in the output.
    */
@@ -1053,7 +1054,7 @@ export class FSHImporter extends FSHVisitor {
     mlstr = mlstr.slice(3, -3);
 
     // split into lines so we can process them to determine what leading spaces to trim
-    const lines = mlstr.split(/\r?\n/);
+    let lines = mlstr.split(/\r?\n/);
 
     // if the first line is only whitespace, remove it
     if (lines[0].search(/\S/) === -1) {
@@ -1065,12 +1066,14 @@ export class FSHImporter extends FSHVisitor {
       lines.pop();
     }
 
+    lines = lines.map(l => (/^\s*$/.test(l) ? '' : l));
+
     // find the minimum number of spaces before the first char (ignore zero-length lines)
     let minSpaces = 0;
     lines.forEach(line => {
       const firstNonSpace = line.search(/\S|$/);
-      const lineIsBlank = /^\s*$/.test(line);
-      if (!lineIsBlank && firstNonSpace > 0 && (minSpaces === 0 || firstNonSpace < minSpaces)) {
+      const lineIsEmpty = /^$/.test(line);
+      if (!lineIsEmpty && firstNonSpace > 0 && (minSpaces === 0 || firstNonSpace < minSpaces)) {
         minSpaces = firstNonSpace;
       }
     });

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -139,4 +139,60 @@ describe('FSHImporter', () => {
     expect(result.profiles.size).toBe(1);
     expect(loggerSpy.getAllLogs().length).toBe(0);
   });
+
+  it('should adjust indentation of multi-line strings that include blank lines', () => {
+    const input = `
+    Profile: ObservationProfile
+    Parent: Observation
+    Description: """
+    SUSHI stands for:
+      SUSHI
+      Unshortens
+      Short
+      Hand
+      Inputs
+
+    Recursive acronyms are very popular these days.
+    """`;
+    const expectedDescription = [
+      'SUSHI stands for:',
+      '  SUSHI',
+      '  Unshortens',
+      '  Short',
+      '  Hand',
+      '  Inputs',
+      '',
+      'Recursive acronyms are very popular these days.'
+    ].join('\n');
+    const result = importSingleText(input);
+    const profile = result.profiles.get('ObservationProfile');
+    expect(profile.description).toBe(expectedDescription);
+  });
+
+  it('should parse multi-line strings with CRLF line breaks', () => {
+    const input = [
+      'Profile: ObservationProfile',
+      'Parent: Observation',
+      'Description: """',
+      'Line endings',
+      'are always',
+      'troublesome.',
+      '"""'
+    ].join('\r\n');
+    const expectedDescription = ['Line endings', 'are always', 'troublesome.'].join('\n');
+    const result = importSingleText(input);
+    const profile = result.profiles.get('ObservationProfile');
+    expect(profile.description).toBe(expectedDescription);
+  });
+
+  it('should parse multi-line strings that only occupy one line', () => {
+    const input = `
+    Profile: ObservationProfile
+    Parent: Observation
+    Description: """Descriptions come in only one size."""
+    `;
+    const result = importSingleText(input);
+    const profile = result.profiles.get('ObservationProfile');
+    expect(profile.description).toBe('Descriptions come in only one size.');
+  });
 });

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -169,6 +169,35 @@ describe('FSHImporter', () => {
     expect(profile.description).toBe(expectedDescription);
   });
 
+  it('should truncate whitespace lines in multi-line strings', () => {
+    const input = `
+    Profile: StaircaseObservation
+    Parent: Observation
+    Description: """
+    This
+      Description
+      
+        Looks
+          Like
+          
+            A
+              Staircase
+                """`;
+    const expectedDescription = [
+      'This',
+      '  Description',
+      '',
+      '    Looks',
+      '      Like',
+      '',
+      '        A',
+      '          Staircase'
+    ].join('\n');
+    const result = importSingleText(input);
+    const profile = result.profiles.get('StaircaseObservation');
+    expect(profile.description).toBe(expectedDescription);
+  });
+
   it('should parse multi-line strings with CRLF line breaks', () => {
     const input = [
       'Profile: ObservationProfile',


### PR DESCRIPTION
Fixes #80 and addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-215.

Input files may use either CRLF or LF as their line break. These are the two most common line break styles.
If a line in a multiline string is only whitespace, truncate it so that it becomes an empty line.
If a line is an empty line, don't check it when determining the number of spaces to un-indent each line in the multiline string.