### PR TITLE
Unfold Content Reference Elements

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1416,8 +1416,7 @@ export class ElementDefinition {
    */
   unfold(fisher: Fishable): ElementDefinition[] {
     if (
-      (this.type?.length === 1 &&
-        (this.type?.[0].profile == null || this.type?.[0].profile.length <= 1)) ||
+      (this.type?.length === 1 && (this.type[0].profile ?? []).length <= 1) ||
       this.contentReference
     ) {
       let newElements: ElementDefinition[] = [];

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -124,6 +124,7 @@ describe('InstanceExporter', () => {
     let instance: Instance;
     let patientProfInstance: Instance;
     let lipidInstance: Instance;
+    let valueSetInstance: Instance;
     beforeEach(() => {
       patient = new Profile('TestPatient');
       patient.parent = 'Patient';
@@ -140,6 +141,9 @@ describe('InstanceExporter', () => {
       lipidInstance = new Instance('Bam');
       lipidInstance.instanceOf = 'lipidprofile';
       doc.instances.set(lipidInstance.name, lipidInstance);
+      valueSetInstance = new Instance('Boom');
+      valueSetInstance.instanceOf = 'ValueSet';
+      doc.instances.set(valueSetInstance.name, valueSetInstance);
     });
 
     // Setting Metadata
@@ -877,6 +881,21 @@ describe('InstanceExporter', () => {
 
     it.skip('should fix sliced elements on a sliced primitive', () => {
       /* Need example of sliced primitive */
+    });
+
+    // Content Reference
+    it('should fix a child of a contentReference element', () => {
+      const barRule = new FixedValueRule('compose.exclude.version');
+      barRule.fixedValue = 'bar';
+      valueSetInstance.rules.push(barRule);
+      const exported = exportInstance(valueSetInstance);
+      expect(exported.compose).toEqual({
+        exclude: [
+          {
+            version: 'bar'
+          }
+        ]
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #184.

When we access the children of an element that has a contentReference field on it, we need to unfold from the element on the StructureDefinition that the contentReference refers to. A contentReference is used to refer to an element defined in that same StructureDefinition. Documentation on contentReferences is here https://www.hl7.org/fhir/elementdefinition-definitions.html#ElementDefinition.contentReference. 

This adds the capability to access children of an element that is a contentReference. Accessing a child will unfold all the children of the referenced element onto the element with the contentReference. The contentReference element will also have the contentReference field deleted, since it is no longer a contentReference. If you want to test on a real example, try adding the Profile on ValueSet described in #184 to a FSH file. You should see that the "exclude" element gets unfolded with the children of the "include" element, and constraints are correctly applied to it.