### PR TITLE
Update default SD differential

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -319,12 +319,12 @@ export class StructureDefinition {
     const differentialElements = this.elements
       .filter(e => e.hasDiff())
       .map(e => e.calculateDiff().toJSON());
+    const defaultDifferentialElements = [
+      { id: j.snapshot.element[0].id, path: j.snapshot.element[0].path }
+    ];
 
     j.differential = {
-      element:
-        differentialElements.length > 0
-          ? differentialElements
-          : [{ id: 'Observation', path: 'Observation' }]
+      element: differentialElements.length > 0 ? differentialElements : defaultDifferentialElements
     };
 
     // Post-process the differential to remove any choice[x] elements if the only thing they do is establish the type


### PR DESCRIPTION
Updated the default Structure Definition differential element to use the the first snapshot element's id and path.

The test that was supposed to be testing this was using an observation. Since it's still technically correctly, I haven't updated the tests. Tested with a patient resource locally, and it indeed has an id and path of 'Patient'.

Should fix #198 