### PR TITLE
Fix resolution of "current" IG dependencies

### DIFF
--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -54,7 +54,7 @@ export async function loadDependency(
         // means to find the package at:
         //    http://build.fhir.org/ig/HL7/US-Core-R4/package.tgz
         // See: https://chat.fhir.org/#narrow/stream/179165-committers/topic/Build.20Problem/near/187610137
-        const [org, repo] = newestPackage.repo.split('/').slice(0, 2);
+        const [org, repo] = newestPackage.repo.split('/');
         packageUrl = `${baseUrl}/${org}/${repo}/package.tgz`;
       } else {
         throw new CurrentPackageLoadError(fullPackageName);

--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -36,18 +36,26 @@ export async function loadDependency(
     } else if (version === 'current') {
       // Current packages need to be loaded using build.fhir.org
       const baseUrl = 'http://build.fhir.org/ig';
-      const res = await rp.get({ uri: `${baseUrl}/qas.json`, json: true });
+      const res: { 'package-id': string; date: string; repo: string }[] = await rp.get({
+        uri: `${baseUrl}/qas.json`,
+        json: true
+      });
       // Find matching packages and sort by date to get the most recent
       let newestPackage;
       if (res && res.length > 0) {
-        const matchingPackages = res.filter((p: any) => p['package-id'] === packageName);
-        newestPackage = matchingPackages.sort((p1: any, p2: any) => {
+        const matchingPackages = res.filter(p => p['package-id'] === packageName);
+        newestPackage = matchingPackages.sort((p1, p2) => {
           return Date.parse(p2['date']) - Date.parse(p1['date']);
         })[0];
       }
-      if (newestPackage) {
-        // Current packages are stored at build.fhir.org
-        packageUrl = `${baseUrl}/${newestPackage.repo}/package.tgz`;
+      if (newestPackage && newestPackage.repo) {
+        // Find the package based on the first two parts of the package's 'repo' property.  E.g.,
+        //   "repo": "HL7/US-Core-R4/branches/test-branch-tweak/qa.json"
+        // means to find the package at:
+        //    http://build.fhir.org/ig/HL7/US-Core-R4/package.tgz
+        // See: https://chat.fhir.org/#narrow/stream/179165-committers/topic/Build.20Problem/near/187610137
+        const [org, repo] = newestPackage.repo.split('/').slice(0, 2);
+        packageUrl = `${baseUrl}/${org}/${repo}/package.tgz`;
       } else {
         throw new CurrentPackageLoadError(fullPackageName);
       }

--- a/test/fhirdefs/load.test.ts
+++ b/test/fhirdefs/load.test.ts
@@ -68,30 +68,30 @@ describe('#loadDependency()', () => {
       if (options.uri === 'http://build.fhir.org/ig/qas.json') {
         return [
           {
-            url: 'http://hl7.org/fhir/hspc/ImplementationGuide/hspc',
-            name: 'HSPC Implementation Guide',
-            'package-id': 'hl7.fhir.hspc',
-            'ig-ver': '1.0',
-            date: 'Thu, 11 Oct, 2018 11:00:14 -0600',
-            errs: 34,
-            warnings: 10,
-            hints: 0,
-            version: '3.0.1',
-            tool: '3.4.0-13844',
-            repo: 'nrdavis1/HSPCFHIRtest/branches/oldbranch/qa.json'
+            url: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core.r4-4.0.0',
+            name: 'USCoreR4',
+            'package-id': 'hl7.fhir.us.core.r4',
+            'ig-ver': '4.0.0',
+            date: 'Sat, 18 May, 2019 01:48:14 +0000',
+            errs: 538,
+            warnings: 34,
+            hints: 202,
+            version: '4.0.0',
+            tool: '4.1.0 (3)',
+            repo: 'HL7Imposter/US-Core-R4/branches/oldbranch/qa.json'
           },
           {
-            url: 'http://hl7.org/fhir/hspc/ImplementationGuide/hspc',
-            name: 'HSPC Implementation Guide',
-            'package-id': 'hl7.fhir.hspc',
-            'ig-ver': '1.0',
-            date: 'Tue, 05 Mar, 2019 12:02:14 -0700',
-            errs: 26980,
-            warnings: 10,
-            hints: 0,
-            version: '3.0.1',
-            tool: '3.4.0-13844',
-            repo: 'nrdavis1/HSPCFHIRtest/branches/master/qa.json'
+            url: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core.r4-4.0.0',
+            name: 'USCoreR4',
+            'package-id': 'hl7.fhir.us.core.r4',
+            'ig-ver': '4.0.0',
+            date: 'Mon, 20 Jan, 2020 19:36:43 +0000',
+            errs: 1496,
+            warnings: 36,
+            hints: 228,
+            version: '4.0.0',
+            tool: '4.1.0 (3)',
+            repo: 'HL7/US-Core-R4/branches/newbranch/qa.json'
           }
         ];
       } else {
@@ -138,8 +138,8 @@ describe('#loadDependency()', () => {
   });
 
   it('should try to load the latest package from build.fhir.org when a current package version is loaded', async () => {
-    await expect(loadDependency('hl7.fhir.hspc', 'current', defs, 'foo')).rejects.toThrow(
-      'The package hl7.fhir.hspc#current could not be loaded locally or from the FHIR package registry'
+    await expect(loadDependency('hl7.fhir.us.core.r4', 'current', defs, 'foo')).rejects.toThrow(
+      'The package hl7.fhir.us.core.r4#current could not be loaded locally or from the FHIR package registry'
     );
     expect(requestSpy.mock.calls[0]).toEqual([
       {
@@ -148,10 +148,10 @@ describe('#loadDependency()', () => {
       }
     ]);
     expect(requestSpy.mock.calls[1][0].uri).toBe(
-      'http://build.fhir.org/ig/nrdavis1/HSPCFHIRtest/package.tgz'
+      'http://build.fhir.org/ig/HL7/US-Core-R4/package.tgz'
     );
-    expect(ensureDirSpy.mock.calls[0]).toEqual([path.join('foo', 'hl7.fhir.hspc#current')]);
-    expect(tarSpy.mock.calls[0][0].cwd).toBe(path.join('foo', 'hl7.fhir.hspc#current'));
+    expect(ensureDirSpy.mock.calls[0]).toEqual([path.join('foo', 'hl7.fhir.us.core.r4#current')]);
+    expect(tarSpy.mock.calls[0][0].cwd).toBe(path.join('foo', 'hl7.fhir.us.core.r4#current'));
   });
 
   it('should throw CurrentPackageLoadError when a current package is not listed', async () => {

--- a/test/fhirdefs/load.test.ts
+++ b/test/fhirdefs/load.test.ts
@@ -78,7 +78,7 @@ describe('#loadDependency()', () => {
             hints: 0,
             version: '3.0.1',
             tool: '3.4.0-13844',
-            repo: 'nrdavis1/HSPCFHIRtest/bran'
+            repo: 'nrdavis1/HSPCFHIRtest/branches/oldbranch/qa.json'
           },
           {
             url: 'http://hl7.org/fhir/hspc/ImplementationGuide/hspc',
@@ -91,7 +91,7 @@ describe('#loadDependency()', () => {
             hints: 0,
             version: '3.0.1',
             tool: '3.4.0-13844',
-            repo: 'nrdavis1/HSPCFHIRtest/branches'
+            repo: 'nrdavis1/HSPCFHIRtest/branches/master/qa.json'
           }
         ];
       } else {
@@ -148,7 +148,7 @@ describe('#loadDependency()', () => {
       }
     ]);
     expect(requestSpy.mock.calls[1][0].uri).toBe(
-      'http://build.fhir.org/ig/nrdavis1/HSPCFHIRtest/branches/package.tgz'
+      'http://build.fhir.org/ig/nrdavis1/HSPCFHIRtest/package.tgz'
     );
     expect(ensureDirSpy.mock.calls[0]).toEqual([path.join('foo', 'hl7.fhir.hspc#current')]);
     expect(tarSpy.mock.calls[0][0].cwd).toBe(path.join('foo', 'hl7.fhir.hspc#current'));


### PR DESCRIPTION
Changes in the CI Build infrastructure broke the way we were finding the "current" version of IG dependencies.  This commit fixes the approach as described on Zulip here: https://chat.fhir.org/#narrow/stream/179165-committers/topic/Build.20Problem/near/187610137

Fixes #201