### PR TITLE
IG Generation Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ If the input folder (i.e., "FSH Tank") contains a sub-folder named "ig-data", th
 
 * `ig-data/ig.ini`: If present, the user-provided igi.ini values will be merged with SUSHI-generated ig.ini.
 * `ig-data/package-list.json`: If present, it will be used instead of a generated package-list.json.
-* `ig-data/input/pagecontent/index.md`: If present, it will provide the content for the IG's main page.
+* `ig-data/input/pagecontent/index.[md|xml]`: If present, it will provide the content for the IG's main page.
+* `ig-data/input/pagecontent/*.[md|xml]`: If present, these files will be generated as individual pages in the IG and will be present in the table of contents.
+* `ig-data/input/pagecontent/{name-of-resource-file}-[intro|notes].[md|xml]`: If present, these files will place content directly on the relevant resource page. Intro files will place content before the resource definition; notes files will place content after.
+* `ig-data/input/pagecontent/*`: If present, all other files of any type that do not match the above patterns will be copied into the IG input, but will not appear in the table of contents.
+* `ig-data/input/images/*`: If present, image files will be copied into the IG input and can be referenced by user-provided pages.
 
 After running SUSHI, change to the output folder and run the `_updatePublisher` and `_genonce` scripts.
 


### PR DESCRIPTION
Updates IG Generation section of README to reflect changes made to support additional user-provided pages and images.

I tried to consolidate the different types of files into a bullet per type, but the name of the file a few bullets reference has a lot of information in it. If it is preferred to break those into different bullets or describe the files name differently, let me know.