### PR TITLE
Escape # in coding system identifier

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -679,14 +679,14 @@ export class FSHImporter extends FSHVisitor {
   visitCode(ctx: pc.CodeContext): FshCode {
     // split on the first unescaped #
     const conceptText = ctx.CODE().getText();
-    const splitPoint = conceptText.search(/$#|[^\\]#/);
+    const splitPoint = conceptText.match(/(^|[^\\])(\\\\)*#/);
     let system: string, code: string;
-    if (splitPoint == 0) {
+    if (splitPoint == null) {
       system = '';
       code = conceptText.slice(1);
     } else {
-      system = conceptText.slice(0, splitPoint + 1);
-      code = conceptText.slice(splitPoint + 2);
+      system = conceptText.slice(0, splitPoint.index) + splitPoint[0].slice(0, -1);
+      code = conceptText.slice(splitPoint.index + splitPoint[0].length);
     }
     system = system.replace(/\\\\/g, '\\').replace(/\\#/g, '#');
     if (code.startsWith('"')) {

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -677,12 +677,18 @@ export class FSHImporter extends FSHVisitor {
   }
 
   visitCode(ctx: pc.CodeContext): FshCode {
-    const conceptText = ctx
-      .CODE()
-      .getText()
-      .split('#', 2);
-    const system = conceptText[0];
-    let code = conceptText[1];
+    // split on the first unescaped #
+    const conceptText = ctx.CODE().getText();
+    const splitPoint = conceptText.search(/$#|[^\\]#/);
+    let system: string, code: string;
+    if (splitPoint == 0) {
+      system = '';
+      code = conceptText.slice(1);
+    } else {
+      system = conceptText.slice(0, splitPoint + 1);
+      code = conceptText.slice(splitPoint + 2);
+    }
+    system = system.replace(/\\\\/g, '\\').replace(/\\#/g, '#');
     if (code.startsWith('"')) {
       code = code
         .slice(1, code.length - 1)

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -81,14 +81,24 @@ describe('FSHImporter', () => {
     Profile: HashBrowns
     Parent: Observation
     * code = https://breakfast.com/good\\\\food\\#potatoes#hash#browns
+    * extraCode = https://lastly.com/backslash\\\\#last
+    * bonusCode = \\\\\\\\#just_backslash "Just Backslash"
     `;
     const result = importSingleText(input, 'HashBrowns.fsh');
     const profile = result.profiles.get('HashBrowns');
     const expectedCode = new FshCode('hash#browns', 'https://breakfast.com/good\\food#potatoes')
       .withLocation([4, 14, 4, 67])
       .withFile('HashBrowns.fsh');
-    expect(profile.rules).toHaveLength(1);
+    const expectedExtraCode = new FshCode('last', 'https://lastly.com/backslash\\')
+      .withLocation([5, 19, 5, 53])
+      .withFile('HashBrowns.fsh');
+    const expectedBonusCode = new FshCode('just_backslash', '\\\\', 'Just Backslash')
+      .withLocation([6, 19, 6, 54])
+      .withFile('HashBrowns.fsh');
+    expect(profile.rules).toHaveLength(3);
     assertFixedValueRule(profile.rules[0], 'code', expectedCode);
+    assertFixedValueRule(profile.rules[1], 'extraCode', expectedExtraCode);
+    assertFixedValueRule(profile.rules[2], 'bonusCode', expectedBonusCode);
   });
 
   it('should parse a rule with an identifying integer', () => {

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -76,6 +76,21 @@ describe('FSHImporter', () => {
     assertFixedValueRule(profile.rules[0], 'code', expectedCode);
   });
 
+  it('should parse escaped hash and backslash characters in system identifiers in codings', () => {
+    const input = `
+    Profile: HashBrowns
+    Parent: Observation
+    * code = https://breakfast.com/good\\\\food\\#potatoes#hash#browns
+    `;
+    const result = importSingleText(input, 'HashBrowns.fsh');
+    const profile = result.profiles.get('HashBrowns');
+    const expectedCode = new FshCode('hash#browns', 'https://breakfast.com/good\\food#potatoes')
+      .withLocation([4, 14, 4, 67])
+      .withFile('HashBrowns.fsh');
+    expect(profile.rules).toHaveLength(1);
+    assertFixedValueRule(profile.rules[0], 'code', expectedCode);
+  });
+
   it('should parse a rule with an identifying integer', () => {
     const input = `
     Profile: IdentifyingInteger


### PR DESCRIPTION
Fixes issue #180 and addresses task https://standardhealthrecord.atlassian.net/browse/CIMPL-265

The `#` character can legally appear in the system identifier in a coding. Since this is normally the separator between the system and code, the system identifier now uses `\` as an escape character. This gets into some exciting scenarios when the system identifier has a suspicious amount of those two characters flying around.
Because the first unescaped `#` character is considered to be the separator, there's no need to be concerned with `#` characters that appear in the code.