### PR TITLE
Infer simple or complex extensions

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -172,25 +172,45 @@ export class StructureDefinitionExporter implements Fishable {
    * @param {Extension} fshDefinition - The extension to do preprocessing on. It is updated directly based on processing.
    */
   private preprocessExtension(fshDefinition: Extension): void {
+    let hasRuleAppliedToValueX = false;
+    let hasRuleAppliedToExtension = false;
     fshDefinition.rules.forEach(rule => {
       if (rule.path.startsWith('extension')) {
-        // If Extension.extension is used, constrain cardinality of Extension.value[x] to 0..0
+        if (hasRuleAppliedToValueX) {
+          logger.error(
+            `Extension ${fshDefinition.name} cannot have both a value and sub-extensions`,
+            rule.sourceInfo
+          );
+        }
         if (!(rule instanceof CardRule && rule.max === '0')) {
-          const valueCardRule = new CardRule('value[x]');
-          valueCardRule.min = 0;
-          valueCardRule.max = '0';
-          fshDefinition.rules.push(valueCardRule);
+          hasRuleAppliedToExtension = true;
         }
       } else if (rule.path.startsWith('value')) {
-        // If Extension.value[x] (or any related properties) is used, constrain cardinality of Extension.extension to 0..0
+        if (hasRuleAppliedToExtension) {
+          logger.error(
+            `Extension ${fshDefinition.name} cannot have both a value and sub-extensions`,
+            rule.sourceInfo
+          );
+        }
         if (!(rule instanceof CardRule && rule.max === '0')) {
-          const extensionCardRule = new CardRule('extension');
-          extensionCardRule.min = 0;
-          extensionCardRule.max = '0';
-          fshDefinition.rules.push(extensionCardRule);
+          hasRuleAppliedToValueX = true;
         }
       }
     });
+
+    // If only value[x] or extension is use, constrain cardinality of the other to 0..0.
+    // If both are used, an error has been logged, but the rules will still be applied.
+    if (hasRuleAppliedToExtension && !hasRuleAppliedToValueX) {
+      const valueCardRule = new CardRule('value[x]');
+      valueCardRule.min = 0;
+      valueCardRule.max = '0';
+      fshDefinition.rules.push(valueCardRule);
+    } else if (hasRuleAppliedToValueX && !hasRuleAppliedToExtension) {
+      const extensionCardRule = new CardRule('extension');
+      extensionCardRule.min = 0;
+      extensionCardRule.max = '0';
+      fshDefinition.rules.push(extensionCardRule);
+    }
   }
 
   fishForFHIR(item: string, ...types: Type[]) {


### PR DESCRIPTION
This PR adds support for inferring if a user is creating a simple or complex extension. It fixes #183. This is accomplished by preprocessing Extensions.

If rules are only set on `value[x]` or any of it's elements and the user doesn't constrain the cardinality of `extension`, we add a new rule to constrain `extension` to 0..0, If rules are set only on `extension`, we add a new rule to constrain `value[x]`. If a user applies rules to both properties, we will log an error and not try to constrain either property and will allow the rules to be set.
