### PR TITLE
Account for pattern on parent

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -105,7 +105,8 @@ export class InstanceExporter {
       );
       // Fixed value can come from fixed[x] or pattern[x] directly on element, or via pattern[x] on parent
       const foundFixedValue =
-        fixableElement[fixedValueKey as keyof ElementDefinition] ?? fixableElement.fixedByParent();
+        fixableElement[fixedValueKey as keyof ElementDefinition] ??
+        fixableElement.fixedByDirectParent();
       // We only fix the value if the element is the original element, or it is a direct child with card 1..n
       if (foundFixedValue && (fixableElement.id === element.id || fixableElement.min > 0)) {
         // Get the end of the path, this is the part that differs from existingPath

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -882,12 +882,14 @@ export class ElementDefinition {
         if (Array.isArray(parentValue)) {
           // If the value is an array, there are two cases
           // 1 - All the fixed values in the array match => return the value
-          // 2 - The fixed values in the array don't match => return undefined
+          // 2 - The fixed values in the array don't match => return [val1, val2]
+          // since values do exist, but they conflict so no value should be allowed to be set
+          // and for any value [val1, val2] != value
           fixedValue =
             parentValue.every(pv => pv[childIndex] === parentValue[0][childIndex]) &&
             parentValue.length > 0
               ? parentValue[0][childIndex]
-              : undefined;
+              : parentValue.map(pv => pv[childIndex]);
         } else {
           fixedValue = parentValue?.[childIndex];
         }

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1254,14 +1254,15 @@ export class ElementDefinition {
    */
   private fixFshCodeToCodeableConcept(code: FshCode): void {
     // Check if this is already fixed to something else
-    if (this.patternCodeableConcept) {
+    const alreadyFixedValue = this.patternCodeableConcept ?? this.fixedByAnyParent();
+    if (alreadyFixedValue) {
       const fixedToSame =
-        this.patternCodeableConcept.coding &&
-        this.patternCodeableConcept.coding.some(c => {
+        alreadyFixedValue.coding &&
+        alreadyFixedValue.coding.some((c: any) => {
           return c.code == code.code && c.system == code.system;
         });
       if (!fixedToSame) {
-        const found = this.patternCodeableConcept.coding[0];
+        const found = alreadyFixedValue.coding[0];
         throw new CodeAlreadyFixedError(new FshCode(found.code, found.system), code);
       }
       // It's already fixed, so there is nothing to do
@@ -1290,10 +1291,13 @@ export class ElementDefinition {
    */
   private fixFshCodeToCoding(code: FshCode): void {
     // Check if this is already fixed to something else
-    if (this.patternCoding) {
-      if (this.patternCoding.code != code.code || this.patternCoding.system != code.system) {
-        const found = this.patternCoding;
-        throw new CodeAlreadyFixedError(new FshCode(found.code, found.system), code);
+    const alreadyFixedValue = this.patternCoding ?? this.fixedByAnyParent();
+    if (alreadyFixedValue) {
+      if (alreadyFixedValue.code != code.code || alreadyFixedValue.system != code.system) {
+        throw new CodeAlreadyFixedError(
+          new FshCode(alreadyFixedValue.code, alreadyFixedValue.system),
+          code
+        );
       }
       // It's already fixed, so there is nothing to do
       return;
@@ -1318,10 +1322,13 @@ export class ElementDefinition {
    */
   private fixFshCodeToQuantityUnitCode(code: FshCode): void {
     // Check if this is already fixed to something else
-    if (this.patternQuantity) {
-      if (this.patternQuantity.code != code.code || this.patternQuantity.system != code.system) {
-        const found = this.patternQuantity;
-        throw new CodeAlreadyFixedError(new FshCode(found.code, found.system), code);
+    const alreadyFixedValue = this.patternQuantity ?? this.fixedByAnyParent();
+    if (alreadyFixedValue) {
+      if (alreadyFixedValue.code != code.code || alreadyFixedValue.system != code.system) {
+        throw new CodeAlreadyFixedError(
+          new FshCode(alreadyFixedValue.code, alreadyFixedValue.system),
+          code
+        );
       }
       // It's already fixed, so there is nothing to do
       return;
@@ -1345,9 +1352,10 @@ export class ElementDefinition {
    */
   private fixFshCodeToCode(code: FshCode): void {
     // Check if this is already fixed to something else
-    if (this.fixedCode) {
-      if (this.fixedCode != code.code) {
-        throw new CodeAlreadyFixedError(new FshCode(this.fixedCode), code);
+    const alreadyFixedValue = this.fixedCode ?? this.fixedByAnyParent();
+    if (alreadyFixedValue) {
+      if (alreadyFixedValue != code.code) {
+        throw new CodeAlreadyFixedError(new FshCode(alreadyFixedValue), code);
       }
       // It's already fixed, so there is nothing to do
       return;
@@ -1365,9 +1373,10 @@ export class ElementDefinition {
    */
   private fixFshCodeToString(code: FshCode): void {
     // Check if this is already fixed to something else
-    if (this.fixedString) {
-      if (this.fixedString != code.code) {
-        throw new CodeAlreadyFixedError(new FshCode(this.fixedString), code);
+    const alreadyFixedValue = this.fixedString ?? this.fixedByAnyParent();
+    if (alreadyFixedValue) {
+      if (alreadyFixedValue != code.code) {
+        throw new CodeAlreadyFixedError(new FshCode(alreadyFixedValue), code);
       }
       // It's already fixed, so there is nothing to do
       return;
@@ -1385,9 +1394,10 @@ export class ElementDefinition {
    */
   private fixFshCodeToUri(code: FshCode): void {
     // Check if this is already fixed to something else
-    if (this.fixedUri) {
-      if (this.fixedUri != code.code) {
-        throw new CodeAlreadyFixedError(new FshCode(this.fixedUri), code);
+    const alreadyFixedValue = this.fixedUri ?? this.fixedByAnyParent();
+    if (alreadyFixedValue) {
+      if (alreadyFixedValue != code.code) {
+        throw new CodeAlreadyFixedError(new FshCode(alreadyFixedValue), code);
       }
       // It's already fixed, so there is nothing to do
       return;

--- a/test/fhirtypes/ElementDefinition.fixFshCode.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixFshCode.test.ts
@@ -47,6 +47,18 @@ describe('ElementDefinition', () => {
       expect(clone).toEqual(concept);
     });
 
+    it('should throw CodeAlreadyFixedError when fixing a code to a CodeableConcept fixed to a different code by a parent', () => {
+      const rr = observation.elements.find(e => e.id === 'Observation.referenceRange');
+      // @ts-ignore
+      rr.patternBackboneElement = { type: { coding: [{ system: 'http://foo.com', code: 'bar' }] } };
+      const rrType = observation.elements.find(e => e.id === 'Observation.referenceRange.type');
+      const clone = cloneDeep(rrType);
+      expect(() => {
+        rrType.fixFshCode(barFooCode);
+      }).toThrow(/http:\/\/bar.com#foo.*http:\/\/foo.com#bar/);
+      expect(clone).toEqual(rrType);
+    });
+
     it('should fix a code to a Coding', () => {
       const concept = observation.elements.find(e => e.id === 'Observation.code');
       concept.unfold(fisher);
@@ -68,6 +80,22 @@ describe('ElementDefinition', () => {
       expect(clone).toEqual(coding);
     });
 
+    it('should throw CodeAlreadyFixedError when fixing a code to a Coding fixed to a different code by a parent', () => {
+      const rr = observation.elements.find(e => e.id === 'Observation.referenceRange');
+      // @ts-ignore
+      rr.patternBackboneElement = { type: { coding: { system: 'http://foo.com', code: 'bar' } } };
+      const rrType = observation.elements.find(e => e.id === 'Observation.referenceRange.type');
+      rrType.unfold(fisher);
+      const rrTypeCoding = observation.elements.find(
+        e => e.id === 'Observation.referenceRange.type.coding'
+      );
+      const clone = cloneDeep(rrTypeCoding);
+      expect(() => {
+        clone.fixFshCode(barFooCode);
+      }).toThrow(/http:\/\/bar.com#foo.*http:\/\/foo.com#bar/);
+      expect(clone).toEqual(rrTypeCoding);
+    });
+
     it('should fix a code to a code', () => {
       const code = observation.elements.find(e => e.id === 'Observation.status');
       code.fixFshCode(fooBarCode);
@@ -83,6 +111,23 @@ describe('ElementDefinition', () => {
         clone.fixFshCode(barFooCode);
       }).toThrow(/http:\/\/bar.com#foo.*#bar/);
       expect(clone).toEqual(code);
+    });
+
+    it('should throw CodeAlreadyFixedError when fixing a code to a code fixed to a different code by a parent', () => {
+      const code = observation.elements.find(e => e.id === 'Observation.code');
+      code.unfold(fisher);
+      const coding = observation.elements.find(e => e.id === 'Observation.code.coding');
+      coding.unfold(fisher);
+      const codeCodingCode = observation.elements.find(
+        e => e.id === 'Observation.code.coding.code'
+      );
+      // Setup original fixed code
+      code.fixFshCode(fooBarCode);
+      const clone = cloneDeep(codeCodingCode);
+      expect(() => {
+        clone.fixFshCode(barFooCode);
+      }).toThrow(/http:\/\/bar.com#foo.*#bar/);
+      expect(clone).toEqual(codeCodingCode);
     });
 
     it('should fix a code to a Quantity', () => {
@@ -102,6 +147,18 @@ describe('ElementDefinition', () => {
       expect(clone).toEqual(quantity);
     });
 
+    it('should throw CodeAlreadyFixedError when fixing a code to a Quantity fixed to a different code by a parent', () => {
+      const rr = observation.elements.find(e => e.id === 'Observation.referenceRange');
+      // @ts-ignore
+      rr.patternBackboneElement = { low: { system: 'http://foo.com', code: 'bar' } };
+      const rrLow = observation.elements.find(e => e.id === 'Observation.referenceRange.low');
+      const clone = cloneDeep(rrLow);
+      expect(() => {
+        clone.fixFshCode(barFooCode);
+      }).toThrow(/http:\/\/bar.com#foo.*http:\/\/foo.com#bar/);
+      expect(clone).toEqual(rrLow);
+    });
+
     it('should fix a code to a string', () => {
       const string = observation.elements.find(e => e.id === 'Observation.referenceRange.text');
       string.fixFshCode(fooBarCode);
@@ -119,6 +176,19 @@ describe('ElementDefinition', () => {
       expect(clone).toEqual(string);
     });
 
+    it('should throw CodeAlreadyFixedError when fixing a code to a string fixed to a different string by a parent', () => {
+      const code = observation.elements.find(e => e.id === 'Observation.code');
+      code.patternCodeableConcept = { text: 'http://foo.com#bar' };
+      code.unfold(fisher);
+      const string = observation.elements.find(e => e.id === 'Observation.code.text');
+      // Setup original fixed code
+      const clone = cloneDeep(string);
+      expect(() => {
+        clone.fixFshCode(barFooCode);
+      }).toThrow(/http:\/\/bar.com#foo.*#bar/);
+      expect(clone).toEqual(string);
+    });
+
     it('should fix a code to a uri', () => {
       const uri = observation.elements.find(e => e.id === 'Observation.implicitRules');
       uri.fixFshCode(fooBarCode);
@@ -129,6 +199,18 @@ describe('ElementDefinition', () => {
       const uri = observation.elements.find(e => e.id === 'Observation.implicitRules');
       // Setup original fixed code
       uri.fixFshCode(fooBarCode);
+      const clone = cloneDeep(uri);
+      expect(() => {
+        clone.fixFshCode(barFooCode);
+      }).toThrow(/http:\/\/bar.com#foo.*#bar/);
+      expect(clone).toEqual(uri);
+    });
+
+    it('should throw CodeAlreadyFixedError when fixing a code to a uri fixed to a different uri by a parent', () => {
+      const rrLow = observation.elements.find(e => e.id === 'Observation.referenceRange.low');
+      rrLow.patternQuantity = { system: 'http://foo.com#bar' };
+      rrLow.unfold(fisher);
+      const uri = observation.elements.find(e => e.id === 'Observation.referenceRange.low.system');
       const clone = cloneDeep(uri);
       expect(() => {
         clone.fixFshCode(barFooCode);

--- a/test/fhirtypes/ElementDefinition.fixValue.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixValue.test.ts
@@ -111,6 +111,15 @@ describe('ElementDefinition', () => {
         'Cannot fix http://ohManIWillNeverGetSet.sad to this element; a different uri is already fixed: http://thankYouForSettingMe.com'
       );
     });
+
+    it('should throw ValueAlreadyFixedError when fixing a value fixed via parent pattern to a conflicting array', () => {
+      const medicationForm = medication.elements.find(e => e.id === 'Medication.form');
+      medicationForm.patternCodeableConcept = { coding: [{ system: 'foo' }, { system: 'bar' }] };
+      const medicationFormCodingSystem = medication.findElementByPath('form.coding.system', fisher);
+      expect(() => {
+        medicationFormCodingSystem.fixValue('baz');
+      }).toThrow('Cannot fix baz to this element; a different uri is already fixed: foo,bar');
+    });
   });
 
   describe('#fixedByDirectParent', () => {
@@ -179,7 +188,7 @@ describe('ElementDefinition', () => {
       // Multiple not matching array elements
       statusReason.patternCodeableConcept = { coding: [{ system: 'foo' }, { system: 'bar' }] };
       patternValue = statusReasonCodingSystem.fixedByAnyParent();
-      expect(patternValue).toBeUndefined();
+      expect(patternValue).toEqual(['foo', 'bar']);
 
       // Multiple matching array elements
       statusReason.patternCodeableConcept = { coding: [{ system: 'foo' }, { system: 'foo' }] };


### PR DESCRIPTION
Fixes #84.

Previously when fixing values, we did not account for values being fixed via their parents by a pattern. This PR adds support for checking if a value is fixed by pattern from its parent, and we now throw an error if we try to re-set a value that is fixed by pattern.

If you'd like to test it out, fixing `CodeableConcept` elements works with pattern, so they provide a good test case. For example, the following will now generate an error, which was not the case with master:
```
Profile: myPatient
Parent: Patient
* maritalStatus = http://wedding.com#married
* maritalStatus.coding.code = #plentyoffish
```