### PR TITLE
Set exit code based on whether or not there are errors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -137,6 +137,9 @@ async function app() {
   CodeSystems: ${outPackage.codeSystems.length}
   Errors:      ${stats.numError}
   Warnings:    ${stats.numWarn}`);
+
+  const exitCode = stats.numError > 0 ? 1 : 0;
+  process.exit(exitCode);
 }
 
 function getVersion(): string {


### PR DESCRIPTION
0 indicates success; 1 indicates errors.

This is needed so that CI scripts can determine if a SUSHI build was clean or not.

You can test it by running sushi and then running the following command directly after:
```sh
$ echo $?
```

If there were no errors, it should print `0`, otherwise `1`.