### PR TITLE
Add Invariant and ObeysRule

### DIFF
--- a/src/fshtypes/Invariant.ts
+++ b/src/fshtypes/Invariant.ts
@@ -1,0 +1,19 @@
+import { FshEntity, FshCode } from '.';
+
+/**
+ * The Invariant class is used to represent the "constraint" field on ElementDefinition
+ * Invariant fields map to their corresponding field on "constraint" except:
+ * description -> constraint.human
+ * name -> constraint.key
+ * @see {@link https://www.hl7.org/fhir/elementdefinition.html}
+ */
+export class Invariant extends FshEntity {
+  description: string;
+  expression?: string;
+  xpath?: string;
+  severity: FshCode;
+
+  constructor(public name: string) {
+    super();
+  }
+}

--- a/src/fshtypes/index.ts
+++ b/src/fshtypes/index.ts
@@ -12,3 +12,4 @@ export * from './Instance';
 export * from './Profile';
 export * from './FshValueSet';
 export * from './ValueSetComponent';
+export * from './Invariant';

--- a/src/fshtypes/rules/ObeysRule.ts
+++ b/src/fshtypes/rules/ObeysRule.ts
@@ -1,0 +1,9 @@
+import { Rule } from './Rule';
+
+export class ObeysRule extends Rule {
+  invariant: string;
+
+  constructor(path: string) {
+    super(path);
+  }
+}

--- a/src/fshtypes/rules/index.ts
+++ b/src/fshtypes/rules/index.ts
@@ -6,3 +6,4 @@ export * from './Rule';
 export * from './ValueSetRule';
 export * from './ContainsRule';
 export * from './CaretValueRule';
+export * from './ObeysRule';

--- a/test/fshtypes/Invariant.test.ts
+++ b/test/fshtypes/Invariant.test.ts
@@ -1,0 +1,15 @@
+import 'jest-extended';
+import { Invariant } from '../../src/fshtypes/Invariant';
+
+describe('Invariant', () => {
+  describe('#constructor', () => {
+    it('should set initial properties correctly', () => {
+      const invariant = new Invariant('MyInvariant');
+      expect(invariant.name).toBe('MyInvariant');
+      expect(invariant.description).toBeUndefined();
+      expect(invariant.expression).toBeUndefined();
+      expect(invariant.xpath).toBeUndefined();
+      expect(invariant.severity).toBeUndefined();
+    });
+  });
+});

--- a/test/fshtypes/rules/ObeysRule.test.ts
+++ b/test/fshtypes/rules/ObeysRule.test.ts
@@ -1,0 +1,12 @@
+import 'jest-extended';
+import { ObeysRule } from '../../../src/fshtypes/rules/ObeysRule';
+
+describe('ObeysRule', () => {
+  describe('#constructor', () => {
+    it('should set the properties correctly', () => {
+      const c = new ObeysRule('component.code');
+      expect(c.path).toBe('component.code');
+      expect(c.invariant).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
This PR adds an Invariant class and the corresponding ObeysRule. The Invariant class is based on the "constraint" field on an ElementDefinition https://www.hl7.org/fhir/elementdefinition-definitions.html#ElementDefinition.constraint. The ObeysRule is used to apply an invariant to an element. This PR doesn't do anything with the classes, just adds them.