### PR TITLE
Sort pages in IG content

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -216,7 +216,7 @@ export class IGExporter {
    * Only add formats that are supported by the IG template
    * Intro and notes file contents are injected into relevant pages and should not be treated as their own page
    *
-   * @param igPath {string} - the path where the IG is exported to
+   * @param {string} igPath - the path where the IG is exported to
    */
   private addOtherPageContent(igPath: string): void {
     const inputPageContentPath = path.join(this.igDataPath, 'input', 'pagecontent');
@@ -262,25 +262,11 @@ export class IGExporter {
    * Sorts and renames pages based on numeric prefixes.
    * Numeric prefixes are used for applying a sort order, but should be removed
    * from the page's name and title unless doing so would cause a name collision.
-   * 
-   * @param pages {string[]} - list of file names with extensions
-   * @returns {{
-      originalName: string;
-      prefix: number;
-      name: string;
-      title: string;
-      fileType: string;
-    } []} - sorted list of file information objects
+   *
+   * @param {string[]} pages - list of file names with extensions
+   * @returns {PageMetadata []} - sorted list of file information objects
    */
-  private organizePageContent(
-    pages: string[]
-  ): {
-    originalName: string;
-    prefix: number;
-    name: string;
-    title: string;
-    fileType: string;
-  }[] {
+  private organizePageContent(pages: string[]): PageMetadata[] {
     const pageData = pages.map(page => {
       const nameParts = page.match(/^(\d+)_(.*)/);
       let prefix: number = null;
@@ -325,14 +311,11 @@ export class IGExporter {
    * If both have a prefix, compares the prefixes numerically.
    * If the prefixes are equal, resolves the tie by comparing the file names alphabetically.
    *
-   * @param pageA { prefix: number; name: string } - name and prefix of first file
-   * @param pageB { prefix: number; name: string } - name and prefix of second file
+   * @param {PageMetadata} pageA - metadata for first file
+   * @param {PageMetadata} pageB - metadata for second file
    * @returns {number} - positive when file b comes first, negative when file a comes first, zero when the file names are equal.
    */
-  private compareIgFilenames(
-    pageA: { prefix: number; name: string },
-    pageB: { prefix: number; name: string }
-  ): number {
+  private compareIgFilenames(pageA: PageMetadata, pageB: PageMetadata): number {
     if (pageA.prefix == null && pageB.prefix == null) {
       return pageA.name.localeCompare(pageB.name);
     } else if (pageA.prefix == null) {
@@ -553,4 +536,12 @@ export class IGExporter {
     );
     logger.info('Generated default package-list.json');
   }
+}
+
+interface PageMetadata {
+  originalName: string;
+  prefix: number;
+  name: string;
+  title: string;
+  fileType: string;
 }

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -571,4 +571,98 @@ describe('IGExporter', () => {
       });
     });
   });
+
+  describe('#sorted-pages-ig', () => {
+    let pkg: Package;
+    let exporter: IGExporter;
+    let tempOut: string;
+
+    beforeAll(() => {
+      const fixtures = path.join(__dirname, 'fixtures', 'sorted-pages-ig');
+      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(config);
+      exporter = new IGExporter(pkg, new FHIRDefinitions(), path.resolve(fixtures, 'ig-data'));
+      tempOut = temp.mkdirSync('sushi-test');
+      // No need to regenerate the IG on every test -- generate it once and inspect what you
+      // need to in the tests
+      exporter.export(tempOut);
+    });
+
+    afterAll(() => {
+      temp.cleanupSync();
+    });
+
+    it('should add user-provided pages in the user-specified order', () => {
+      const pageContentPath = path.join(tempOut, 'input', 'pagecontent');
+      expect(fs.existsSync(pageContentPath)).toBeTruthy();
+
+      const igPath = path.join(tempOut, 'input', 'ImplementationGuide-sushi-test.json');
+      expect(fs.existsSync(igPath)).toBeTruthy();
+      const igContent = fs.readJSONSync(igPath);
+      expect(igContent.definition.page.page).toHaveLength(9);
+      expect(igContent.definition.page.page).toEqual([
+        {
+          nameUrl: 'index.html',
+          title: 'FSH Test IG',
+          generation: 'html'
+        },
+        {
+          nameUrl: 'oranges.html',
+          title: 'Oranges',
+          generation: 'markdown'
+        },
+        {
+          nameUrl: 'apples.html',
+          title: 'Apples',
+          generation: 'markdown'
+        },
+        {
+          nameUrl: 'bananas.html',
+          title: 'Bananas',
+          generation: 'markdown'
+        },
+        {
+          nameUrl: 'pears.html',
+          title: 'Pears',
+          generation: 'markdown'
+        },
+        {
+          nameUrl: 'left.html',
+          title: 'Left',
+          generation: 'markdown'
+        },
+        {
+          nameUrl: 'right.html',
+          title: 'Right',
+          generation: 'markdown'
+        },
+        {
+          nameUrl: 'big.html',
+          title: 'Big',
+          generation: 'markdown'
+        },
+        {
+          nameUrl: 'pasta.html',
+          title: 'Pasta',
+          generation: 'markdown'
+        }
+      ]);
+    });
+
+    it('should remove numeric prefixes from copied files', () => {
+      const pageContentPath = path.join(tempOut, 'input', 'pagecontent');
+      expect(fs.existsSync(pageContentPath)).toBeTruthy();
+      const pageContentFiles = fs.readdirSync(pageContentPath);
+      expect(pageContentFiles).toHaveLength(9);
+      expect(pageContentFiles).toContain('index.xml');
+      expect(pageContentFiles).toContain('oranges.md');
+      expect(pageContentFiles).toContain('apples.md');
+      expect(pageContentFiles).toContain('bananas.md');
+      expect(pageContentFiles).toContain('pears.md');
+      expect(pageContentFiles).toContain('left.md');
+      expect(pageContentFiles).toContain('right.md');
+      expect(pageContentFiles).toContain('big.md');
+      expect(pageContentFiles).toContain('pasta.md');
+    });
+  });
 });

--- a/test/ig/fixtures/name-collision-ig/ig-data/ig.ini
+++ b/test/ig/fixtures/name-collision-ig/ig-data/ig.ini
@@ -1,0 +1,13 @@
+[IG]
+ig = input/ImplementationGuide-sushi-test.json
+template = hl7.fhir.template
+usage-stats-opt-out = true
+copyrightyear = 2018+
+license = CC0-1.0
+version = 0.1.0
+ballotstatus = STU1
+fhirspec = http://hl7.org/fhir/R4/
+excludexml = Yes
+excludejson = Yes
+excludettl = Yes
+excludeMaps = Yes

--- a/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/1_rocks.md
+++ b/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/1_rocks.md
@@ -1,0 +1,1 @@
+This is the first file with rocks.

--- a/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/2_rocks.md
+++ b/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/2_rocks.md
@@ -1,0 +1,1 @@
+This is the second file with rocks

--- a/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/3_index.md
+++ b/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/3_index.md
@@ -1,0 +1,1 @@
+This is another index file, which is probably a bad idea.

--- a/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/4_2_rocks.md
+++ b/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/4_2_rocks.md
@@ -1,0 +1,1 @@
+This is yet another file with even more rocks.

--- a/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/index.xml
+++ b/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/index.xml
@@ -1,0 +1,6 @@
+<div xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../input-cache/schemas/R5/fhir-single.xsd">
+  <h3>Index File</h3>
+	<p>
+    An index file in XML
+  </p>
+</div>

--- a/test/ig/fixtures/name-collision-ig/package.json
+++ b/test/ig/fixtures/name-collision-ig/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sushi-test",
+  "version": "0.1.0",
+  "canonical": "http://hl7.org/fhir/sushi-test",
+  "url": "http://hl7.org/fhir/sushi-test",
+  "title": "FSH Test IG",
+  "description": "Provides a simple example of how FSH can be used to create an IG",
+  "dependencies": {
+    "hl7.fhir.r4.core": "4.0.1"
+  },
+  "language": "en",
+  "author": "James Tuna",
+  "maintainers": [
+    {
+      "name": "Bill Cod",
+      "email": "cod@reef.gov"
+    }
+  ],
+  "license": "CC0-1.0"
+}

--- a/test/ig/fixtures/sorted-pages-ig/ig-data/ig.ini
+++ b/test/ig/fixtures/sorted-pages-ig/ig-data/ig.ini
@@ -1,0 +1,13 @@
+[IG]
+ig = input/ImplementationGuide-sushi-test.json
+template = hl7.fhir.template
+usage-stats-opt-out = true
+copyrightyear = 2018+
+license = CC0-1.0
+version = 0.1.0
+ballotstatus = STU1
+fhirspec = http://hl7.org/fhir/R4/
+excludexml = Yes
+excludejson = Yes
+excludettl = Yes
+excludeMaps = Yes

--- a/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/100_big.md
+++ b/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/100_big.md
@@ -1,0 +1,1 @@
+One hundred is bigger than the other numbers.

--- a/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/1_oranges.md
+++ b/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/1_oranges.md
@@ -1,0 +1,1 @@
+This file is all about oranges.

--- a/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/2_apples.md
+++ b/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/2_apples.md
@@ -1,0 +1,1 @@
+This file is all about apples.

--- a/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/3_bananas.md
+++ b/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/3_bananas.md
@@ -1,0 +1,1 @@
+This file is all about bananas.

--- a/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/4_pears.md
+++ b/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/4_pears.md
@@ -1,0 +1,1 @@
+This file is all about pears.

--- a/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/7_left.md
+++ b/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/7_left.md
@@ -1,0 +1,1 @@
+This file points to the left.

--- a/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/7_right.md
+++ b/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/7_right.md
@@ -1,0 +1,1 @@
+This file points to the right.

--- a/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/index.xml
+++ b/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/index.xml
@@ -1,0 +1,6 @@
+<div xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../input-cache/schemas/R5/fhir-single.xsd">
+  <h3>Index File</h3>
+	<p>
+    An index file in XML
+  </p>
+</div>

--- a/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/pasta.md
+++ b/test/ig/fixtures/sorted-pages-ig/ig-data/input/pagecontent/pasta.md
@@ -1,0 +1,1 @@
+Pasta is not a type of fruit.

--- a/test/ig/fixtures/sorted-pages-ig/package.json
+++ b/test/ig/fixtures/sorted-pages-ig/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sushi-test",
+  "version": "0.1.0",
+  "canonical": "http://hl7.org/fhir/sushi-test",
+  "url": "http://hl7.org/fhir/sushi-test",
+  "title": "FSH Test IG",
+  "description": "Provides a simple example of how FSH can be used to create an IG",
+  "dependencies": {
+    "hl7.fhir.r4.core": "4.0.1"
+  },
+  "language": "en",
+  "author": "James Tuna",
+  "maintainers": [
+    {
+      "name": "Bill Cod",
+      "email": "cod@reef.gov"
+    }
+  ],
+  "license": "CC0-1.0"
+}


### PR DESCRIPTION
Numeric prefixes in IG content files enable sorting. The prefixes get removed during processing, unless doing so would cause problems. Because this code involves dealing with IG content files, there are some small content files added in to support the tests.

The case where two files have the same name other than their extension, for example `Something.xml` and `Something.md`, is not accounted for here.

This pull request is for task https://standardhealthrecord.atlassian.net/browse/CIMPL-268.