### PR TITLE
Convert maintainer url to IG contact url

### DIFF
--- a/src/fshtypes/Config.ts
+++ b/src/fshtypes/Config.ts
@@ -20,6 +20,7 @@ export type Config = {
   maintainers?: [
     {
       name: string;
+      url: string;
       email: string;
     }
   ];

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -75,13 +75,20 @@ export class IGExporter {
         if (m.name) {
           contact.name = m.name;
         }
-        if (m.email) {
+        if (m.url) {
           contact.telecom = [
             {
-              system: 'email',
-              value: m.email
+              system: 'url',
+              value: m.url
             }
           ];
+        }
+        if (m.email) {
+          contact.telecom = contact.telecom ?? [];
+          contact.telecom.push({
+            system: 'email',
+            value: m.email
+          });
         }
         return contact;
       }),

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -115,6 +115,10 @@ describe('IGExporter', () => {
             name: 'Bill Cod',
             telecom: [
               {
+                system: 'url',
+                value: 'https://capecodfishermen.org/'
+              },
+              {
                 system: 'email',
                 value: 'cod@reef.gov'
               }

--- a/test/ig/fixtures/simple-ig/package.json
+++ b/test/ig/fixtures/simple-ig/package.json
@@ -15,7 +15,8 @@
   "maintainers": [
     {
       "name": "Bill Cod",
-      "email": "cod@reef.gov"
+      "email": "cod@reef.gov",
+      "url": "https://capecodfishermen.org/"
     }
   ],
   "license": "CC0-1.0"


### PR DESCRIPTION
Maintainer URLs (in package.json) were being dropped when generating the contacts in IG JSON.  This has been fixed.

Fixes #234