### PR TITLE
Import Invariant and ObeysRule

### DIFF
--- a/src/import/FSHDocument.ts
+++ b/src/import/FSHDocument.ts
@@ -1,4 +1,4 @@
-import { Profile, Extension, Instance, FshValueSet, FshCodeSystem } from '../fshtypes';
+import { Profile, Extension, Instance, FshValueSet, FshCodeSystem, Invariant } from '../fshtypes';
 
 export class FSHDocument {
   readonly aliases: Map<string, string>;
@@ -7,6 +7,7 @@ export class FSHDocument {
   readonly instances: Map<string, Instance>;
   readonly valueSets: Map<string, FshValueSet>;
   readonly codeSystems: Map<string, FshCodeSystem>;
+  readonly invariants: Map<string, Invariant>;
 
   constructor(public readonly file: string) {
     this.aliases = new Map();
@@ -15,5 +16,6 @@ export class FSHDocument {
     this.instances = new Map();
     this.valueSets = new Map();
     this.codeSystems = new Map();
+    this.invariants = new Map();
   }
 }

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -619,6 +619,12 @@ export class FSHImporter extends FSHVisitor {
       logger.warn('Do not specify a system for invariant severity.', concept.sourceInfo);
       concept.system = this.aliasAwareValue(system);
     }
+    if (code != 'error' && code != 'warning') {
+      logger.error(
+        'Invalid invariant severity code: code must be "#error" or "#warning".',
+        concept.sourceInfo
+      );
+    }
     return concept;
   }
 

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -447,6 +447,12 @@ export class FSHImporter extends FSHVisitor {
       .withLocation(this.extractStartStop(ctx))
       .withFile(this.currentFile);
     this.parseInvariant(invariant, ctx.invariantMetadata());
+    if (invariant.description == null) {
+      logger.error(`Invariant ${invariant.name} must have a Description.`, invariant.sourceInfo);
+    }
+    if (invariant.severity == null) {
+      logger.error(`Invariant ${invariant.name} must have a Severity.`, invariant.sourceInfo);
+    }
     this.currentDoc.invariants.set(invariant.name, invariant);
   }
 

--- a/src/import/parserContexts.ts
+++ b/src/import/parserContexts.ts
@@ -11,7 +11,7 @@ export interface EntityContext extends ParserRuleContext {
   instance(): InstanceContext;
   valueSet(): ValueSetContext;
   codeSystem(): CodeSystemContext;
-  //invariant(): InvariantContext;
+  invariant(): InvariantContext;
 }
 
 export interface AliasContext extends ParserRuleContext {
@@ -75,6 +75,18 @@ export interface CsMetadataContext extends ParserRuleContext {
   description(): DescriptionContext;
 }
 
+export interface InvariantContext extends ParserRuleContext {
+  SEQUENCE(): ParserRuleContext;
+  invariantMetadata(): InvariantMetadataContext[];
+}
+
+export interface InvariantMetadataContext extends ParserRuleContext {
+  description(): DescriptionContext;
+  expression(): ExpressionContext;
+  xpath(): XpathContext;
+  severity(): SeverityContext;
+}
+
 export interface ParentContext extends ParserRuleContext {
   SEQUENCE(): ParserRuleContext;
 }
@@ -90,6 +102,18 @@ export interface TitleContext extends ParserRuleContext {
 export interface DescriptionContext extends ParserRuleContext {
   STRING(): ParserRuleContext;
   MULTILINE_STRING(): ParserRuleContext;
+}
+
+export interface ExpressionContext extends ParserRuleContext {
+  STRING(): ParserRuleContext;
+}
+
+export interface XpathContext extends ParserRuleContext {
+  STRING(): ParserRuleContext;
+}
+
+export interface SeverityContext extends ParserRuleContext {
+  CODE(): ParserRuleContext;
 }
 
 export interface InstanceOfContext extends ParserRuleContext {

--- a/src/import/parserContexts.ts
+++ b/src/import/parserContexts.ts
@@ -127,7 +127,7 @@ export interface SdRuleContext extends ParserRuleContext {
   fixedValueRule(): FixedValueRuleContext;
   containsRule(): ContainsRuleContext;
   onlyRule(): OnlyRuleContext;
-  // obeysRule(): ObeysRuleContext;
+  obeysRule(): ObeysRuleContext;
   caretValueRule(): CaretValueRuleContext;
 }
 
@@ -244,6 +244,11 @@ export interface OnlyRuleContext extends ParserRuleContext {
 export interface TargetTypeContext extends ParserRuleContext {
   SEQUENCE(): ParserRuleContext;
   reference(): ReferenceContext;
+}
+
+export interface ObeysRuleContext extends ParserRuleContext {
+  path(): PathContext;
+  SEQUENCE(): ParserRuleContext[];
 }
 
 export interface CaretValueRuleContext extends ParserRuleContext {

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -3,7 +3,8 @@ import {
   assertFlagRule,
   assertOnlyRule,
   assertValueSetRule,
-  assertCaretValueRule
+  assertCaretValueRule,
+  assertObeysRule
 } from '../testhelpers/asserts';
 import { loggerSpy } from '../testhelpers/loggerSpy';
 import { importSingleText } from '../testhelpers/importSingleText';
@@ -188,6 +189,21 @@ describe('FSHImporter', () => {
         const extension = result.extensions.get('SomeExtension');
         expect(extension.rules).toHaveLength(1);
         assertCaretValueRule(extension.rules[0], 'id', 'short', 'foo');
+      });
+    });
+
+    describe('#obeysRule', () => {
+      it('should parse an obeys rule with a path and multiple invariants', () => {
+        const input = `
+        Extension: SomeExtension
+        * extension obeys inv-1 and inv-2
+        `;
+
+        const result = importSingleText(input);
+        const extension = result.extensions.get('SomeExtension');
+        expect(extension.rules).toHaveLength(2);
+        assertObeysRule(extension.rules[0], 'extension', 'inv-1');
+        assertObeysRule(extension.rules[1], 'extension', 'inv-2');
       });
     });
   });

--- a/test/import/FSHImporter.Invariant.test.ts
+++ b/test/import/FSHImporter.Invariant.test.ts
@@ -88,10 +88,10 @@ describe('FSHImporter', () => {
         Severity: #warning
         `;
         importSingleText(input, 'Twice.fsh');
-        expect(loggerSpy.getMessageAtIndex(-4, 'error')).toMatch(/File: Twice\.fsh.*Line: 7\D/s);
-        expect(loggerSpy.getMessageAtIndex(-3, 'error')).toMatch(/File: Twice\.fsh.*Line: 8\D/s);
-        expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(/File: Twice\.fsh.*Line: 9\D/s);
-        expect(loggerSpy.getLastMessage('error')).toMatch(/File: Twice\.fsh.*Line: 10\D/s);
+        expect(loggerSpy.getMessageAtIndex(-4, 'error')).toMatch(/File: Twice\.fsh.*Line: 7\D*/s);
+        expect(loggerSpy.getMessageAtIndex(-3, 'error')).toMatch(/File: Twice\.fsh.*Line: 8\D*/s);
+        expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(/File: Twice\.fsh.*Line: 9\D*/s);
+        expect(loggerSpy.getLastMessage('error')).toMatch(/File: Twice\.fsh.*Line: 10\D*/s);
       });
 
       it('should log a warning when the severity code includes a system', () => {
@@ -106,7 +106,7 @@ describe('FSHImporter', () => {
           .withLocation([3, 19, 3, 47])
           .withFile('Unnecessary.fsh');
         expect(invariant.severity).toEqual(severityCode);
-        expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Unnecessary\.fsh.*Line: 3\D/s);
+        expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Unnecessary\.fsh.*Line: 3\D*/s);
       });
     });
   });

--- a/test/import/FSHImporter.Invariant.test.ts
+++ b/test/import/FSHImporter.Invariant.test.ts
@@ -1,0 +1,113 @@
+import { importSingleText } from '../testhelpers/importSingleText';
+import { FshCode } from '../../src/fshtypes';
+import { loggerSpy } from '../testhelpers/loggerSpy';
+
+describe('FSHImporter', () => {
+  describe('Invariant', () => {
+    describe('#invariantMetadata', () => {
+      it('should parse the simplest possible invariant', () => {
+        const input = `
+        Invariant: emp-1
+        Description: "This does not actually require anything."
+        `;
+        const result = importSingleText(input, 'Empty.fsh');
+        expect(result.invariants.size).toBe(1);
+        const invariant = result.invariants.get('emp-1');
+        expect(invariant.name).toBe('emp-1');
+        expect(invariant.description).toBe('This does not actually require anything.');
+        expect(invariant.sourceInfo.location).toEqual({
+          startLine: 2,
+          startColumn: 9,
+          endLine: 3,
+          endColumn: 63
+        });
+        expect(invariant.sourceInfo.file).toBe('Empty.fsh');
+      });
+
+      it('should parse an invariant with additional metadata', () => {
+        const input = `
+        Invariant: full-1
+        Description: "This resource must define a cage and aquarium."
+        Expression: "cage.exists() and aquarium.exists()"
+        XPath: "exists(f:cage) and exists(f:aquarium)"
+        Severity: #error
+        `;
+        const result = importSingleText(input, 'Full.fsh');
+        expect(result.invariants.size).toBe(1);
+        const invariant = result.invariants.get('full-1');
+        expect(invariant.name).toBe('full-1');
+        expect(invariant.description).toBe('This resource must define a cage and aquarium.');
+        expect(invariant.expression).toBe('cage.exists() and aquarium.exists()');
+        expect(invariant.xpath).toBe('exists(f:cage) and exists(f:aquarium)');
+        const severityCode = new FshCode('error').withLocation([6, 19, 6, 24]).withFile('Full.fsh');
+        expect(invariant.severity).toEqual(severityCode);
+        expect(invariant.sourceInfo.location).toEqual({
+          startLine: 2,
+          startColumn: 9,
+          endLine: 6,
+          endColumn: 24
+        });
+        expect(invariant.sourceInfo.file).toBe('Full.fsh');
+      });
+
+      it('should only apply each metadata attribute the first time it is declared', () => {
+        const input = `
+        Invariant: twice-1
+        Description: "This resource is described."
+        Expression: "description.exists()"
+        XPath: "exists(f:description)"
+        Severity: #error
+        Description: "This resource is not described."
+        Expression: "not(description.exists())"
+        XPath: "not(exists(f:description))"
+        Severity: #warning
+        `;
+        const result = importSingleText(input, 'Twice.fsh');
+        expect(result.invariants.size).toBe(1);
+        const invariant = result.invariants.get('twice-1');
+        expect(invariant.name).toBe('twice-1');
+        expect(invariant.description).toBe('This resource is described.');
+        expect(invariant.expression).toBe('description.exists()');
+        expect(invariant.xpath).toBe('exists(f:description)');
+        const severityCode = new FshCode('error')
+          .withLocation([6, 19, 6, 24])
+          .withFile('Twice.fsh');
+        expect(invariant.severity).toEqual(severityCode);
+      });
+
+      it('should log an error when encountering a duplicate metadata attribute', () => {
+        const input = `
+        Invariant: twice-1
+        Description: "This resource is described."
+        Expression: "description.exists()"
+        XPath: "exists(f:description)"
+        Severity: #error
+        Description: "This resource is not described."
+        Expression: "not(description.exists())"
+        XPath: "not(exists(f:description))"
+        Severity: #warning
+        `;
+        importSingleText(input, 'Twice.fsh');
+        expect(loggerSpy.getMessageAtIndex(-4, 'error')).toMatch(/File: Twice\.fsh.*Line: 7\D/s);
+        expect(loggerSpy.getMessageAtIndex(-3, 'error')).toMatch(/File: Twice\.fsh.*Line: 8\D/s);
+        expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(/File: Twice\.fsh.*Line: 9\D/s);
+        expect(loggerSpy.getLastMessage('error')).toMatch(/File: Twice\.fsh.*Line: 10\D/s);
+      });
+
+      it('should log a warning when the severity code includes a system', () => {
+        const input = `
+        Invariant: un-1
+        Severity: https://unnecessary.org#error
+        `;
+        const result = importSingleText(input, 'Unnecessary.fsh');
+        expect(result.invariants.size).toBe(1);
+        const invariant = result.invariants.get('un-1');
+        const severityCode = new FshCode('error', 'https://unnecessary.org')
+          .withLocation([3, 19, 3, 47])
+          .withFile('Unnecessary.fsh');
+        expect(invariant.severity).toEqual(severityCode);
+        expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Unnecessary\.fsh.*Line: 3\D/s);
+      });
+    });
+  });
+});

--- a/test/import/FSHImporter.Invariant.test.ts
+++ b/test/import/FSHImporter.Invariant.test.ts
@@ -108,6 +108,19 @@ describe('FSHImporter', () => {
         expect(invariant.severity).toEqual(severityCode);
         expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Unnecessary\.fsh.*Line: 3\D*/s);
       });
+
+      it('should log an error when the severity code is invalid', () => {
+        const input = `
+        Invariant: nope-3
+        Severity: #nope
+        `;
+        const result = importSingleText(input, 'Nope.fsh');
+        expect(result.invariants.size).toBe(1);
+        const invariant = result.invariants.get('nope-3');
+        const severityCode = new FshCode('nope').withLocation([3, 19, 3, 23]).withFile('Nope.fsh');
+        expect(invariant.severity).toEqual(severityCode);
+        expect(loggerSpy.getLastMessage('error')).toMatch(/File: Nope\.fsh.*Line: 3\D*/s);
+      });
     });
   });
 });

--- a/test/testhelpers/asserts.ts
+++ b/test/testhelpers/asserts.ts
@@ -8,7 +8,8 @@ import {
   OnlyRule,
   OnlyRuleType,
   ContainsRule,
-  CaretValueRule
+  CaretValueRule,
+  ObeysRule
 } from '../../src/fshtypes/rules';
 import {
   ValueSetComponent,
@@ -87,6 +88,13 @@ export function assertCaretValueRule(
   expect(caretValueRule.path).toBe(path);
   expect(caretValueRule.caretPath).toBe(caretPath);
   expect(caretValueRule.value).toEqual(value);
+}
+
+export function assertObeysRule(rule: Rule, path: string, invariant: string) {
+  expect(rule).toBeInstanceOf(ObeysRule);
+  const obeysRule = rule as ObeysRule;
+  expect(obeysRule.path).toBe(path);
+  expect(obeysRule.invariant).toBe(invariant);
 }
 
 export function assertValueSetConceptComponent(


### PR DESCRIPTION
An `ObeysRule` on a `Profile` or `Extension` references one or more `Invariant` instances. Messages are produced when:
* a system is specified for `ObeysRule.severity`, since the system is required to be `ConstraintSeverity`.
* a code other than `error` or `warning` is specified for `ObeysRule.severity`
See https://www.hl7.org/fhir/elementdefinition-definitions.html#ElementDefinition.constraint.severity, https://www.hl7.org/fhir/valueset-constraint-severity.html, and https://www.hl7.org/fhir/codesystem-constraint-severity.html for additional details. 

This pull request completes task https://standardhealthrecord.atlassian.net/browse/CIMPL-154.