### PR TITLE
Infer cardinalities for inline extensions

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -2,7 +2,12 @@ import { FSHTank } from '../import/FSHTank';
 import { StructureDefinition, InstanceDefinition, ElementDefinition } from '../fhirtypes';
 import { Instance } from '../fshtypes';
 import { logger, Fishable, Type } from '../utils';
-import { setPropertyOnInstance, replaceReferences, replaceField } from '../fhirtypes/common';
+import {
+  setPropertyOnInstance,
+  replaceReferences,
+  replaceField,
+  splitOnPathPeriods
+} from '../fhirtypes/common';
 import { InstanceOfNotDefinedError } from '../errors/InstanceOfNotDefinedError';
 import { Package } from '.';
 import { isEmpty, cloneDeep } from 'lodash';
@@ -46,8 +51,7 @@ export class InstanceExporter {
           pathPart.brackets?.forEach(b => (path += /^[-+]?\d+$/.test(b) ? '' : `[${b}]`));
           const element = instanceOfStructureDefinition.findElementByPath(path, this.fisher);
           // Reconstruct the part of the rule's path that we just got the element for
-          let rulePathPart = rule.path
-            .split(/\.(?![^\[]*\])/g) // match a period that isn't within square brackets
+          let rulePathPart = splitOnPathPeriods(rule.path)
             .slice(0, i + 1)
             .join('.');
           rulePathPart += '.';

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -205,6 +205,10 @@ export class StructureDefinitionExporter implements Fishable {
               const relevantRule = `${basePath}value[x]`;
               inferredCardRulesMap.set(relevantRule, true);
             }
+          } else {
+            if (relevantContradictoryRuleMapEntry) {
+              inferredCardRulesMap.set(relevantContradictoryRule, false);
+            }
           }
         } else if (pathPart.startsWith('value') && isOnExtension) {
           const relevantContradictoryRule = `${basePath}value[x]`;
@@ -222,6 +226,10 @@ export class StructureDefinitionExporter implements Fishable {
               // If we don't already have a contradiction, add new rule to infer extension constraints
               const relevantRule = `${basePath}extension`;
               inferredCardRulesMap.set(relevantRule, true);
+            }
+          } else {
+            if (relevantContradictoryRuleMapEntry) {
+              inferredCardRulesMap.set(relevantContradictoryRule, false);
             }
           }
         }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -183,32 +183,36 @@ export class StructureDefinitionExporter implements Fishable {
           const relevantContradictoryRuleMapEntry = inferredCardRulesMap.get(
             relevantContradictoryRule
           );
-          if (relevantContradictoryRuleMapEntry) {
-            logger.error(
-              `Extension ${fshDefinition.name} cannot have both a value and sub-extensions`,
-              rule.sourceInfo
-            );
-            inferredCardRulesMap.set(relevantContradictoryRule, false);
-          } else if (!(rule instanceof CardRule && rule.max === '0')) {
-            // If we don't already have a contradiction, add new rule to infer value[x] constraints
-            const relevantRule = `${basePath}value[x]`;
-            inferredCardRulesMap.set(relevantRule, true);
+          if (!(rule instanceof CardRule && rule.max === '0')) {
+            if (relevantContradictoryRuleMapEntry) {
+              logger.error(
+                `Extension ${fshDefinition.name} cannot have both a value and sub-extensions`,
+                rule.sourceInfo
+              );
+              inferredCardRulesMap.set(relevantContradictoryRule, false);
+            } else {
+              // If we don't already have a contradiction, add new rule to infer value[x] constraints
+              const relevantRule = `${basePath}value[x]`;
+              inferredCardRulesMap.set(relevantRule, true);
+            }
           }
         } else if (pathPart.startsWith('value')) {
           const relevantContradictoryRule = `${basePath}value[x]`;
           const relevantContradictoryRuleMapEntry = inferredCardRulesMap.get(
             relevantContradictoryRule
           );
-          if (relevantContradictoryRuleMapEntry) {
-            logger.error(
-              `Extension ${fshDefinition.name} cannot have both a value and sub-extensions`,
-              rule.sourceInfo
-            );
-            inferredCardRulesMap.set(relevantContradictoryRule, false);
-          } else if (!(rule instanceof CardRule && rule.max === '0')) {
-            // If we don't already have a contradiction, add new rule to infer extension constraints
-            const relevantRule = `${basePath}extension`;
-            inferredCardRulesMap.set(relevantRule, true);
+          if (!(rule instanceof CardRule && rule.max === '0')) {
+            if (relevantContradictoryRuleMapEntry) {
+              logger.error(
+                `Extension ${fshDefinition.name} cannot have both a value and sub-extensions`,
+                rule.sourceInfo
+              );
+              inferredCardRulesMap.set(relevantContradictoryRule, false);
+            } else {
+              // If we don't already have a contradiction, add new rule to infer extension constraints
+              const relevantRule = `${basePath}extension`;
+              inferredCardRulesMap.set(relevantRule, true);
+            }
           }
         }
       });

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -208,10 +208,11 @@ export class StructureDefinitionExporter implements Fishable {
           }
         } else if (
           pathPart.startsWith('value') &&
-          !(isProfile && rule.path.startsWith('value') && rulePathParts.length === 1)
+          (previousPathPart?.startsWith('extension') || (!isProfile && rulePathParts.length === 1))
         ) {
           // If the current portion of the path starts with 'value'
-          // but it is not a profile setting the root value[x], check for inferred extension rules
+          // and if the rule sets a value on an inline extension or sets extension directly on a FSH Extension,
+          // then check for inferred extension rules
           const relevantContradictoryRule = `${basePath}value[x]`;
           const relevantContradictoryRuleMapEntry = inferredCardRulesMap.get(
             relevantContradictoryRule

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -196,7 +196,7 @@ export class StructureDefinitionExporter implements Fishable {
           if (!(rule instanceof CardRule && rule.max === '0')) {
             if (relevantContradictoryRuleMapEntry) {
               logger.error(
-                `Extension ${fshDefinition.name} cannot have both a value and sub-extensions`,
+                `Extension on ${fshDefinition.name} cannot have both a value and sub-extensions`,
                 rule.sourceInfo
               );
               inferredCardRulesMap.set(relevantContradictoryRule, false);
@@ -214,7 +214,7 @@ export class StructureDefinitionExporter implements Fishable {
           if (!(rule instanceof CardRule && rule.max === '0')) {
             if (relevantContradictoryRuleMapEntry) {
               logger.error(
-                `Extension ${fshDefinition.name} cannot have both a value and sub-extensions`,
+                `Extension on ${fshDefinition.name} cannot have both a value and sub-extensions`,
                 rule.sourceInfo
               );
               inferredCardRulesMap.set(relevantContradictoryRule, false);

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -354,6 +354,12 @@ export class ElementDefinition {
     setPropertyOnDefinitionInstance(this, path, value, fisher);
   }
 
+  getSlices() {
+    return this.structDef.elements.filter(
+      e => e.id !== this.id && e.path === this.path && e.id.startsWith(this.id)
+    );
+  }
+
   /**
    * Constrains the cardinality of this element.  Cardinality constraints can only narrow
    * cardinality.  Attempts to constrain to a wider cardinality will throw.
@@ -394,7 +400,7 @@ export class ElementDefinition {
       // Check that new max >= sum of mins of children
       this.checkSumOfSliceMins(max);
       // Check that new max >= every individual child max
-      const slices = this.structDef.elements.filter(e => e.id !== this.id && e.path === this.path);
+      const slices = this.getSlices();
       const overMaxChild = slices.find(child => child.max === '*' || parseInt(child.max) > maxInt);
       if (!isUnbounded && overMaxChild) {
         throw new InvalidMaxOfSliceError(overMaxChild.max, overMaxChild.sliceName, max);
@@ -424,9 +430,7 @@ export class ElementDefinition {
    * @throws {InvalidSumOfSliceMinsError} when the sum of mins of the slices exceeds max of sliced element
    */
   private checkSumOfSliceMins(newSlicedElementMax: string, sliceMinIncrease = 0) {
-    const slices = this.parent()
-      .children()
-      .filter(e => e.id !== this.id && e.path === this.path && !e.slicing);
+    const slices = this.getSlices();
     const sumOfMins = sliceMinIncrease + slices.reduce((prev, curr) => (prev += curr.min), 0);
     if (newSlicedElementMax !== '*' && sumOfMins > parseInt(newSlicedElementMax)) {
       throw new InvalidSumOfSliceMinsError(sumOfMins, newSlicedElementMax, this.id);

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -9,7 +9,13 @@ import { Meta } from './specialTypes';
 import { Identifier, CodeableConcept, Coding, Narrative, Resource, Extension } from './dataTypes';
 import { ContactDetail, UsageContext } from './metaDataTypes';
 import { CannotResolvePathError, InvalidElementAccessError } from '../errors';
-import { getArrayIndex, setPropertyOnDefinitionInstance, HasName, HasId } from './common';
+import {
+  getArrayIndex,
+  setPropertyOnDefinitionInstance,
+  HasName,
+  HasId,
+  splitOnPathPeriods
+} from './common';
 import { Fishable, Type } from '../utils/Fishable';
 import { applyMixins } from '../utils';
 
@@ -503,7 +509,7 @@ export class StructureDefinition {
    */
   private parseFSHPath(fshPath: string): PathPart[] {
     const pathParts: PathPart[] = [];
-    const splitPath = fshPath.split(/\.(?![^\[]*\])/g); // match a period that isn't within square brackets
+    const splitPath = splitOnPathPeriods(fshPath);
     for (const pathPart of splitPath) {
       const splitPathPart = pathPart.split('[');
       if (splitPathPart.length === 1 || pathPart.endsWith('[x]')) {

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -14,6 +14,10 @@ import cloneDeep = require('lodash/cloneDeep');
 import { logger } from '../utils';
 import { FHIRId, idRegex } from './primitiveTypes';
 
+export function splitOnPathPeriods(path: string): string[] {
+  return path.split(/\.(?![^\[]*\])/g); // match a period that isn't within square brackets
+}
+
 /**
  * This function sets an instance property of an SD or ED if possible
  * @param {StructureDefinition | ElementDefinition} - The instance to fix a value on

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -50,6 +50,7 @@ describe('StructureDefinitionExporter', () => {
     pkg = new Package(input.config);
     fisher = new TestFisher(input, defs, pkg);
     exporter = new StructureDefinitionExporter(input, pkg, fisher);
+    loggerSpy.reset();
   });
 
   // Profile
@@ -1404,6 +1405,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(valueElement.min).toEqual(0);
     expect(valueElement.max).toEqual('0');
+    expect(loggerSpy.getAllMessages()).toEqual([]);
   });
 
   it('should not zero out Extension.value[x] if Extension.extension is zeroed out', () => {
@@ -1421,6 +1423,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(valueElement.min).toEqual(0);
     expect(valueElement.max).toEqual('1');
+    expect(loggerSpy.getAllMessages()).toEqual([]);
   });
 
   it('should log an error if Extension.extension and Extension.value[x] are both used but apply both rules', () => {
@@ -1449,6 +1452,7 @@ describe('StructureDefinitionExporter', () => {
       /Extension MyInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidExtension\.fsh.*Line: 4\D*/s);
+    expect(loggerSpy.getAllMessages()).toHaveLength(1);
   });
 
   it('should zero out Extension.extension when Extension.value[x] is used', () => {
@@ -1465,11 +1469,16 @@ describe('StructureDefinitionExporter', () => {
 
     expect(extensionElement.min).toEqual(0);
     expect(extensionElement.max).toEqual('0');
+    expect(loggerSpy.getAllMessages()).toEqual([]);
   });
 
   it('should not zero out Extension.extension if Extension.value[x] is zeroed out', () => {
     const extension = new Extension('MyExplicitComplexExtension');
     extension.id = 'complex-extension';
+
+    const containsRuleForExtension = new ContainsRule('extension');
+    containsRuleForExtension.items = ['MySlice'];
+    extension.rules.push(containsRuleForExtension);
 
     const cardRuleForValue = new CardRule('value[x]');
     cardRuleForValue.min = 0;
@@ -1482,6 +1491,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(extensionElement.min).toEqual(0);
     expect(extensionElement.max).toEqual('*');
+    expect(loggerSpy.getAllMessages()).toEqual([]);
   });
 
   it('should log an error if Extension.value[x] is changed after Extension.extension is used but apply both rules', () => {
@@ -1510,6 +1520,7 @@ describe('StructureDefinitionExporter', () => {
       /Extension MyOtherInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: OtherInvalidExtension\.fsh.*Line: 4\D*/s);
+    expect(loggerSpy.getAllMessages()).toHaveLength(1);
   });
 
   it('should zero out value[x] on an extension defined inline that uses extension', () => {
@@ -1534,6 +1545,7 @@ describe('StructureDefinitionExporter', () => {
     expect(valueElement.max).toEqual('0');
     expect(mySliceValueElement.min).toEqual(0);
     expect(mySliceValueElement.max).toEqual('0');
+    expect(loggerSpy.getAllMessages()).toEqual([]);
   });
 
   it('should zero out extension on an extension defined inline that uses value[x]', () => {
@@ -1557,6 +1569,7 @@ describe('StructureDefinitionExporter', () => {
     expect(valueElement.max).toEqual('0');
     expect(mySliceExtensionElement.min).toEqual(0);
     expect(mySliceExtensionElement.max).toEqual('0');
+    expect(loggerSpy.getAllMessages()).toEqual([]);
   });
 
   it('should not zero out extension if value[x] is zeroed out on an extension defined inline', () => {
@@ -1584,6 +1597,7 @@ describe('StructureDefinitionExporter', () => {
     expect(mySliceValueElement.max).toEqual('0');
     expect(mySliceExtensionElement.min).toEqual(0);
     expect(mySliceExtensionElement.max).toEqual('*'); // extension[mySlice].extension cardinality is unchanged
+    expect(loggerSpy.getAllMessages()).toEqual([]);
   });
 
   it('should not zero out value[x] if extension is zeroed out on an extension defined inline', () => {
@@ -1611,6 +1625,7 @@ describe('StructureDefinitionExporter', () => {
     expect(mySliceValueElement.max).toEqual('1'); // extension[mySlice].value[x] cardinality is unchanged
     expect(mySliceExtensionElement.min).toEqual(0);
     expect(mySliceExtensionElement.max).toEqual('0');
+    expect(loggerSpy.getAllMessages()).toEqual([]);
   });
 
   it('should log an error if extension is used after value[x] on an extension defined inline and apply both rules', () => {
@@ -1649,6 +1664,7 @@ describe('StructureDefinitionExporter', () => {
       /Extension MyInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidInlineExtension\.fsh.*Line: 4\D*/s);
+    expect(loggerSpy.getAllMessages()).toHaveLength(1);
   });
 
   it('should log an error if value[x] is used after extension on an extension defined inline and apply both rules', () => {
@@ -1687,6 +1703,7 @@ describe('StructureDefinitionExporter', () => {
       /Extension MyInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidInlineExtension\.fsh.*Line: 5\D*/s);
+    expect(loggerSpy.getAllMessages()).toHaveLength(1);
   });
 
   it('should zero out value[x] if extension is used on an extension defined inline on a profile', () => {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1405,7 +1405,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(valueElement.min).toEqual(0);
     expect(valueElement.max).toEqual('0');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should not zero out Extension.value[x] if Extension.extension is zeroed out', () => {
@@ -1423,7 +1423,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(valueElement.min).toEqual(0);
     expect(valueElement.max).toEqual('1');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should log an error if Extension.extension and Extension.value[x] are both used but apply both rules', () => {
@@ -1452,7 +1452,7 @@ describe('StructureDefinitionExporter', () => {
       /Extension on MyInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidExtension\.fsh.*Line: 4\D*/s);
-    expect(loggerSpy.getAllMessages()).toHaveLength(1);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(1);
   });
 
   it('should zero out Extension.extension when Extension.value[x] is used', () => {
@@ -1469,7 +1469,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(extensionElement.min).toEqual(0);
     expect(extensionElement.max).toEqual('0');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should not zero out Extension.extension if Extension.value[x] is zeroed out', () => {
@@ -1491,7 +1491,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(extensionElement.min).toEqual(0);
     expect(extensionElement.max).toEqual('*');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should log an error if Extension.value[x] is changed after Extension.extension is used but apply both rules', () => {
@@ -1520,7 +1520,7 @@ describe('StructureDefinitionExporter', () => {
       /Extension on MyOtherInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: OtherInvalidExtension\.fsh.*Line: 4\D*/s);
-    expect(loggerSpy.getAllMessages()).toHaveLength(1);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(1);
   });
 
   it('should zero out value[x] on an extension defined inline that uses extension', () => {
@@ -1545,7 +1545,7 @@ describe('StructureDefinitionExporter', () => {
     expect(valueElement.max).toEqual('0');
     expect(mySliceValueElement.min).toEqual(0);
     expect(mySliceValueElement.max).toEqual('0');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should zero out extension on an extension defined inline that uses value[x]', () => {
@@ -1569,7 +1569,7 @@ describe('StructureDefinitionExporter', () => {
     expect(valueElement.max).toEqual('0');
     expect(mySliceExtensionElement.min).toEqual(0);
     expect(mySliceExtensionElement.max).toEqual('0');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should not zero out extension if value[x] is zeroed out on an extension defined inline', () => {
@@ -1597,7 +1597,7 @@ describe('StructureDefinitionExporter', () => {
     expect(mySliceValueElement.max).toEqual('0');
     expect(mySliceExtensionElement.min).toEqual(0);
     expect(mySliceExtensionElement.max).toEqual('*'); // extension[mySlice].extension cardinality is unchanged
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should not zero out value[x] if extension is zeroed out on an extension defined inline', () => {
@@ -1625,7 +1625,7 @@ describe('StructureDefinitionExporter', () => {
     expect(mySliceValueElement.max).toEqual('1'); // extension[mySlice].value[x] cardinality is unchanged
     expect(mySliceExtensionElement.min).toEqual(0);
     expect(mySliceExtensionElement.max).toEqual('0');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should log an error if extension is used after value[x] on an extension defined inline and apply both rules', () => {
@@ -1664,7 +1664,7 @@ describe('StructureDefinitionExporter', () => {
       /Extension on MyInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidInlineExtension\.fsh.*Line: 4\D*/s);
-    expect(loggerSpy.getAllMessages()).toHaveLength(1);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(1);
   });
 
   it('should log an error if value[x] is used after extension on an extension defined inline and apply both rules', () => {
@@ -1703,7 +1703,7 @@ describe('StructureDefinitionExporter', () => {
       /Extension on MyInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidInlineExtension\.fsh.*Line: 5\D*/s);
-    expect(loggerSpy.getAllMessages()).toHaveLength(1);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(1);
   });
 
   it('should zero out value[x] if extension is used on an extension defined inline on a profile', () => {
@@ -1724,7 +1724,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(valueElement.min).toEqual(0);
     expect(valueElement.max).toEqual('0');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should correctly allow both extension and value[x] on profiles', () => {
@@ -1747,7 +1747,7 @@ describe('StructureDefinitionExporter', () => {
     expect(valueElement.max).toEqual('1');
     expect(extensionElement.min).toEqual(0);
     expect(extensionElement.max).toEqual('*');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should not add value[x] onto non-extension elements', () => {
@@ -1774,7 +1774,7 @@ describe('StructureDefinitionExporter', () => {
     expect(sliceExtensionElement.max).toEqual('1');
     expect(sliceValueElement.min).toEqual(0);
     expect(sliceValueElement.max).toEqual('0');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should set value[x] on nested elements of a profile without zeroing extension', () => {
@@ -1797,7 +1797,7 @@ describe('StructureDefinitionExporter', () => {
     expect(componentValueElement.type[0]).toEqual(new ElementDefinitionType('string'));
     expect(componentExtensionElement.min).toEqual(1);
     expect(componentExtensionElement.max).toEqual('1');
-    expect(loggerSpy.getAllMessages()).toEqual([]);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   it('should not set inferred 0..0 CardRules if they were set on the FSH definition', () => {
@@ -1864,7 +1864,7 @@ describe('StructureDefinitionExporter', () => {
       },
       { sourceInfo: {}, path: 'value[x]', min: 0, max: '0' } // The only rule inferred
     ]);
-    expect(loggerSpy.getAllMessages()).toHaveLength(0);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 
   // toJSON

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1449,7 +1449,7 @@ describe('StructureDefinitionExporter', () => {
     expect(extensionElement).toBeDefined();
     expect(extensionElement.sliceName).toEqual('MySlice');
     expect(loggerSpy.getLastMessage()).toMatch(
-      /Extension MyInvalidExtension cannot have both a value and sub-extensions/s
+      /Extension on MyInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidExtension\.fsh.*Line: 4\D*/s);
     expect(loggerSpy.getAllMessages()).toHaveLength(1);
@@ -1517,7 +1517,7 @@ describe('StructureDefinitionExporter', () => {
     expect(extensionElement.sliceName).toEqual('MySlice');
     expect(valueElement.type).toEqual([new ElementDefinitionType('string')]);
     expect(loggerSpy.getLastMessage()).toMatch(
-      /Extension MyOtherInvalidExtension cannot have both a value and sub-extensions/s
+      /Extension on MyOtherInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: OtherInvalidExtension\.fsh.*Line: 4\D*/s);
     expect(loggerSpy.getAllMessages()).toHaveLength(1);
@@ -1661,7 +1661,7 @@ describe('StructureDefinitionExporter', () => {
     expect(mySliceValueElement.min).toEqual(1);
     expect(mySliceValueElement.max).toEqual('1');
     expect(loggerSpy.getLastMessage()).toMatch(
-      /Extension MyInvalidExtension cannot have both a value and sub-extensions/s
+      /Extension on MyInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidInlineExtension\.fsh.*Line: 4\D*/s);
     expect(loggerSpy.getAllMessages()).toHaveLength(1);
@@ -1700,7 +1700,7 @@ describe('StructureDefinitionExporter', () => {
     expect(mySliceValueElement.min).toEqual(1);
     expect(mySliceValueElement.max).toEqual('1');
     expect(loggerSpy.getLastMessage()).toMatch(
-      /Extension MyInvalidExtension cannot have both a value and sub-extensions/s
+      /Extension on MyInvalidExtension cannot have both a value and sub-extensions/s
     );
     expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidInlineExtension\.fsh.*Line: 5\D*/s);
     expect(loggerSpy.getAllMessages()).toHaveLength(1);

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1777,6 +1777,29 @@ describe('StructureDefinitionExporter', () => {
     expect(loggerSpy.getAllMessages()).toEqual([]);
   });
 
+  it('should set value[x] on nested elements of a profile without zeroing extension', () => {
+    const profile = new Profile('MyObservation');
+    profile.parent = 'Observation';
+
+    const onlyRule = new OnlyRule('component.value[x]');
+    onlyRule.types = [{ type: 'string' }];
+    const cardRule = new CardRule('component.extension');
+    cardRule.min = 1;
+    cardRule.max = '1';
+    profile.rules.push(onlyRule, cardRule);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+
+    const componentValueElement = sd.findElement('Observation.component.value[x]');
+    const componentExtensionElement = sd.findElement('Observation.component.extension');
+
+    expect(componentValueElement.type[0]).toEqual(new ElementDefinitionType('string'));
+    expect(componentExtensionElement.min).toEqual(1);
+    expect(componentExtensionElement.max).toEqual('1');
+    expect(loggerSpy.getAllMessages()).toEqual([]);
+  });
+
   // toJSON
   it('should correctly generate a diff containing only changed elements', () => {
     // We already have separate tests for the differentials, so this just ensures that the
@@ -1886,7 +1909,7 @@ describe('StructureDefinitionExporter', () => {
     const json = sd.toJSON();
 
     const diffs = json.differential.element;
-    expect(diffs).toHaveLength(9);
+    expect(diffs).toHaveLength(7);
     expect(diffs[0]).toEqual({
       id: 'Observation.component',
       path: 'Observation.component',
@@ -1903,41 +1926,31 @@ describe('StructureDefinitionExporter', () => {
       max: '1'
     });
     expect(diffs[2]).toEqual({
-      id: 'Observation.component:SystolicBP.extension',
-      path: 'Observation.component.extension',
-      max: '0'
-    });
-    expect(diffs[3]).toEqual({
       id: 'Observation.component:SystolicBP.code',
       path: 'Observation.component.code',
       patternCodeableConcept: {
         coding: [{ code: '8480-6', system: 'http://loinc.org' }]
       }
     });
-    expect(diffs[4]).toEqual({
+    expect(diffs[3]).toEqual({
       id: 'Observation.component:SystolicBP.value[x]',
       path: 'Observation.component.value[x]',
       type: [{ code: 'Quantity' }]
     });
-    expect(diffs[5]).toEqual({
+    expect(diffs[4]).toEqual({
       id: 'Observation.component:DiastolicBP',
       path: 'Observation.component',
       sliceName: 'DiastolicBP',
       max: '1'
     });
-    expect(diffs[6]).toEqual({
-      id: 'Observation.component:DiastolicBP.extension',
-      path: 'Observation.component.extension',
-      max: '0'
-    });
-    expect(diffs[7]).toEqual({
+    expect(diffs[5]).toEqual({
       id: 'Observation.component:DiastolicBP.code',
       path: 'Observation.component.code',
       patternCodeableConcept: {
         coding: [{ code: '8462-4', system: 'http://loinc.org' }]
       }
     });
-    expect(diffs[8]).toEqual({
+    expect(diffs[6]).toEqual({
       id: 'Observation.component:DiastolicBP.value[x]',
       path: 'Observation.component.value[x]',
       type: [{ code: 'Quantity' }]

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -139,6 +139,24 @@ describe('ElementDefinition', () => {
     });
   });
 
+  describe('#getSlices', () => {
+    it('should get slices of an element', () => {
+      const component = observation.elements.find(e => e.path === 'Observation.component');
+      component.slicing = {
+        ordered: false,
+        rules: 'open',
+        discriminator: [{ type: 'value', path: 'code' }]
+      };
+      const fooSlice = component.addSlice('FooSlice');
+      const slices = component.getSlices();
+      const newElements = fooSlice.unfold(fisher);
+      const fooSliceExtension = newElements[1];
+      expect(slices).toHaveLength(1);
+      expect(slices[0].id).toEqual('Observation.component:FooSlice');
+      expect(fooSliceExtension.getSlices()).toEqual([]);
+    });
+  });
+
   describe('#hasDiff', () => {
     it('should always show a diff for brand new elements w/ no original captured', () => {
       const newElement = new ElementDefinition('newElement');


### PR DESCRIPTION
This PR adds support for setting a `0..0` cardinality on `value[x]` or `extension` on extensions that are defined inline. Since extensions can be defined inline on Extensions or Profiles, this moves the preprocessing onto all the StructureDefinitions that are exported.

This should resolve the comment on PR #215 - comment [here](https://github.com/FHIR/sushi/pull/215#issuecomment-585749318).