### PR TITLE
Fix processing nested directories

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -80,7 +80,7 @@ async function app() {
   const rawFSHes = files
     .filter(file => file.endsWith('.fsh'))
     .map(file => {
-      const filePath = path.resolve(input, file);
+      const filePath = path.resolve(file);
       const fileContent = fs.readFileSync(filePath, 'utf8');
       return new RawFSH(fileContent, filePath);
     });


### PR DESCRIPTION
It seems there was a small bug in the reading in recursive directories functionality. When SUSHI was run on a directory like:
```
sushi ../myfshtank
```
things worked fine. But when the directory path was like:
```
sushi ../dir1/myfshtank
```
the processing would crash, and we would not be able to find files. This was because the new recursive function returned full file paths relative to the working directory, but the rest of our processing still assumed it was working with paths relative to the input directory. This fixes that assumption.
