### PR TITLE
Show a message when created choices are made obsolete with type constraints

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -120,7 +120,7 @@ export class StructureDefinitionExporter implements Fishable {
             element.applyFlags(rule.mustSupport, rule.summary, rule.modifier);
           } else if (rule instanceof OnlyRule) {
             const target = structDef.getReferenceName(rule.path, element);
-            element.constrainType(rule.types, this, target);
+            element.constrainType(rule, this, target);
           } else if (rule instanceof ValueSetRule) {
             const vsURI = this.fishForMetadata(rule.valueSet, Type.ValueSet)?.url ?? rule.valueSet;
             element.bindToVS(vsURI, rule.strength as ElementDefinitionBindingStrength);

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -4,7 +4,7 @@ import { minify } from 'html-minifier';
 import { StructureDefinition } from './StructureDefinition';
 import { CodeableConcept, Coding, Quantity, Ratio, Reference } from './dataTypes';
 import { FshCode, FshRatio, FshQuantity, FshReference } from '../fshtypes';
-import { FixedValueType } from '../fshtypes/rules';
+import { FixedValueType, OnlyRule } from '../fshtypes/rules';
 import {
   BindingStrengthError,
   CodedTypeNotFoundError,
@@ -459,8 +459,7 @@ export class ElementDefinition {
    * - specifying a target that does not match any of the existing type choices
    * - specifying types or a target whose definition cannot be found
    * @see {@link http://hl7.org/fhir/R4/elementdefinition-definitions.html#ElementDefinition.type}
-   * @param {{ type: string; isReference?: boolean }[]} types - the set of constrained types,
-   *   identified by id/type/url strings and an optional reference flag (defaults false)
+   * @param {OnlyRule} rule - The rule specifying the types to apply
    * @param {Fishable} fisher - A fishable implementation for finding definitions and metadata
    * @param {string} [target] - a specific target type to constrain.  If supplied, will attempt to
    *   constrain only that type without affecting other types (in a choice or reference to a choice).
@@ -468,11 +467,8 @@ export class ElementDefinition {
    * @throws {InvalidTypeError} when a passed in type or the targetType doesn't match any existing
    *   types
    */
-  constrainType(
-    types: { type: string; isReference?: boolean }[],
-    fisher: Fishable,
-    target?: string
-  ): void {
+  constrainType(rule: OnlyRule, fisher: Fishable, target?: string): void {
+    const types = rule.types;
     // Establish the target types (if applicable)
     const targetType = this.getTargetType(target, fisher);
     const targetTypes: ElementDefinitionType[] = targetType ? [targetType] : this.type;
@@ -489,6 +485,7 @@ export class ElementDefinition {
 
     // Loop through the existing element types building the new set of element types w/ constraints
     const newTypes: ElementDefinitionType[] = [];
+    const oldTypes: ElementDefinitionType[] = [];
     for (const type of this.type) {
       // If the typeMatches map doesn't have the type code at all, this means that a target was
       // specified, and this element type wasn't the target.  In this case, we want to keep it.
@@ -501,6 +498,7 @@ export class ElementDefinition {
       // element type should be filtered out of the results, so just skip to the next one.
       const matches = typeMatches.get(type.code);
       if (isEmpty(matches)) {
+        oldTypes.push(type);
         continue;
       }
 
@@ -529,6 +527,17 @@ export class ElementDefinition {
         this.applyProfiles(newType, targetType, currentMatches);
         newTypes.push(newType);
       }
+    }
+
+    // Let user know if other rules have been made obsolete
+    const obsoleteChoices = this.structDef.findObsoleteChoices(this, oldTypes);
+    if (obsoleteChoices.length > 0) {
+      logger.error(
+        `Type constraint on ${this.path} makes rules in ${
+          this.structDef.name
+        } obsolete for choices: ${obsoleteChoices.join(', ')}`,
+        rule.sourceInfo
+      );
     }
 
     // Finally, reset this element's types to the new types

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -560,7 +560,7 @@ export class StructureDefinition {
         // if we do not have a matching slice, we want to slice the first match
         const matchingXElement = matchingXElements[0];
         // If we find a matching [x] element, we need to slice it to create the child element
-        // NOTE: The spec is somewhat incosistent on handling choice slicing, we decided on this
+        // NOTE: The spec is somewhat inconsistent on handling choice slicing, we decided on this
         // approach per consistency with 4.0.1 observation-vitalsigns profiles and per this post
         // https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/.
         matchingXElement.sliceIt('type', '$this', false, 'open');
@@ -596,6 +596,28 @@ export class StructureDefinition {
     // sliceName/refName. To find the matching element for foo[sliceName][refName], you must
     // use the findMatchingRef function. Be aware of this ambiguity in the bracket path syntax.
     return matchingSlice;
+  }
+
+  findObsoleteChoices(baseElement: ElementDefinition, oldTypes: ElementDefinitionType[]): string[] {
+    // first, find all the elements representing choices
+    const choiceElements = this.elements.filter(e => {
+      return e.path === baseElement.path;
+    });
+    const matchedThings: ElementDefinition[] = [];
+    const desiredSliceName = baseElement.path
+      .slice(baseElement.path.lastIndexOf('.') + 1)
+      .slice(0, -3);
+    // an obsolete choice is one where:
+    // 1. the choice represents a type being constrained out, and
+    // 2. a rule has been applied to that choice
+    oldTypes.forEach(oldType => {
+      matchedThings.push(
+        ...choiceElements.filter(e => {
+          return e.sliceName == `${desiredSliceName}${upperFirst(oldType.code)}` && e.hasDiff();
+        })
+      );
+    });
+    return matchedThings.map(e => e.sliceName);
   }
 
   /**

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -600,9 +600,9 @@ export class StructureDefinition {
 
   findObsoleteChoices(baseElement: ElementDefinition, oldTypes: ElementDefinitionType[]): string[] {
     // first, find all the elements representing choices for the same choice element
-    const baseId = baseElement.id.slice(0, baseElement.id.lastIndexOf('.'));
+    const parentId = baseElement.parent().id;
     const choiceElements = this.elements.filter(e => {
-      return e.path === baseElement.path && e.id.startsWith(baseId);
+      return e.path === baseElement.path && e.id.startsWith(parentId);
     });
     const matchedThings: ElementDefinition[] = [];
     const desiredSliceName = baseElement.path

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -599,9 +599,10 @@ export class StructureDefinition {
   }
 
   findObsoleteChoices(baseElement: ElementDefinition, oldTypes: ElementDefinitionType[]): string[] {
-    // first, find all the elements representing choices
+    // first, find all the elements representing choices for the same choice element
+    const baseId = baseElement.id.slice(0, baseElement.id.lastIndexOf('.'));
     const choiceElements = this.elements.filter(e => {
-      return e.path === baseElement.path;
+      return e.path === baseElement.path && e.id.startsWith(baseId);
     });
     const matchedThings: ElementDefinition[] = [];
     const desiredSliceName = baseElement.path

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1064,6 +1064,44 @@ describe('StructureDefinitionExporter', () => {
     expect(loggerSpy.getAllLogs()).toHaveLength(0);
   });
 
+  it('should not log an error when a type constraint is applied to a specific slice', () => {
+    loggerSpy.reset();
+    const profile = new Profile('ConstrainedObservation');
+    profile.parent = 'Observation';
+    const slicingType = new CaretValueRule('component');
+    slicingType.caretPath = 'slicing.discriminator[0].type';
+    slicingType.value = new FshCode('pattern');
+    const slicingPath = new CaretValueRule('component');
+    slicingPath.caretPath = 'slicing.discriminator[0].path';
+    slicingPath.value = 'code';
+    const slicingRules = new CaretValueRule('component');
+    slicingRules.caretPath = 'slicing.rules';
+    slicingRules.value = new FshCode('open');
+    const componentSlices = new ContainsRule('component');
+    componentSlices.items = ['FirstSlice', 'SecondSlice'];
+    const firstType = new OnlyRule('component[FirstSlice].value[x]');
+    firstType.types = [{ type: 'Quantity' }];
+    const firstCard = new CardRule('component[FirstSlice].valueQuantity');
+    firstCard.min = 1;
+    const secondType = new OnlyRule('component[SecondSlice].value[x]');
+    secondType.types = [{ type: 'string' }];
+
+    profile.rules.push(
+      slicingType,
+      slicingPath,
+      slicingRules,
+      componentSlices,
+      firstType,
+      firstCard,
+      secondType
+    );
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+    expect(sd).toBeTruthy();
+    expect(loggerSpy.getAllLogs()).toHaveLength(0);
+  });
+
   // Fixed Value Rule
   it('should apply a correct FixedValueRule', () => {
     const profile = new Profile('Foo');

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1019,6 +1019,51 @@ describe('StructureDefinitionExporter', () => {
     expect(loggerSpy.getLastMessage()).toMatch(/File: Only\.fsh.*Line: 10\D*/s);
   });
 
+  it('should log an error when a type constraint implicitly removes a choice created in the current StructureDefinition', () => {
+    const flagFirst = new Profile('FlagFirst');
+    flagFirst.parent = 'Observation';
+    const flagRule = new FlagRule('valueCodeableConcept')
+      .withFile('FlagFirst.fsh')
+      .withLocation([7, 12, 7, 31]);
+    flagRule.mustSupport = true;
+    const secondFlagRule = new FlagRule('valueString')
+      .withFile('FlagFirst.fsh')
+      .withLocation([8, 12, 8, 31]);
+    secondFlagRule.mustSupport = true;
+    const onlyRule = new OnlyRule('value[x]')
+      .withFile('FlagFirst.fsh')
+      .withLocation([9, 12, 9, 24]);
+    onlyRule.types = [{ type: 'Quantity' }, { type: 'string' }];
+
+    flagFirst.rules.push(flagRule);
+    flagFirst.rules.push(secondFlagRule);
+    flagFirst.rules.push(onlyRule);
+
+    exporter.exportStructDef(flagFirst);
+    const sd = pkg.profiles[0];
+    const constrainedValue = sd.findElement('Observation.value[x]');
+    expect(constrainedValue.type).toHaveLength(2);
+    expect(loggerSpy.getLastMessage('error')).toMatch(/File: FlagFirst\.fsh.*Line: 9\D*/s);
+  });
+
+  it('should not log an error when a type constraint implicitly removes a choice that has no rules applied in the current StructureDefinition', () => {
+    loggerSpy.reset();
+    const parentProfile = new Profile('ParentProfile');
+    parentProfile.parent = 'Observation';
+    const flagRule = new FlagRule('valueCodeableConcept');
+    flagRule.mustSupport = true;
+    parentProfile.rules.push(flagRule);
+    const childProfile = new Profile('ChildProfile');
+    childProfile.parent = 'ParentProfile';
+    const onlyRule = new OnlyRule('value[x]');
+    onlyRule.types = [{ type: 'Quantity' }];
+    childProfile.rules.push(onlyRule);
+    exporter.exportStructDef(parentProfile);
+    exporter.exportStructDef(childProfile);
+    expect(pkg.profiles).toHaveLength(2);
+    expect(loggerSpy.getAllLogs()).toHaveLength(0);
+  });
+
   // Fixed Value Rule
   it('should apply a correct FixedValueRule', () => {
     const profile = new Profile('Foo');

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -7,6 +7,7 @@ import { ElementDefinition, ElementDefinitionType } from '../../src/fhirtypes/El
 import { TestFisher } from '../testhelpers';
 import { FshCode } from '../../src/fshtypes';
 import { Type } from '../../src/utils/Fishable';
+import { OnlyRule } from '../../src/fshtypes/rules';
 
 describe('StructureDefinition', () => {
   let defs: FHIRDefinitions;
@@ -158,7 +159,9 @@ describe('StructureDefinition', () => {
       // constrain value[x] to only a Quantity or string and give each its own short
       const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
       valueX.sliceIt('type', '$this', false, 'open');
-      valueX.constrainType([{ type: 'Quantity' }, { type: 'string' }], fisher);
+      const valueConstraint = new OnlyRule('value[x]');
+      valueConstraint.types = [{ type: 'Quantity' }, { type: 'string' }];
+      valueX.constrainType(valueConstraint, fisher);
       const valueQuantity = valueX.addSlice('valueQuantity', new ElementDefinitionType('Quantity'));
       valueQuantity.short = 'the quantity choice';
       const valueString = valueX.addSlice('valueString', new ElementDefinitionType('string'));


### PR DESCRIPTION
Fixes #210 with task https://standardhealthrecord.atlassian.net/browse/CIMPL-271

The sample FSH in the issue gives an example of the case being handled: when a type constraint comes after a different rule that creates a choice, and the type constraint makes that choice obsolete, that's probably a user error. So, show a message to the user indicating this. When the type constraint comes first, existing code handles that case and logs an error.

To explain a bit about the `should not log an error when a type constraint is applied to a specific slice` test case: exciting things can happen when sliced elements contain choice elements. This test shows that type constraints on one slice's choice won't cause problems for other slices.