### PR TITLE
Log error when SD is missing snapshot

### DIFF
--- a/src/errors/MissingSnapshotError.ts
+++ b/src/errors/MissingSnapshotError.ts
@@ -1,0 +1,5 @@
+export class MissingSnapshotError extends Error {
+  constructor(public url: string) {
+    super(`Structure Definition ${url} is missing snapshot. Snapshot is required for import.`);
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -31,3 +31,4 @@ export * from './ParentNotDefinedError';
 export * from './PackageLoadError';
 export * from './DevPackageLoadError';
 export * from './CurrentPackageLoadError';
+export * from './MissingSnapshotError';

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -8,7 +8,7 @@ import {
 import { Meta } from './specialTypes';
 import { Identifier, CodeableConcept, Coding, Narrative, Resource, Extension } from './dataTypes';
 import { ContactDetail, UsageContext } from './metaDataTypes';
-import { CannotResolvePathError, InvalidElementAccessError } from '../errors';
+import { CannotResolvePathError, InvalidElementAccessError, MissingSnapshotError } from '../errors';
 import {
   getArrayIndex,
   setPropertyOnDefinitionInstance,
@@ -395,6 +395,8 @@ export class StructureDefinition {
         ed.structDef = sd;
         sd.elements.push(ed);
       }
+    } else {
+      throw new MissingSnapshotError(sd.url);
     }
     // And finally add back the inProgress field if it's there
     if (json.inProgress) {

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -92,6 +92,14 @@ describe('StructureDefinition', () => {
         new ElementDefinitionType('Period')
       ]);
     });
+
+    it('should throw a MissingSnapshotError when the StructureDefinition to load is missing a snapshot', () => {
+      const noSnapshotJsonObservation = defs.fishForFHIR('Observation', Type.Resource);
+      delete noSnapshotJsonObservation.snapshot;
+      expect(() => StructureDefinition.fromJSON(noSnapshotJsonObservation)).toThrow(
+        /http:\/\/hl7.org\/fhir\/StructureDefinition\/Observation is missing snapshot/
+      );
+    });
   });
 
   describe('#toJSON', () => {


### PR DESCRIPTION
This fixes https://github.com/FHIR/sushi/issues/248.

This doesn't add support for importing SDs that don't have a snapshot. But now we log an error and more gracefully alert the user that they can't import SDs that don't have a snapshot.