### PR TITLE
When resolving extensions by name, only search Extensions

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -132,7 +132,7 @@ export class StructureDefinitionExporter implements Fishable {
             rule.items.forEach(item => {
               const slice = element.addSlice(item);
               if (isExtension) {
-                const extension = this.fishForMetadata(item);
+                const extension = this.fishForMetadata(item, Type.Extension);
                 if (extension) {
                   if (!slice.type[0].profile) {
                     slice.type[0].profile = [];

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -4,7 +4,8 @@ import {
   assertOnlyRule,
   assertValueSetRule,
   assertCaretValueRule,
-  assertObeysRule
+  assertObeysRule,
+  assertContainsRule
 } from '../testhelpers/asserts';
 import { loggerSpy } from '../testhelpers/loggerSpy';
 import { importSingleText } from '../testhelpers/importSingleText';
@@ -175,6 +176,38 @@ describe('FSHImporter', () => {
         const extension = result.extensions.get('SomeExtension');
         expect(extension.rules).toHaveLength(1);
         assertOnlyRule(extension.rules[0], 'value[x]', { type: 'Quantity' });
+      });
+    });
+
+    describe('#containsRule', () => {
+      it('should parse contains rule with one type', () => {
+        const input = `
+        Extension: SomeExtension
+        * extension contains foo 1..1
+        * extension[foo].value[x] only Quantity
+        `;
+
+        const result = importSingleText(input);
+        const extension = result.extensions.get('SomeExtension');
+        expect(extension.rules).toHaveLength(3);
+        assertContainsRule(extension.rules[0], 'extension', 'foo');
+        assertCardRule(extension.rules[1], 'extension[foo]', 1, 1);
+        assertOnlyRule(extension.rules[2], 'extension[foo].value[x]', { type: 'Quantity' });
+      });
+
+      it('should parse contains rule with reserved word (code)', () => {
+        const input = `
+        Extension: SomeExtension
+        * extension contains code 1..1
+        * extension[code].value[x] only Quantity
+        `;
+
+        const result = importSingleText(input);
+        const extension = result.extensions.get('SomeExtension');
+        expect(extension.rules).toHaveLength(3);
+        assertContainsRule(extension.rules[0], 'extension', 'code');
+        assertCardRule(extension.rules[1], 'extension[code]', 1, 1);
+        assertOnlyRule(extension.rules[2], 'extension[code].value[x]', { type: 'Quantity' });
       });
     });
 


### PR DESCRIPTION
When we have a rule like:
```
* extension contains code 0..1
```
then when we check to see if code refers to something external, we should only look at Extensions, since those are the only things that make sense here.

Since I originally thought this was an issue w/ reserved words, I wrote some importer tests that specified an extension named code.  When those didn't fail, I realized it was an exporter issue -- but decided we should keep the tests anyway, so... bonus tests!

Fixes #83.