### PR TITLE
Don't print logs during testing

### DIFF
--- a/test/testhelpers/loggerSpy.ts
+++ b/test/testhelpers/loggerSpy.ts
@@ -1,10 +1,22 @@
 import { logger } from '../../src/utils/FSHLogger';
 import { LogEntry } from 'winston';
 
+// MUTE_LOGS controls whether or not logs get printed during testing.
+// Usually, we don't want logs actually printed, as they cause clutter.
+const MUTE_LOGS = true;
+
+// Winston levels: https://github.com/winstonjs/winston#logging-levels
+type Level = 'silly' | 'debug' | 'verbose' | 'http' | 'info' | 'warn' | 'error';
+
 class LoggerSpy {
   private mockWriter = jest.spyOn(logger.transports[0], 'write');
+  constructor() {
+    if (MUTE_LOGS) {
+      this.mockWriter = this.mockWriter.mockImplementation(() => true);
+    }
+  }
 
-  getAllLogs(level?: string): LogEntry[] {
+  getAllLogs(level?: Level): LogEntry[] {
     const logs = this.mockWriter.mock.calls.map(m => m[0]);
     if (level) {
       return logs.filter(entry => RegExp(level).test(entry.level));
@@ -13,33 +25,33 @@ class LoggerSpy {
     }
   }
 
-  getLogAtIndex(index: number, level?: string): LogEntry {
+  getLogAtIndex(index: number, level?: Level): LogEntry {
     const logs = this.getAllLogs(level);
     const i = index < 0 ? logs.length + index : index;
     return logs[i];
   }
 
-  getFirstLog(level?: string): LogEntry {
+  getFirstLog(level?: Level): LogEntry {
     return this.getLogAtIndex(0, level);
   }
 
-  getLastLog(level?: string): LogEntry {
+  getLastLog(level?: Level): LogEntry {
     return this.getLogAtIndex(-1, level);
   }
 
-  getAllMessages(level?: string): string[] {
+  getAllMessages(level?: Level): string[] {
     return this.getAllLogs(level).map(l => l.message);
   }
 
-  getMessageAtIndex(index: number, level?: string): string {
+  getMessageAtIndex(index: number, level?: Level): string {
     return this.getLogAtIndex(index, level)?.message;
   }
 
-  getFirstMessage(level?: string): string {
+  getFirstMessage(level?: Level): string {
     return this.getMessageAtIndex(0, level);
   }
 
-  getLastMessage(level?: string): string {
+  getLastMessage(level?: Level): string {
     return this.getMessageAtIndex(-1, level);
   }
 

--- a/test/utils/FSHLogger.test.ts
+++ b/test/utils/FSHLogger.test.ts
@@ -1,8 +1,24 @@
 import { logger, stats } from '../../src/utils/FSHLogger';
 
+// MUTE_LOGS controls whether or not logs get printed during testing.
+// Usually, we don't want logs actually printed, as they cause clutter.
+const MUTE_LOGS = true;
+
 describe('FSHLogger', () => {
+  let originalWriteFn = logger.transports[0]['write'];
+
   beforeEach(() => {
     stats.reset();
+    if (MUTE_LOGS) {
+      originalWriteFn = logger.transports[0]['write'];
+      logger.transports[0]['write'] = jest.fn(() => true);
+    }
+  });
+
+  afterEach(() => {
+    if (MUTE_LOGS) {
+      logger.transports[0]['write'] = originalWriteFn;
+    }
   });
 
   it('should store number of logger info messages', () => {


### PR DESCRIPTION
When the log statements are printed out to the console during testing, it creates a lot of clutter.  This suppresses log messages during testing.  They can be temporarily turned back on by setting the MUTE_LOGS constant to false.

BONUS: Also creates a type for the log level so I don't have to keep trying to remember if it's `'warn'` or `'warning'`.