### PR TITLE
Catch errors arising from mismatched input

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -177,7 +177,12 @@ export class FSHImporter extends FSHVisitor {
 
   visitDoc(ctx: pc.DocContext): void {
     ctx.entity().forEach(e => {
-      this.visitEntity(e);
+      try {
+        this.visitEntity(e);
+      } catch (err) {
+        const sourceInfo = { location: this.extractStartStop(e), file: this.currentFile };
+        logger.error(`Error in parsing: ${err.message}`, sourceInfo);
+      }
     });
   }
 

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -260,4 +260,18 @@ describe('FSHImporter', () => {
     expect(allLogs[1].level).toMatch(/info/);
     expect(allLogs[1].message).toMatch(/Imported 0 definitions/);
   });
+
+  it('should avoid crashing because of mismatched input', () => {
+    const input = `
+    Profile: "BadProfile"
+  
+    Profile: GoodProfile
+    Id: "BadId"
+    Parent: "BadParent"
+    Title: BadTitle
+    Description: BadDescription
+    `;
+    const result = importSingleText(input);
+    expect(result).toBeDefined();
+  });
 });

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -261,17 +261,24 @@ describe('FSHImporter', () => {
     expect(allLogs[1].message).toMatch(/Imported 0 definitions/);
   });
 
-  it('should avoid crashing because of mismatched input', () => {
+  it('should avoid crashing and log error messages because of mismatched input', () => {
     const input = `
     Profile: "BadProfile"
   
-    Profile: GoodProfile
+    Profile: BetterProfile
     Id: "BadId"
-    Parent: "BadParent"
-    Title: BadTitle
     Description: BadDescription
     `;
-    const result = importSingleText(input);
+    const result = importSingleText(input, 'Mismatch.fsh');
+    const messages = loggerSpy.getAllMessages('error');
+    expect(messages).toHaveLength(5);
+    expect(messages[0]).toMatch(/BadProfile.*SEQUENCE.*File: Mismatch\.fsh.*Line: 2\D*/s);
+    expect(messages[1]).toMatch(/BadId.*SEQUENCE.*File: Mismatch\.fsh.*Line: 5\D*/s);
+    expect(messages[2]).toMatch(
+      /BadDescription.*{STRING, MULTILINE_STRING}.*File: Mismatch\.fsh.*Line: 6\D*/s
+    );
+    expect(messages[3]).toMatch(/Error in parsing.*File: Mismatch\.fsh.*Line: 2\D*/s);
+    expect(messages[4]).toMatch(/Error in parsing.*File: Mismatch\.fsh.*Line: 4 - 6\D*/s);
     expect(result).toBeDefined();
   });
 });


### PR DESCRIPTION
This fixes https://github.com/FHIR/sushi/issues/228.

When there is mismatched input like:
```
Profile: "BadProfileName"
```
The importer was emitting an error that the mismatched input was detected, but would then crash when parsing the input. This PR prevents that crash by catching the error during parsing and logging it.

To test this, try making a FSH file with mismatched input, strings where ANTLR expects SEQUENCE, or the reverse. The mismatched input will cause crashed on `master`, but should not cause crashes on this branch.