### PR TITLE
Specify system version when fixing a code

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1307,7 +1307,11 @@ export class ElementDefinition {
       coding.code = code.code;
     }
     if (code.system) {
-      coding.system = code.system;
+      if (code.system.indexOf('|') > -1) {
+        [coding.system, coding.version] = code.system.split('|', 2);
+      } else {
+        coding.system = code.system;
+      }
     }
     this.patternCodeableConcept = {
       coding: [coding]
@@ -1341,7 +1345,11 @@ export class ElementDefinition {
       this.patternCoding.code = code.code;
     }
     if (code.system) {
-      this.patternCoding.system = code.system;
+      if (code.system.indexOf('|') > -1) {
+        [this.patternCoding.system, this.patternCoding.version] = code.system.split('|', 2);
+      } else {
+        this.patternCoding.system = code.system;
+      }
     }
   }
 

--- a/test/fhirtypes/ElementDefinition.fixFshCode.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixFshCode.test.ts
@@ -11,6 +11,7 @@ describe('ElementDefinition', () => {
   let observation: StructureDefinition;
   let fooBarCode: FshCode;
   let barFooCode: FshCode;
+  let versionedCode: FshCode;
   let fisher: TestFisher;
   beforeAll(() => {
     defs = new FHIRDefinitions();
@@ -25,6 +26,7 @@ describe('ElementDefinition', () => {
     observation = fisher.fishForStructureDefinition('Observation');
     fooBarCode = new FshCode('bar', 'http://foo.com');
     barFooCode = new FshCode('foo', 'http://bar.com');
+    versionedCode = new FshCode('versioned', 'http://versioned.com|7.6.5');
   });
 
   describe('#fixFshCode()', () => {
@@ -33,6 +35,20 @@ describe('ElementDefinition', () => {
       concept.fixFshCode(fooBarCode);
       expect(concept.patternCodeableConcept).toEqual({
         coding: [{ code: 'bar', system: 'http://foo.com' }]
+      });
+    });
+
+    it('should fix a code with a version to a CodeableConcept', () => {
+      const concept = observation.findElementByPath('code', fisher);
+      concept.fixFshCode(versionedCode);
+      expect(concept.patternCodeableConcept).toEqual({
+        coding: [
+          {
+            code: 'versioned',
+            system: 'http://versioned.com',
+            version: '7.6.5'
+          }
+        ]
       });
     });
 
@@ -65,6 +81,16 @@ describe('ElementDefinition', () => {
       const coding = observation.elements.find(e => e.id === 'Observation.code.coding');
       coding.fixFshCode(fooBarCode);
       expect(coding.patternCoding).toEqual({ code: 'bar', system: 'http://foo.com' });
+    });
+
+    it('should fix a code with a version to a Coding', () => {
+      const coding = observation.findElementByPath('code.coding', fisher);
+      coding.fixFshCode(versionedCode);
+      expect(coding.patternCoding).toEqual({
+        code: 'versioned',
+        system: 'http://versioned.com',
+        version: '7.6.5'
+      });
     });
 
     it('should throw CodeAlreadyFixedError when fixing a code to a Coding fixed to a different code', () => {


### PR DESCRIPTION
Fixes #252 and completes task https://standardhealthrecord.atlassian.net/browse/CIMPL-287

When fixing a code to a Coding or CodeableConcept, the system string will be split based on a | character into a system and version. If this character is not present, the version will not be defined.