### PR TITLE
Update IG scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ If the input folder (i.e., "FSH Tank") contains a sub-folder named "ig-data", th
 
 After running SUSHI, change to the output folder and run the `_updatePublisher` script and enter `y|Y` to download latest publisher when prompted. Then run the `_genonce` or `_gencontinuous` script.
 `_genonce` will generate the IG one time. `_gencontinuous` will continuously run the `genonce` script, which will regenerate the IG with any changes that were made to the input of the IG build.
-Note that `curl` is required to run these scripts.
 
 If the input folder does not contain a sub-folder named "ig-data", then only the resources (e.g., profiles, extensions, etc.) will be generated.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ If the input folder (i.e., "FSH Tank") contains a sub-folder named "ig-data", th
 * `ig-data/input/pagecontent/*`: If present, all other files of any type that do not match the above patterns will be copied into the IG input, but will not appear in the table of contents.
 * `ig-data/input/{supported-resource-input-folder}`: JSON files found in supported subfolders will be processed as additional resources in the IG, added to the IG JSON file, and copied to the corresponding locations in the IG input. This allows for a "Bring Your Own JSON" capability when you already have resources that were generated via another method. If a provided JSON file has the same URL as a FSH-defined resource, the provided JSON file will overwrite the FSH-defined one. Supported folders match those documented in the [Guidance for FHIR IG Creation](https://build.fhir.org/ig/FHIR/ig-guidance/using-templates.html#root.input): capabilities, examples, extensions, models, operations, profiles, resources, vocabulary.
 
-After running SUSHI, change to the output folder and run the `_updatePublisher` and `_genonce` scripts.
+After running SUSHI, change to the output folder and run the `_updatePublisher` script and enter `y|Y` to download latest publisher when prompted. Then run the `_genonce` or `_gencontinuous` script.
+`_genonce` will generate the IG one time. `_gencontinuous` will continuously run the `genonce` script, which will regenerate the IG with any changes that were made to the input of the IG build.
+Note that `curl` is required to run these scripts.
 
 If the input folder does not contain a sub-folder named "ig-data", then only the resources (e.g., profiles, extensions, etc.) will be generated.
 

--- a/src/ig/files/_gencontinuous.bat
+++ b/src/ig/files/_gencontinuous.bat
@@ -1,0 +1,2 @@
+@ECHO OFF
+CALL ./_genonce.bat -watch

--- a/src/ig/files/_gencontinuous.sh
+++ b/src/ig/files/_gencontinuous.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./_genonce.sh -watch

--- a/src/ig/files/_genonce.bat
+++ b/src/ig/files/_genonce.bat
@@ -1,3 +1,27 @@
-@SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
-JAVA -jar input-cache/org.hl7.fhir.publisher.jar -ig ig.ini
-@PAUSE
+@ECHO OFF
+SET publisher_jar=org.hl7.fhir.publisher.jar
+SET input_cache_path=%CD%\input-cache
+
+ECHO Checking internet connection...
+PING tx.fhir.org -n 1 -w 1000 | FINDSTR TTL && GOTO isonline
+ECHO We're offline...
+SET txoption=-tx n/a
+GOTO igpublish
+
+:isonline
+ECHO We're online
+SET txoption=
+
+:igpublish
+
+SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
+
+IF EXIST "%input_cache_path%\%publisher_jar%" (
+	JAVA -jar "%input_cache_path%\%publisher_jar%" -ig ig.ini %txoption% %*
+) ELSE If exist "..\%publisher_jar%" (
+	JAVA -jar "..\%publisher_jar%" -ig ig.ini %txoption% %*
+) ELSE (
+	ECHO IG Publisher NOT FOUND in input-cache or parent folder.  Please run _updatePublisher.  Aborting...
+)
+
+PAUSE

--- a/src/ig/files/_genonce.sh
+++ b/src/ig/files/_genonce.sh
@@ -1,3 +1,29 @@
 #!/bin/bash
+publisher_jar=org.hl7.fhir.publisher.jar
+input_cache_path=./input-cache/
 set -e
-java -jar input-cache/org.hl7.fhir.publisher.jar -ig ig.ini
+echo Checking internet connection...
+curl -sSf tx.fhir.org > /dev/null
+
+if [ $? -eq 0 ]; then
+	echo "Online"
+	txoption=""
+else
+	echo "Offline"
+	txoption="-tx n/a"
+fi
+
+echo "$txoption"
+
+publisher=$input_cache_path/$publisher_jar
+if test -f "$publisher"; then
+	JAVA -jar $publisher -ig ig.ini $txoption $*
+
+else
+	publisher=../$publisher_jar
+	if test -f "$publisher"; then
+		JAVA -jar $publisher -ig ig.ini $txoption $*
+	else
+		echo IG Publisher NOT FOUND in input-cache or parent folder.  Please run _updatePublisher.  Aborting...
+	fi
+fi

--- a/src/ig/files/_updatePublisher.bat
+++ b/src/ig/files/_updatePublisher.bat
@@ -1,5 +1,73 @@
-@MKDIR input-cache
-@ECHO "Downloading most recent publisher - it's ~100 MB, so this may take a bit
-@POWERSHELL -command (new-object System.Net.WebClient).DownloadFile(\"https://fhir.github.io/latest-ig-publisher/org.hl7.fhir.publisher.jar\",\"input-cache\org.hl7.fhir.publisher.jar\")
-@ECHO "Done"
-@PAUSE
+@ECHO OFF
+SET dlurl=https://fhir.github.io/latest-ig-publisher/org.hl7.fhir.publisher.jar
+SET publisher_jar=org.hl7.fhir.publisher.jar
+SET input_cache_path=%CD%\input-cache\
+
+FOR %%x IN ("%CD%") DO SET upper_path=%%~dpx
+
+IF NOT EXIST "%input_cache_path%%publisher_jar%" (
+	IF NOT EXIST "%upper_path%%publisher_jar%" (
+		SET jarlocation="%input_cache_path%%publisher_jar%"
+		SET jarlocationname=Input Cache
+		ECHO IG Publisher is not yet in input-cache or parent folder.
+		REM we don't use jarlocation below because it will be empty because we're in a bracketed if statement
+		GOTO create
+	) ELSE (
+		ECHO IG Publisher FOUND in parent folder
+		SET jarlocation="%upper_path%%publisher_jar%"
+		SET jarlocationname=Parent folder
+		GOTO:upgrade
+	)
+) ELSE (
+	ECHO IG Publisher FOUND in input-cache
+	SET jarlocation="%input_cache_path%%publisher_jar%"
+	SET jarlocationname=Input Cache
+	GOTO:upgrade
+)
+
+:create
+ECHO Will place publisher jar here: %input_cache_path%%publisher_jar%
+SET /p create="Ok? (Y/N)"
+IF /I "%create%"=="Y" (
+	MKDIR "%input_cache_path%" 2> NUL
+	GOTO:download
+)
+GOTO:done
+
+:upgrade
+SET /p overwrite="Overwrite %jarlocation%? (Y/N)"
+IF /I "%overwrite%"=="Y" (
+	GOTO:download
+)
+GOTO:done
+
+:download
+ECHO Downloading most recent publisher to %jarlocationname% - it's ~100 MB, so this may take a bit
+
+FOR /f "tokens=4-5 delims=. " %%i IN ('ver') DO SET VERSION=%%i.%%j
+IF "%version%" == "10.0" GOTO win10
+IF "%version%" == "6.3" GOTO win8.1
+IF "%version%" == "6.2" GOTO win8
+IF "%version%" == "6.1" GOTO win7
+IF "%version%" == "6.0" GOTO vista
+
+ECHO Unrecognized version: %version%
+GOTO done
+
+:win10
+CALL POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%dlurl%\",\"%jarlocation%\") } else { Invoke-WebRequest -Uri "%dlurl%" -Outfile "%jarlocation%" }
+
+GOTO done
+
+:win7
+CALL bitsadmin /transfer GetPublisher /download /priority normal "%dlurl%" "%jarlocation%"
+GOTO done
+
+:win8.1
+:win8
+:vista
+ECHO This script does not yet support Windows %winver%.  Please ask for help on http://chat.fhir.org
+GOTO done
+
+:done
+PAUSE

--- a/src/ig/files/_updatePublisher.bat
+++ b/src/ig/files/_updatePublisher.bat
@@ -27,7 +27,7 @@ IF NOT EXIST "%input_cache_path%%publisher_jar%" (
 
 :create
 ECHO Will place publisher jar here: %input_cache_path%%publisher_jar%
-SET /p create="Ok? (Y/N)"
+SET /p create="Ok? (Y/N) "
 IF /I "%create%"=="Y" (
 	MKDIR "%input_cache_path%" 2> NUL
 	GOTO:download
@@ -35,7 +35,7 @@ IF /I "%create%"=="Y" (
 GOTO:done
 
 :upgrade
-SET /p overwrite="Overwrite %jarlocation%? (Y/N)"
+SET /p overwrite="Overwrite %jarlocation%? (Y/N) "
 IF /I "%overwrite%"=="Y" (
 	GOTO:download
 )

--- a/src/ig/files/_updatePublisher.sh
+++ b/src/ig/files/_updatePublisher.sh
@@ -1,9 +1,48 @@
 #!/bin/bash
+dlurl=https://fhir.github.io/latest-ig-publisher/org.hl7.fhir.publisher.jar
+publisher_jar=org.hl7.fhir.publisher.jar
+input_cache_path=./input-cache/
+
 set -e
 if ! type "curl" > /dev/null; then
-  echo "ERROR: Script needs curl to download latest IG Publisher. Please install curl."
-  exit 1
+	echo "ERROR: Script needs curl to download latest IG Publisher. Please install curl."
+	exit 1
 fi
-echo "Downloading most recent publisher - it's ~100 MB, so this may take a bit"
-curl https://fhir.github.io/latest-ig-publisher/org.hl7.fhir.publisher.jar -o input-cache/org.hl7.fhir.publisher.jar --create-dirs
-echo "Done"
+
+publisher="$input_cache_path$publisher_jar"
+if test -f "$publisher"; then
+	echo "IG Publisher FOUND in input-cache"
+	jarlocation="$publisher"
+	jarlocationname="Input Cache"
+	upgrade=true
+else
+	publisher="../$publisher_jar"
+	upgrade=true
+	if test -f "$publisher"; then
+		echo "IG Publisher FOUND in parent folder"
+		jarlocation="$publisher"
+		jarlocationname="Parent Folder"
+		upgrade=true
+	else
+		echo IG Publisher NOT FOUND in input-cache or parent folder...
+		jarlocation=$input_cache_path$publisher_jar
+		jarlocationname="Input Cache"
+		upgrade=false
+	fi
+fi
+
+if "$upgrade"; then
+	message="Overwrite $jarlocation?"
+else
+	echo Will place publisher jar here: "$jarlocation"
+	message="Ok?"
+fi
+
+read -r -p "$message" response
+if [[ "$response" =~ ^([yY])$ ]]; then
+	echo "Downloading most recent publisher to $jarlocationname - it's ~100 MB, so this may take a bit"
+#	wget "https://fhir.github.io/latest-ig-publisher/org.hl7.fhir.publisher.jar" -O "$jarlocation" 
+	curl $dlurl -o "$jarlocation" --create-dirs
+else
+	echo cancel...
+fi

--- a/src/ig/files/_updatePublisher.sh
+++ b/src/ig/files/_updatePublisher.sh
@@ -32,10 +32,10 @@ else
 fi
 
 if "$upgrade"; then
-	message="Overwrite $jarlocation?"
+	message="Overwrite $jarlocation? (Y/N) "
 else
 	echo Will place publisher jar here: "$jarlocation"
-	message="Ok?"
+	message="Ok? (Y/N) "
 fi
 
 read -r -p "$message" response


### PR DESCRIPTION
This PR satisfies https://standardhealthrecord.atlassian.net/browse/CIMPL-301.

This updates the `updatePublisher` and `genonce` scripts based on the updates in the sample-ig: https://github.com/FHIR/sample-ig.

I had to made two changes:
- In the `_genonce.sh` script, the sample-ig was using `wget` to check for an internet connection, but we don't want to impose another dependency on users and the `updatePublisher` script is already using `curl`, so I changed [line 6](https://github.com/FHIR/sushi/blob/update-ig-scripts/src/ig/files/_genonce.sh#L6) in our script. The original line is [here](https://github.com/FHIR/sample-ig/blob/master/_genonce.sh#L6).
- In the `_gencontinuous.sh` script, I changed the reference to the `genonce` script from `_genonce.sh` to `./_genonce.sh` because I got a "command not found" error with the original line they had in the sample IG repo. For reference, my line is [here](https://github.com/FHIR/sushi/blob/update-ig-scripts/src/ig/files/_gencontinuous.sh#L2) and the sample-ig file is [here](https://github.com/FHIR/sample-ig/blob/master/_gencontinuous.sh#L2). I also made the same change in the `_gencontinuous.bat` script ([here](https://github.com/FHIR/sushi/blob/update-ig-scripts/src/ig/files/_gencontinuous.bat#L2)), but haven't been able to test it.

If either or both of these changes make sense and seem useful, I can make a PR on the sample-ig repository with the changes.

This PR needs at least one reviewer who is using a Windows computer to test the `.bat` scripts. Also any feedback on the changes I made to the existing sample-ig scripts is appreciated.