### PR TITLE
Fix invariant on empty constraint

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -392,7 +392,11 @@ export class ElementDefinition {
       ...(invariant.xpath && { xpath: invariant.xpath }),
       ...(source && { source })
     };
-    this.constraint.push(constraint);
+    if (this.constraint) {
+      this.constraint.push(constraint);
+    } else {
+      this.constraint = [constraint];
+    }
     this.findConnectedElements().forEach(ce => ce.applyConstraint(invariant, source));
   }
 

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1987,6 +1987,32 @@ describe('StructureDefinitionExporter', () => {
     expect(changedValueX.constraint[1].key).toEqual(invariant.name);
   });
 
+  it('should apply an ObeysRule at the path which does not have a constraint', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+    doc.profiles.set(profile.name, profile);
+
+    const invariant = new Invariant('MyInvariant');
+    invariant.description = 'My important invariant';
+    invariant.severity = new FshCode('error');
+    doc.invariants.set(invariant.name, invariant);
+
+    const rule = new ObeysRule('id');
+    rule.invariant = 'MyInvariant';
+    profile.rules.push(rule); // * id obeys MyInvariant
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+    const baseStructDef = fisher.fishForStructureDefinition('Observation');
+
+    const basedId = baseStructDef.findElement('Observation.id');
+    const changedId = sd.findElement('Observation.id');
+
+    expect(basedId.constraint).toBeUndefined();
+    expect(changedId.constraint).toHaveLength(1);
+    expect(changedId.constraint[0].key).toEqual(invariant.name);
+  });
+
   it('should apply an ObeysRule to the base element when not path specified', () => {
     const profile = new Profile('Foo');
     profile.parent = 'Observation';

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -194,6 +194,28 @@ describe('ElementDefinition', () => {
         severity: invariant.severity.code
       });
     });
+
+    it('should apply a constraint to an ElementDefinition with no constraint array', () => {
+      const invariant = new Invariant('MyInvariant');
+      invariant.description = 'An invariant with all metadata specified.';
+      invariant.expression = 'metadata.exists()';
+      invariant.xpath = 'exists(f:metadata)';
+      invariant.severity = new FshCode('error');
+      expect(valueId.constraint).toBeUndefined(); // constraint initially undefined
+
+      valueId.applyConstraint(invariant, 'http://example.org/fhir/StructureDefinition/SomeProfile');
+
+      expect(valueId.constraint).toHaveLength(1); // Adds an additional constraint
+      expect(valueId.constraint[0].key).toEqual(invariant.name);
+      expect(valueId.constraint[0]).toStrictEqual({
+        key: invariant.name,
+        severity: invariant.severity.code,
+        human: invariant.description,
+        expression: invariant.expression,
+        xpath: invariant.xpath,
+        source: 'http://example.org/fhir/StructureDefinition/SomeProfile'
+      });
+    });
   });
 
   describe('#hasDiff', () => {

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -35,6 +35,7 @@ describe('ElementDefinition', () => {
     valueX = ElementDefinition.fromJSON(jsonValueX);
     valueId = ElementDefinition.fromJSON(jsonValueId);
     valueX.structDef = observation;
+    valueId.structDef = observation;
   });
 
   describe('#fromJSON', () => {


### PR DESCRIPTION
This fixes #298.

To test, you can use the FSH linked in the issue. If you run that FSH on master, you will get an error like:
```
error Cannot read property 'push' of undefined
```
When you run that FSH on this branch, you should not see any errors! 