### PR TITLE
Fix handling of local templates in ig.ini

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -561,7 +561,7 @@ export class IGExporter {
       // FHIR allows templates to have versions identified using #.  E.g.,
       //   template = hl7.fhir.template#0.1.0
       // The ini library, however, treats # as a comment unless it is escaped.  So if it exists, we need to escape it.
-      inputIniContents = inputIniContents.replace(/^\s*template\s*=\s*[^#]+(#.+)?$/m, ($0, $1) =>
+      inputIniContents = inputIniContents.replace(/^\s*template\s*=\s*[^#]*(#.+)?$/m, ($0, $1) =>
         $1 ? $0.replace($1, `\\${$1}`) : $0
       );
       const inputIni = ini.parse(inputIniContents);
@@ -600,7 +600,7 @@ export class IGExporter {
 
     // Now we need to do the reverse of what we did before.  If `#` is escaped, then unescape it.
     let outputIniContents = ini.encode(iniObj, { section: 'IG', whitespace: true });
-    outputIniContents = outputIniContents.replace(/^template\s*=\s*.+?(\\#.+)?$/m, ($0, $1) =>
+    outputIniContents = outputIniContents.replace(/^template\s*=\s*.*?(\\#.+)?$/m, ($0, $1) =>
       $1 ? $0.replace($1, $1.slice(1)) : $0
     );
 

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -485,7 +485,7 @@ describe('IGExporter', () => {
     });
   });
 
-  describe('#customized-ig', () => {
+  describe('#customized-ig-with-local-template', () => {
     let pkg: Package;
     let exporter: IGExporter;
     let tempOut: string;

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -485,6 +485,33 @@ describe('IGExporter', () => {
     });
   });
 
+  describe('#customized-ig', () => {
+    let pkg: Package;
+    let exporter: IGExporter;
+    let tempOut: string;
+
+    beforeAll(() => {
+      const fixtures = path.join(__dirname, 'fixtures', 'customized-ig-with-local-template');
+      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(config);
+      exporter = new IGExporter(pkg, new FHIRDefinitions(), path.resolve(fixtures, 'ig-data'));
+      tempOut = temp.mkdirSync('sushi-test');
+      exporter.export(tempOut);
+    });
+
+    afterAll(() => {
+      temp.cleanupSync();
+    });
+
+    it('should generate an ig.ini with working local-template value', () => {
+      const iniPath = path.join(tempOut, 'ig.ini');
+      expect(fs.existsSync(iniPath)).toBeTruthy();
+      const content = fs.readFileSync(iniPath, 'utf8');
+      const lines = content.split(os.EOL); // Windows: /r/n; Mac: /n
+      expect(lines[2]).toEqual('template = #local-template');
+    });
+  });
+
   describe('#customized-ig-with-index-xml', () => {
     let pkg: Package;
     let exporter: IGExporter;

--- a/test/ig/fixtures/customized-ig-with-local-template/ig-data/ig.ini
+++ b/test/ig/fixtures/customized-ig-with-local-template/ig-data/ig.ini
@@ -1,0 +1,3 @@
+[IG]
+ig = input/ImplementationGuide-sushi-test.json
+template = #local-template

--- a/test/ig/fixtures/customized-ig-with-local-template/package.json
+++ b/test/ig/fixtures/customized-ig-with-local-template/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sushi-test",
+  "version" : "0.1.0",
+  "canonical" : "http://hl7.org/fhir/sushi-test",
+  "url" : "http://hl7.org/fhir/sushi-test",
+  "title" : "FSH Test IG",
+  "description": "Provides a simple example of how FSH can be used to create an IG",
+  "dependencies": {
+     "hl7.fhir.r4.core": "4.0.1"
+  },
+  "language": "en",
+  "author": "James Tuna",
+  "maintainers": [
+    {
+      "name": "Bill Cod",
+      "email": "cod@reef.gov"
+    }
+  ],
+  "license": "CC0-1.0"
+ }


### PR DESCRIPTION
Local templates start with # in the ig.ini file, but we were expecting name#version. This fixes it so it works when # is the first character.

Fixes #299.