### PR TITLE
Handle non-indented lines

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1504,7 +1504,7 @@ export class FSHImporter extends FSHVisitor {
     lines.forEach(line => {
       const firstNonSpace = line.search(/\S|$/);
       const lineIsEmpty = /^$/.test(line);
-      if (!lineIsEmpty && firstNonSpace > 0 && (minSpaces === 0 || firstNonSpace < minSpaces)) {
+      if (!lineIsEmpty && firstNonSpace >= 0 && (minSpaces === 0 || firstNonSpace < minSpaces)) {
         minSpaces = firstNonSpace;
       }
     });


### PR DESCRIPTION
This fixes #306. The issue has a more detailed description, but basically when a string is multiple lines and some are indented and some are not indented at all:
```
* name.text = """
Let's say for some reason I write something

  But oh wait I really want an indented block of
  text here how is that going to work out for me?
  I am not so sure.

Woah that was fun back to non-indents now though."""
```
The first part of the non-indented lines will be cut off. You can test this by creating a quick profile of any resource and running SUSHI on master, and placing the above rule on that profile. The beginning of "Let's" and "Woah" will be cut off in the output. Then try running SUSHI on this branch, you will see that the beginnings are not cropped.