### PR TITLE
Generate path-history parameter for HL7 IGs

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -108,7 +108,7 @@ export class IGExporter {
           generation: 'html',
           page: [] // index.[md|html] is required and added later
         },
-        // Parameter apparently required by IG Publisher (as of Jan 29, 2020)
+        // Parameters apparently required by IG Publisher (as of Jan 29, 2020)
         parameter: [
           {
             code: 'copyrightyear',
@@ -125,6 +125,14 @@ export class IGExporter {
         ]
       }
     };
+
+    // Add the path-history, if applicable (only applies to HL7 IGs)
+    if (/^https?:\/\/hl7.org\//.test(this.pkg.config.canonical)) {
+      this.ig.definition.parameter.push({
+        code: 'path-history',
+        value: `${this.pkg.config.canonical}/history.html`
+      });
+    }
 
     // Add the dependencies
     if (this.pkg.config.dependencies) {

--- a/test/ig/fixtures/non-hl7-ig/package.json
+++ b/test/ig/fixtures/non-hl7-ig/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "sushi-test",
+  "version" : "0.1.0",
+  "canonical" : "http://example.org/fhir/sushi-test",
+  "url" : "http://example.org/fhir/sushi-test",
+  "title" : "FSH Test IG",
+  "description": "Provides a simple example of how FSH can be used to create an IG",
+  "dependencies": {
+     "hl7.fhir.r4.core": "4.0.1"
+  },
+  "language": "en",
+  "author": "James Tuna",
+  "maintainers": [
+    {
+      "name": "Bill Cod",
+      "email": "cod@reef.gov",
+      "url": "https://capecodfishermen.org/"
+    }
+  ],
+  "license": "CC0-1.0"
+ }


### PR DESCRIPTION
Generate a path-history parameter for HL7 IGs.  We use the same approach to recognizing HL7 IGs as the publisher does -- looking at the canonical to see if it is in the `hl7.org` domain.

The publisher expects history paths to have the format `${canonical}/history.html`.

Unit tests show how it works, but if you want to test manually, run the master branch against an HL7 IG and then run the IG Publisher.  After the publisher completes, look at `output/qa.html` in a browser.  You will see something like this near the top of the page:
![image](https://user-images.githubusercontent.com/2278253/77758470-67fef480-7009-11ea-99b6-3851457fb6b7.png)

Now do the same thing using this branch.  After running the IG Publisher again, now the `qa.html` should have this instead:
![image](https://user-images.githubusercontent.com/2278253/77758730-dd6ac500-7009-11ea-887a-b9352989eed1.png)

Fixes #286