### PR TITLE
Apply CaretValueRule to parent element with .

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -173,7 +173,7 @@ export class StructureDefinition {
   findElementByPath(path: string, fisher: Fishable): ElementDefinition {
     // If the path already exists, get it and return the match
     // If !path just return the base parent element
-    const fullPath = path ? `${this.type}.${path}` : this.type;
+    const fullPath = path && path !== '.' ? `${this.type}.${path}` : this.type;
     const match = this.elements.find(e => e.path === fullPath && !e.id.includes(':'));
     if (match != null) {
       return match;

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1930,6 +1930,24 @@ describe('StructureDefinitionExporter', () => {
     expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidValue\.fsh.*Line: 6\D*/s);
   });
 
+  it('should apply a CaretValueRule on the parent element', () => {
+    // Profile: ShortObservation
+    // Parent: Observation
+    // * . ^ short = "This one is not so tall."
+    const profile = new Profile('ShortObservation');
+    profile.parent = 'Observation';
+
+    const rule = new CaretValueRule('.');
+    rule.caretPath = 'short';
+    rule.value = 'This one is not so tall.';
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+    const observation = sd.findElement('Observation');
+    expect(observation.short).toBe('This one is not so tall.');
+  });
+
   it('should apply a CaretValueRule on an element without a path', () => {
     const profile = new Profile('Foo');
     profile.parent = 'Observation';


### PR DESCRIPTION
Fixes #277 and completes task https://standardhealthrecord.atlassian.net/browse/CIMPL-313

When a path of "." is used in a CaretValueRule, the rule is applied to the parent element in the structure definition. This is distinct from an empty path "", where the rule is applied to the structure definition itself.