### PR TITLE
Add the pull_request event to the GH workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,6 @@
 name: Lint and Test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
I think this may cause the actions to run when we get PRs from forked repositories as well.  Although I'm not 100% sure.  The documentation is a bit murky:

> When you create a pull request from a forked repository to the base repository, GitHub sends the pull_request event to the base repository and no pull request events occur on the forked repository.
> 
> Workflows don't run on forked repositories by default. You must enable GitHub Actions in the Actions tab of the forked repository.

Anyway, it's worth a shot.