### PR TITLE
FHIR Spot Check

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -100,13 +100,14 @@ async function app() {
     return;
   }
 
-  const fhirR4Dependency = config.dependencies['hl7.fhir.r4.core'];
-  if (!(fhirR4Dependency && fhirR4Dependency === '4.0.1')) {
+  // Ensure FHIR R4 is added as a dependency
+  const fhirR4Dependency = config.dependencies?.['hl7.fhir.r4.core'];
+  if (fhirR4Dependency !== '4.0.1') {
     logger.error(
       'The package.json must specify FHIR R4 as a dependency. Be sure to' +
         ' add "hl7.fhir.r4.core": "4.0.1" to the dependencies list.'
     );
-    program.help();
+    return;
   }
 
   // Load external dependencies
@@ -145,11 +146,13 @@ async function app() {
 
   // Check for StructureDefinition
   const structDef = defs.fishForFHIR('StructureDefinition', Type.Resource);
-  if (!(structDef && structDef.version === '4.0.1')) {
+  if (structDef?.version !== '4.0.1') {
     logger.error(
-      'StructureDefinition resource not found for 4.0.1. Your FHIR package may be corrupt.'
+      'StructureDefinition resource not found for v4.0.1. The FHIR R4 package in local cache' +
+        ' may be corrupt. Local FHIR cache can be found at <home-directory>/.fhir/packages.' +
+        ' For more information, see https://wiki.hl7.org/FHIR_Package_Cache#Location.'
     );
-    program.help();
+    return;
   }
 
   logger.info('Converting FSH to FHIR resources...');


### PR DESCRIPTION
This PR adds support for two early checks in the SUSHI process, addressing https://standardhealthrecord.atlassian.net/browse/CIMPL-221.

1. We check if the user specified FHIR R4 in their dependencies in `package.json`. If they did not, we log an error and exit.
2. We check if the StructureDefinition resource exists and has a basic `version` property on it. If something has gone in the FHIR definition download, this property likely won't exist. If there is something wrong with the resource, we log an error and exit.

Since these changes just live in `app.ts`, there are no tests. To test this PR locally, I did the following:

1. To check the FHIR R4 version, I changed the version specified in the `hl7.fhir.r4.core` dependency in package.json of the FSH tank, and I also removed that dependency entirely from the package.json.
2. To test that the StructureDefinition check worked, I moved the `StructureDefinition-StructureDefinition.json` file in my FHIR cache in r4 core package out of its usual directory. If you don't want to mess around with your FHIR cache, you can feel free to just look at the code or I can show you it working (and breaking) on my computer.