### PR TITLE
Set discriminator value cardinality

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1176,7 +1176,8 @@ export class ElementDefinition {
           d =>
             `${slicedElement.path}${d.path === '$this' ? '' : `.${d.path}`}` === this.path &&
             ['value', 'pattern'].includes(d.type)
-        )
+        ) &&
+        this.min === 0
       ) {
         this.constrainCardinality(1, '');
       }

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1168,9 +1168,9 @@ export class ElementDefinition {
 
     // If the element is found in a discriminator.path, then we enforce that it has minimum cardinality 1
     // since its value is fixed
-    const nearestSlice = [this, ...this.getAllParents().reverse()].find(el => el.sliceName);
-    if (nearestSlice) {
-      const slicedElement = nearestSlice.slicedElement();
+    const parentSlices = [this, ...this.getAllParents().reverse()].filter(el => el.sliceName);
+    parentSlices.forEach(parentSlice => {
+      const slicedElement = parentSlice.slicedElement();
       if (
         slicedElement.slicing.discriminator.some(
           d =>
@@ -1181,7 +1181,7 @@ export class ElementDefinition {
       ) {
         this.constrainCardinality(1, '');
       }
-    }
+    });
 
     // Units error should not stop fixing value, but must still be logged
     const types = this.findTypesByCode('Quantity');

--- a/test/fhirtypes/ElementDefinition.fixValue.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixValue.test.ts
@@ -110,6 +110,23 @@ describe('ElementDefinition', () => {
       expect(inUriMouse.min).toBe(1);
     });
 
+    it('should ensure that minimum cardinality is 1 when fixing a value mentioned in the discriminator of a grandparent slice', () => {
+      const cat = medicationRequest.elements.find(e => e.id === 'MedicationRequest.category');
+      cat.slicing = { discriminator: [{ type: 'value', path: 'coding.code' }], rules: 'open' };
+      cat.addSlice('mouse');
+      const catCoding = medicationRequest.findElementByPath('category.coding', fisher);
+      catCoding.slicing = { discriminator: [{ type: 'value', path: 'coding' }], rules: 'open' };
+      catCoding.addSlice('rat');
+      const catMouseCodingRatCode = medicationRequest.findElementByPath(
+        'category[mouse].coding[rat].code',
+        fisher
+      );
+      expect(catMouseCodingRatCode.min).toBe(0);
+      catMouseCodingRatCode.fixValue(new FshCode('cheese'));
+      expect(catMouseCodingRatCode.patternCode).toBe('cheese');
+      expect(catMouseCodingRatCode.min).toBe(1);
+    });
+
     it('should not ensure that minimum cardinality is 1 when fixing a value not mentioned in a slice discriminator', () => {
       const cat = medicationRequest.elements.find(e => e.id === 'MedicationRequest.category');
       cat.slicing = { discriminator: [{ type: 'value', path: 'coding.code' }], rules: 'open' };

--- a/test/fhirtypes/ElementDefinition.fixValue.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixValue.test.ts
@@ -137,6 +137,18 @@ describe('ElementDefinition', () => {
       expect(catMouseCodingCode.patternCode).toBe('cheese');
       expect(catMouseCodingCode.min).toBe(0);
     });
+
+    it('should not ensure that minimum cardinality is 1 when fixing a value with min card > 1 mentioned in a parent slice discriminator', () => {
+      const cat = medicationRequest.elements.find(e => e.id === 'MedicationRequest.category');
+      cat.slicing = { discriminator: [{ type: 'value', path: 'coding' }], rules: 'open' };
+      cat.addSlice('mouse');
+      const catMouseCoding = medicationRequest.findElementByPath('category[mouse].coding', fisher);
+      catMouseCoding.min = 2;
+      expect(catMouseCoding.min).toBe(2);
+      catMouseCoding.fixValue(new FshCode('cheese'));
+      expect(catMouseCoding.patternCoding).toEqual({ code: 'cheese' });
+      expect(catMouseCoding.min).toBe(2); // We do not try to decrease min to 1
+    });
   });
 
   describe('#fixedByDirectParent', () => {


### PR DESCRIPTION
This fixes #301 

Now when a part of a slice gets a value fixed on it, and that value is used by the `path` in the relevant slice discriminator which discriminates based on `value` or `pattern`, if the slice has a minimum cardinality of 0, we change that minimum cardinality to be 1.