### PR TITLE
Fix length of puns

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -308,7 +308,7 @@ const MESSAGE_MAP: { [key in ResultStatus]: string[] } = {
     'Something smells fishy...',
     'Warnings... Water those about?',
     'Looks like you are casting about.',
-    'A bit pitchy, but tuna-ble'
+    'A bit pitchy, but tuna-ble.'
   ],
   errors: [
     'Ick! Errors!',
@@ -318,7 +318,7 @@ const MESSAGE_MAP: { [key in ResultStatus]: string[] } = {
     'You spawned some errors.',
     'Just keep swimming, Dory.',
     'This is the one that got away.',
-    'The documentation might be bene-fish-al'
+    'The docs might be bene-fish-al.'
   ]
 };
 


### PR DESCRIPTION
One of the puns added to app.ts was too long, so the box would get offset:
![image](https://user-images.githubusercontent.com/52747882/79232012-f3172180-7e34-11ea-80e8-c72325ba039a.png)
This fixes that.