### PR TITLE
Config YAML type

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -92,16 +92,16 @@ async function app() {
   }
 
   // Parse package.json
-  let config: any;
+  let packageJSON: any;
   try {
-    config = fs.readJSONSync(packagePath);
+    packageJSON = fs.readJSONSync(packagePath);
   } catch (e) {
     logger.error(`The package.json file is not valid JSON: ${packagePath}`);
     return;
   }
 
   // Ensure FHIR R4 is added as a dependency
-  const fhirR4Dependency = config.dependencies?.['hl7.fhir.r4.core'];
+  const fhirR4Dependency = packageJSON.dependencies?.['hl7.fhir.r4.core'];
   if (fhirR4Dependency !== '4.0.1') {
     logger.error(
       'The package.json must specify FHIR R4 as a dependency. Be sure to' +
@@ -113,15 +113,15 @@ async function app() {
   // Load external dependencies
   const defs = new FHIRDefinitions();
   const dependencyDefs: Promise<FHIRDefinitions | void>[] = [];
-  for (const dep of Object.keys(config?.dependencies ?? {})) {
+  for (const dep of Object.keys(packageJSON?.dependencies ?? {})) {
     dependencyDefs.push(
-      loadDependency(dep, config.dependencies[dep], defs)
+      loadDependency(dep, packageJSON.dependencies[dep], defs)
         .then(def => {
-          logger.info(`Loaded package ${dep}#${config.dependencies[dep]}`);
+          logger.info(`Loaded package ${dep}#${packageJSON.dependencies[dep]}`);
           return def;
         })
         .catch(e => {
-          logger.error(`Failed to load ${dep}#${config.dependencies[dep]}`);
+          logger.error(`Failed to load ${dep}#${packageJSON.dependencies[dep]}`);
           logger.error(e.message);
         })
     );
@@ -141,7 +141,7 @@ async function app() {
   logger.info('Importing FSH text...');
   const docs = importText(rawFSHes);
 
-  const tank = new FSHTank(docs, config);
+  const tank = new FSHTank(docs, packageJSON);
   await Promise.all(dependencyDefs);
 
   // Check for StructureDefinition
@@ -172,7 +172,7 @@ async function app() {
 
   fs.writeFileSync(
     path.join(outDir, 'package.json'),
-    JSON.stringify(outPackage.config, null, 2),
+    JSON.stringify(outPackage.packageJSON, null, 2),
     'utf8'
   );
 

--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -19,9 +19,9 @@ export class CodeSystemExporter {
     codeSystem.setId(fshDefinition.id, fshDefinition.sourceInfo);
     if (fshDefinition.title) codeSystem.title = fshDefinition.title;
     if (fshDefinition.description) codeSystem.description = fshDefinition.description;
-    // Version is set to value provided in config, will be overriden if reset by rules
-    codeSystem.version = this.tank.config.version;
-    codeSystem.url = `${this.tank.config.canonical}/CodeSystem/${codeSystem.id}`;
+    // Version is set to value provided in packageJSON, will be overriden if reset by rules
+    codeSystem.version = this.tank.packageJSON.version;
+    codeSystem.url = `${this.tank.packageJSON.canonical}/CodeSystem/${codeSystem.id}`;
   }
 
   private setConcepts(codeSystem: CodeSystem, fshDefinition: FshCodeSystem): void {

--- a/src/export/Package.ts
+++ b/src/export/Package.ts
@@ -1,5 +1,5 @@
 import { StructureDefinition, InstanceDefinition, ValueSet, CodeSystem } from '../fhirtypes';
-import { Config } from '../fshtypes';
+import { PackageJSON } from '../fshtypes';
 import { Fishable, Type, Metadata } from '../utils/Fishable';
 
 export class Package implements Fishable {
@@ -9,7 +9,7 @@ export class Package implements Fishable {
   public readonly valueSets: ValueSet[] = [];
   public readonly codeSystems: CodeSystem[] = [];
 
-  constructor(public readonly config: Config) {}
+  constructor(public readonly packageJSON: PackageJSON) {}
 
   fish(
     item: string,

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -59,9 +59,9 @@ export class StructureDefinitionExporter implements Fishable {
     delete structDef.contained;
     delete structDef.extension; // see https://github.com/FHIR/sushi/issues/116
     delete structDef.modifierExtension;
-    structDef.url = `${this.tank.config.canonical}/StructureDefinition/${structDef.id}`;
+    structDef.url = `${this.tank.packageJSON.canonical}/StructureDefinition/${structDef.id}`;
     delete structDef.identifier;
-    structDef.version = this.tank.config.version; // can be overridden using a rule
+    structDef.version = this.tank.packageJSON.version; // can be overridden using a rule
     structDef.setName(fshDefinition.name, fshDefinition.sourceInfo);
     if (fshDefinition.title) {
       structDef.title = fshDefinition.title;

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -33,9 +33,9 @@ export class ValueSetExporter {
     if (fshDefinition.description) {
       valueSet.description = fshDefinition.description;
     }
-    // Version is set to value provided in config, will be overriden if reset by rules
-    valueSet.version = this.tank.config.version;
-    valueSet.url = `${this.tank.config.canonical}/ValueSet/${valueSet.id}`;
+    // Version is set to value provided in packageJSON, will be overriden if reset by rules
+    valueSet.version = this.tank.packageJSON.version;
+    valueSet.url = `${this.tank.packageJSON.canonical}/ValueSet/${valueSet.id}`;
   }
 
   private setCompose(valueSet: ValueSet, components: ValueSetComponent[]) {

--- a/src/export/exportFHIR.ts
+++ b/src/export/exportFHIR.ts
@@ -11,7 +11,7 @@ import { MasterFisher } from '../utils';
  * @returns {Package} - the Package structure returned from processing the FSH definitions
  */
 export function exportFHIR(tank: FSHTank, FHIRDefs: FHIRDefinitions): Package {
-  const pkg = new Package(tank.config);
+  const pkg = new Package(tank.packageJSON);
   const fisher = new MasterFisher(tank, FHIRDefs, pkg);
   const exporter = new FHIRExporter(tank, pkg, fisher);
   return exporter.export();

--- a/src/fhirtypes/ImplementationGuide.ts
+++ b/src/fhirtypes/ImplementationGuide.ts
@@ -8,7 +8,7 @@ export type ImplementationGuide = {
   version?: string;
   name: string;
   title?: string;
-  status: 'draft' | 'active' | 'retired' | 'unknown';
+  status: ImplementationGuideStatus;
   experimental?: boolean;
   date?: string;
   publisher?: string;
@@ -26,8 +26,10 @@ export type ImplementationGuide = {
   manifest?: ImplementationGuideManifest;
 };
 
+export type ImplementationGuideStatus = 'draft' | 'active' | 'retired' | 'unknown';
+
 export type ImplementationGuideDependsOn = {
-  uri: string;
+  uri?: string; // optional for Configuration usecase where packageId is used instead
   packageId?: string;
   version?: string;
 };
@@ -51,7 +53,7 @@ export type ImplementationGuideDefinitionGrouping = {
 };
 
 export type ImplementationGuideDefinitionResource = {
-  reference: Reference;
+  reference?: Reference; // optional to support Configuration use case where key is the reference
   fhirVersion?: string[];
   name?: string;
   description?: string;
@@ -63,8 +65,8 @@ export type ImplementationGuideDefinitionResource = {
 export type ImplementationGuideDefinitionPage = {
   nameUrl?: string;
   nameReference?: Reference;
-  title: string;
-  generation: ImplementationGuideDefinitionPageGeneration;
+  title?: string; // optional to support Configuration use case where title has a default
+  generation?: ImplementationGuideDefinitionPageGeneration; // optional to support Configuration...
   page?: ImplementationGuideDefinitionPage[];
 };
 

--- a/src/fhirtypes/dataTypes.ts
+++ b/src/fhirtypes/dataTypes.ts
@@ -36,9 +36,9 @@ export type Coding = {
  * @see {@link http://hl7.org/fhir/R4/datatypes.html#ContactPoint}
  */
 export type ContactPoint = {
-  system?: string;
+  system?: 'phone' | 'fax' | 'email' | 'pager' | 'url' | 'sms' | 'other';
   value?: string;
-  use?: string;
+  use?: 'home' | 'work' | 'temp' | 'old' | 'mobile';
   rank?: number;
   period?: Period;
 };

--- a/src/fshtypes/Configuration.ts
+++ b/src/fshtypes/Configuration.ts
@@ -1,0 +1,168 @@
+import {
+  ContactDetail,
+  UsageContext,
+  ImplementationGuideDefinitionTemplate,
+  Meta,
+  Narrative,
+  Extension,
+  ImplementationGuideDependsOn,
+  ImplementationGuideGlobal,
+  ImplementationGuideDefinitionResource,
+  ImplementationGuideDefinitionPage,
+  ImplementationGuideDefinitionParameter,
+  ImplementationGuideStatus,
+  CodeableConcept
+} from '../fhirtypes';
+
+/**
+ * Configuration is related to the proposed YAML configuration format for FSH, but eliminates
+ * ambiguities (like singular vs list representations) and normalizes closer to the intended
+ * export formats.
+ *
+ * @see {@link http://hl7.org/fhir/R4/implementationguide.html}
+ * @see {@link https://build.fhir.org/ig/FHIR/ig-guidance/using-templates.html#igroot}
+ * @see {@link https://confluence.hl7.org/display/FHIR/NPM+Package+Specification}
+ * @see {@link https://confluence.hl7.org/pages/viewpage.action?pageId=66928420#FHIRIGPackageListdoco-PublicationObject}
+ * @see {@link https://github.com/FHIR/sample-ig/blob/master/input/includes/menu.xml}
+ */
+export type Configuration = {
+  filePath: string;
+  id: string;
+  meta?: Meta;
+  implicitRules?: string;
+  language?: string;
+  text?: Narrative;
+  contained?: any[];
+  extension?: Extension[];
+  modifierExtension?: Extension[];
+  url: string;
+  version: string;
+  name: string;
+  title?: string;
+  status: ImplementationGuideStatus;
+  experimental?: boolean;
+  date?: string;
+
+  // The first publisher's name in the YAML file will be used as IG.publisher.  The contact details
+  // and/or additional publishers is translated into IG.contact values.
+  publisher?: string;
+
+  // The first contact entry contains additional publisher contact info (if applicable).
+  // Those who need more control or want to add additional details to the contact values can use
+  // contact directly and follow the format outlined in the ImplementationGuide resource and
+  // ContactDetail.
+  contact?: ContactDetail[];
+
+  description?: string;
+  useContext?: UsageContext[];
+  jurisdiction?: CodeableConcept[];
+  copyright?: string;
+
+  // SUSHI will use id as both id and packageId in the IG unless a specific packageId is specified
+  packageId?: string;
+
+  license?: string;
+  fhirVersion: string[];
+  dependencies?: ImplementationGuideDependsOn[];
+  global?: ImplementationGuideGlobal[];
+
+  // Groups can control certain aspects of the IG generation.  The IG documentation recommends that
+  // authors use the default groups that are provided by the templating framework, but if authors
+  // want to use their own instead, they can use the mechanism below.  This will create
+  // IG.definition.grouping entries and associate the individual resource entries with the
+  // corresponding groupIds.
+  groups?: ConfigurationGroup[];
+
+  // The resources property corresponds to IG.definition.resource. SUSHI can auto-generate all of
+  // the resource entries based on the FSH definitions and/or information in any user-provided
+  // JSON resource files. If the generated entries are not sufficient or complete, however, the
+  // author can add entries here. If the reference matches a generated entry, it will replace the
+  // generated entry. If it doesn't match any generated entries, it will be added to the generated
+  // entries. The format follows IG.definition.resource with the following differences:
+  // * additional "omit" property to omit a FSH-generated resource from the resource list.
+  // * groupingId can be used, but top-level groups syntax may be a better option (see below).
+  resources?: ConfigurationResource[];
+
+  // The pages property corresponds to IG.definition.page. SUSHI can auto-generate the page list,
+  // but if the author includes pages in this file, it is assumed that the author will fully manage
+  // the pages section and SUSHI will not generate any page entries. If title is not provided, then
+  // the title will be generated from the file name.  If a generation value is not provided, it
+  // will be inferred from the file name extension.
+  pages?: ImplementationGuideDefinitionPage[];
+
+  // The parameters property represents IG.definition.parameter. For a partial list of allowed
+  // parameters see: https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+  parameters?: ImplementationGuideDefinitionParameter[];
+
+  // The templates property corresponds 1:1 with IG.definition.template. Note that plural templates
+  // refers to the IG.definiton.template definitions; singular template refers to the specific
+  // template to use for this IG.
+  templates?: ImplementationGuideDefinitionTemplate[];
+
+  // The template property will be copied into the ig.ini file. If the value of template is "none",
+  // then only the resources will be generated (with no supporting ImplementationGuide sources).
+  template: string;
+
+  // The menu property will be used to generate the input/menu.xml file. The menu is represented as
+  // a simple structure where the YAML key is the menu item name and the value is the URL. The IG
+  // publisher currently only supports one level deep on sub-menus.
+  // TO CONSIDER: If no menu data is provided, can we generate the menu based on the pages order
+  // or should we just generate a very standard menu (since there may be too many pages to fit in
+  // a menu)?
+  menu?: ConfigurationMenuItem[];
+
+  // The history property corresponds to package-list.json. SUSHI will use the existing top-level
+  // properties in its config to populate the top-level package-list.json properties: package-id,
+  // canonical, title, and introduction. Authors that wish to provide different values can supply
+  // them as properties under history. All other properties under history are assumed to be
+  // versions.
+  //
+  // The current version is special. If the author provides only a single string value, it is
+  // assumed to be the URL path to the current build. The following default values will then be
+  // used:
+  // * desc: Continuous Integration Build (latest in version control)
+  // * status: ci-build
+  // * current: true
+  history?: ConfigurationHistory;
+};
+
+export type ConfigurationGroup = {
+  name: string;
+  description?: string;
+  resources: string[];
+};
+
+export type ConfigurationResource = ImplementationGuideDefinitionResource & { omit?: boolean };
+
+export type ConfigurationMenuItem = {
+  name: string;
+  url?: string;
+  subMenu?: ConfigurationMenuItem[];
+};
+
+export type ConfigurationHistory = {
+  'package-id'?: string;
+  canonical?: string;
+  title?: string;
+  introduction?: string;
+  list?: ConfigurationHistoryItem[];
+};
+
+export type ConfigurationHistoryItem = {
+  version: string;
+  date?: string;
+  desc?: string;
+  path: string;
+  changes?: string;
+  status?:
+    | 'ci-build'
+    | 'preview'
+    | 'ballot'
+    | 'trial-use'
+    | 'update'
+    | 'normative'
+    | 'trial=use+normative';
+  sequence?: string;
+  fhirversion?: string;
+  current?: boolean;
+};

--- a/src/fshtypes/PackageJSON.ts
+++ b/src/fshtypes/PackageJSON.ts
@@ -1,10 +1,10 @@
 /**
- * Config follows the package.json format defined for FSH
+ * PackageJSON follows the package.json format defined for FSH
  *
  * @see {@link https://build.fhir.org/ig/FHIR/ig-guidance/index.html}
  * @see {@link https://confluence.hl7.org/display/FHIR/NPM+Package+Specification}
  */
-export type Config = {
+export type PackageJSON = {
   name: string;
   version: string;
   canonical: string;

--- a/src/fshtypes/index.ts
+++ b/src/fshtypes/index.ts
@@ -1,5 +1,5 @@
 export * from './FshCodeSystem';
-export * from './Config';
+export * from './PackageJSON';
 export * from './Extension';
 export * from './Instance';
 export * from './FshCode';

--- a/src/fshtypes/index.ts
+++ b/src/fshtypes/index.ts
@@ -15,3 +15,4 @@ export * from './ValueSetComponent';
 export * from './Invariant';
 export * from './RuleSet';
 export * from './Mapping';
+export * from './Configuration';

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -10,13 +10,13 @@ import {
   Mapping
 } from '../fshtypes';
 import flatMap from 'lodash/flatMap';
-import { Config } from '../fshtypes/Config';
+import { PackageJSON } from '../fshtypes/PackageJSON';
 import { Type, Metadata, Fishable } from '../utils/Fishable';
 
 export class FSHTank implements Fishable {
   constructor(
     public readonly docs: FSHDocument[],
-    public readonly config: Config,
+    public readonly packageJSON: PackageJSON,
     public readonly root?: string
   ) {}
 
@@ -143,7 +143,7 @@ export class FSHTank implements Fishable {
             p =>
               p.name === item ||
               p.id === item ||
-              `${this.config.canonical}/StructureDefinition/${p.id}` === item
+              `${this.packageJSON.canonical}/StructureDefinition/${p.id}` === item
           );
           break;
         case Type.Extension:
@@ -151,7 +151,7 @@ export class FSHTank implements Fishable {
             e =>
               e.name === item ||
               e.id === item ||
-              `${this.config.canonical}/StructureDefinition/${e.id}` === item
+              `${this.packageJSON.canonical}/StructureDefinition/${e.id}` === item
           );
           break;
         case Type.ValueSet:
@@ -159,7 +159,7 @@ export class FSHTank implements Fishable {
             vs =>
               vs.name === item ||
               vs.id === item ||
-              `${this.config.canonical}/ValueSet/${vs.id}` === item
+              `${this.packageJSON.canonical}/ValueSet/${vs.id}` === item
           );
           break;
         case Type.CodeSystem:
@@ -167,7 +167,7 @@ export class FSHTank implements Fishable {
             vs =>
               vs.name === item ||
               vs.id === item ||
-              `${this.config.canonical}/CodeSystem/${vs.id}` === item
+              `${this.packageJSON.canonical}/CodeSystem/${vs.id}` === item
           );
           break;
         case Type.Instance:
@@ -204,12 +204,12 @@ export class FSHTank implements Fishable {
         name: result.name
       };
       if (result instanceof Profile || result instanceof Extension) {
-        meta.url = `${this.config.canonical}/StructureDefinition/${result.id}`;
+        meta.url = `${this.packageJSON.canonical}/StructureDefinition/${result.id}`;
         meta.parent = result.parent;
       } else if (result instanceof FshValueSet) {
-        meta.url = `${this.config.canonical}/ValueSet/${result.id}`;
+        meta.url = `${this.packageJSON.canonical}/ValueSet/${result.id}`;
       } else if (result instanceof FshCodeSystem) {
-        meta.url = `${this.config.canonical}/CodeSystem/${result.id}`;
+        meta.url = `${this.packageJSON.canonical}/CodeSystem/${result.id}`;
       }
       return meta;
     }

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -29,7 +29,7 @@ describe('CodeSystemExporter', () => {
       version: '0.0.1',
       canonical: 'http://example.com'
     });
-    const pkg = new Package(input.config);
+    const pkg = new Package(input.packageJSON);
     const fisher = new TestFisher(input, defs, pkg);
     exporter = new CodeSystemExporter(input, pkg, fisher);
   });

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -44,7 +44,7 @@ describe('InstanceExporter', () => {
       version: '0.0.1',
       canonical: 'http://example.com'
     });
-    const pkg = new Package(input.config);
+    const pkg = new Package(input.packageJSON);
     const fisher = new TestFisher(input, defs, pkg);
     sdExporter = new StructureDefinitionExporter(input, pkg, fisher);
     exporter = new InstanceExporter(input, pkg, fisher);

--- a/test/export/MappingExporter.test.ts
+++ b/test/export/MappingExporter.test.ts
@@ -30,7 +30,7 @@ describe('MappingExporter', () => {
       version: '0.0.1',
       canonical: 'http://example.com'
     });
-    const pkg = new Package(input.config);
+    const pkg = new Package(input.packageJSON);
     const fisher = new TestFisher(input, defs, pkg);
     exporter = new MappingExporter(input, pkg, fisher);
     observation = fisher.fishForStructureDefinition('Observation');

--- a/test/export/StructureDefinition.ExtensionExporter.test.ts
+++ b/test/export/StructureDefinition.ExtensionExporter.test.ts
@@ -27,7 +27,7 @@ describe('ExtensionExporter', () => {
       version: '0.0.1',
       canonical: 'http://example.com'
     });
-    const pkg = new Package(input.config);
+    const pkg = new Package(input.packageJSON);
     const fisher = new TestFisher(input, defs, pkg);
     exporter = new StructureDefinitionExporter(input, pkg, fisher);
   });

--- a/test/export/StructureDefinition.ProfileExporter.test.ts
+++ b/test/export/StructureDefinition.ProfileExporter.test.ts
@@ -27,7 +27,7 @@ describe('ProfileExporter', () => {
       version: '0.0.1',
       canonical: 'http://example.com'
     });
-    const pkg = new Package(input.config);
+    const pkg = new Package(input.packageJSON);
     const fisher = new TestFisher(input, defs, pkg);
     exporter = new StructureDefinitionExporter(input, pkg, fisher);
   });

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -50,7 +50,7 @@ describe('StructureDefinitionExporter', () => {
       version: '0.0.1',
       canonical: 'http://example.com'
     });
-    pkg = new Package(input.config);
+    pkg = new Package(input.packageJSON);
     fisher = new TestFisher(input, defs, pkg);
     exporter = new StructureDefinitionExporter(input, pkg, fisher);
     loggerSpy.reset();
@@ -93,7 +93,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.modifierExtension).toBeUndefined();
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo'); // constructed from canonical and id
     expect(exported.identifier).toBeUndefined();
-    expect(exported.version).toBe('0.0.1'); // provided by config
+    expect(exported.version).toBe('0.0.1'); // provided by packageJSON
     expect(exported.name).toBe('Foo'); // provided by user
     expect(exported.title).toBeUndefined();
     expect(exported.status).toBe('active'); // always active
@@ -233,7 +233,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.modifierExtension).toBeUndefined();
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo'); // constructed from canonical and id
     expect(exported.identifier).toBeUndefined();
-    expect(exported.version).toBe('0.0.1'); // provided by config
+    expect(exported.version).toBe('0.0.1'); // provided by packageJSON
     expect(exported.name).toBe('Foo'); // provided by user
     expect(exported.title).toBeUndefined();
     expect(exported.status).toBe('active'); // always active

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -36,7 +36,7 @@ describe('ValueSetExporter', () => {
       version: '0.0.1',
       canonical: 'http://example.com'
     });
-    const pkg = new Package(input.config);
+    const pkg = new Package(input.packageJSON);
     const fisher = new TestFisher(input, defs, pkg);
     exporter = new ValueSetExporter(input, pkg, fisher);
   });

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -5,7 +5,7 @@ import os from 'os';
 import { IGExporter } from '../../src/ig';
 import { StructureDefinition, InstanceDefinition, CodeSystem } from '../../src/fhirtypes';
 import { Package } from '../../src/export';
-import { Config } from '../../src/fshtypes';
+import { PackageJSON } from '../../src/fshtypes';
 import { loggerSpy } from '../testhelpers/loggerSpy';
 import { FHIRDefinitions, loadFromPath, loadCustomResources } from '../../src/fhirdefs';
 import { TestFisher } from '../testhelpers';
@@ -27,8 +27,8 @@ describe('IGExporter', () => {
         defs
       );
       const fixtures = path.join(__dirname, 'fixtures', 'simple-ig');
-      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package(config);
+      const packageJSON: PackageJSON = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(packageJSON);
       const profiles = path.join(fixtures, 'profiles');
       fs.readdirSync(profiles).forEach(f => {
         if (f.endsWith('.json')) {
@@ -381,8 +381,8 @@ describe('IGExporter', () => {
         defs
       );
       const fixtures = path.join(__dirname, 'fixtures', 'simple-ig');
-      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package(config);
+      const packageJSON: PackageJSON = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(packageJSON);
 
       exporter = new IGExporter(pkg, defs, path.resolve(fixtures, 'ig-data'), true); // set to true to indicate ig publisher context
       tempOut = temp.mkdirSync('sushi-test');
@@ -446,8 +446,8 @@ describe('IGExporter', () => {
         defs
       );
       const fixtures = path.join(__dirname, 'fixtures', 'non-hl7-ig');
-      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package(config);
+      const packageJSON: PackageJSON = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(packageJSON);
 
       exporter = new IGExporter(pkg, defs, path.resolve(fixtures, 'ig-data'));
       tempOut = temp.mkdirSync('sushi-test');
@@ -531,8 +531,8 @@ describe('IGExporter', () => {
 
     beforeAll(() => {
       const fixtures = path.join(__dirname, 'fixtures', 'customized-ig');
-      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package(config);
+      const packageJSON: PackageJSON = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(packageJSON);
       exporter = new IGExporter(pkg, new FHIRDefinitions(), path.resolve(fixtures, 'ig-data'));
       tempOut = temp.mkdirSync('sushi-test');
       // No need to regenerate the IG on every test -- generate it once and inspect what you
@@ -804,8 +804,8 @@ describe('IGExporter', () => {
 
     beforeAll(() => {
       const fixtures = path.join(__dirname, 'fixtures', 'customized-ig-with-local-template');
-      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package(config);
+      const packageJSON: PackageJSON = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(packageJSON);
       exporter = new IGExporter(pkg, new FHIRDefinitions(), path.resolve(fixtures, 'ig-data'));
       tempOut = temp.mkdirSync('sushi-test');
       exporter.export(tempOut);
@@ -831,8 +831,8 @@ describe('IGExporter', () => {
 
     beforeAll(() => {
       const fixtures = path.join(__dirname, 'fixtures', 'customized-ig-with-index-xml');
-      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package(config);
+      const packageJSON: PackageJSON = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(packageJSON);
       exporter = new IGExporter(pkg, new FHIRDefinitions(), path.resolve(fixtures, 'ig-data'));
       tempOut = temp.mkdirSync('sushi-test');
       // No need to regenerate the IG on every test -- generate it once and inspect what you
@@ -883,8 +883,8 @@ describe('IGExporter', () => {
         defs
       );
       const fixtures = path.join(__dirname, 'fixtures', 'customized-ig-with-resources');
-      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package(config);
+      const packageJSON: PackageJSON = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(packageJSON);
       loadCustomResources(fixtures, defs);
 
       // Add a patient to the package that will be overwritten
@@ -1069,8 +1069,8 @@ describe('IGExporter', () => {
 
     beforeAll(() => {
       const fixtures = path.join(__dirname, 'fixtures', 'invalid-data-ig');
-      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package(config);
+      const packageJSON: PackageJSON = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(packageJSON);
       exporter = new IGExporter(pkg, new FHIRDefinitions(), path.resolve(fixtures, 'ig-data'));
       tempOut = temp.mkdirSync('sushi-test');
       // No need to regenerate the IG on every test -- generate it once and inspect what you
@@ -1200,8 +1200,8 @@ describe('IGExporter', () => {
 
     beforeAll(() => {
       const fixtures = path.join(__dirname, 'fixtures', 'sorted-pages-ig');
-      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package(config);
+      const packageJSON: PackageJSON = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(packageJSON);
       exporter = new IGExporter(pkg, new FHIRDefinitions(), path.resolve(fixtures, 'ig-data'));
       tempOut = temp.mkdirSync('sushi-test');
       // No need to regenerate the IG on every test -- generate it once and inspect what you
@@ -1293,8 +1293,8 @@ describe('IGExporter', () => {
 
     beforeAll(() => {
       const fixtures = path.join(__dirname, 'fixtures', 'name-collision-ig');
-      const config: Config = fs.readJSONSync(path.join(fixtures, 'package.json'));
-      pkg = new Package(config);
+      const packageJSON: PackageJSON = fs.readJSONSync(path.join(fixtures, 'package.json'));
+      pkg = new Package(packageJSON);
       exporter = new IGExporter(pkg, new FHIRDefinitions(), path.resolve(fixtures, 'ig-data'));
       tempOut = temp.mkdirSync('sushi-test');
       // No need to regenerate the IG on every test -- generate it once and inspect what you

--- a/test/import/fixtures/example-config.yaml
+++ b/test/import/fixtures/example-config.yaml
@@ -1,0 +1,198 @@
+# This IG YML file is inspired by the ImplementationGuide resource
+# and also draws from package.json, package-list.json, and ig.ini.
+# That said, it is structured for ease-of-use, so it is not strictly
+# conformant to any of those existing configuration formats.
+
+# SUSHI will use id as both id and packageId in the IG unless a
+# specific packageId is also provided in this file.
+id: fhir.us.example
+url: http://hl7.org/fhir/us/example
+name: ExampleIG
+title: "HL7 FHIR Implementation Guide: Example IG Release 1 - US Realm | STU1"
+description: Example IG exercises many of the fields in a SUSHI configuration.
+status: active
+license: CC0-1.0
+date: 2020-02-26
+version: 1.0.0
+
+# Although fhirVersions is 0..* in the ImplementationGuide resource
+# it can be a single item OR and array here (but so far SUSHI only
+# support 4.0.1 anyway).
+fhirVersion: 4.0.1
+
+# The template property will be copied into the ig.ini file.
+# If the value of template is "none", then only the resources will be
+# generated (with no supporting ImplementationGuide sources).
+template: hl7.fhir.template#0.0.5
+
+# The following two lines correspond to items that used to be in
+# ig.ini but were recently moved to IG.definition.parameter. For
+# consistency within this file, the names are represented using
+# camelcase, but if authors use the formal parameter names, SUSHI
+# will recognize them as well. In either case, they'll be copied
+# to the IG JSON using the formal names.
+copyrightYear: 2019+
+releaseLabel: STU1
+
+# The publisher can be a single item or a list, each with a name and
+# optional url and/or email. The first publisher's name will be used
+# as IG.publisher.  The contact details and/or additional publishers
+# will be translated into IG.contact values.
+publisher:
+  name: HL7 FHIR Management Group
+  url: http://www.hl7.org/Special/committees/fhirmg
+  email: fmg@lists.HL7.org
+
+# Those who need more control or want to add additional details to the contact values can use
+# contact directly and follow the format outlined in the ImplementationGuide resource and
+# ContactDetail.
+contact:
+  - name: Bob Smith
+    telecom:
+      - system: email
+        value: bobsmith@example.org
+        use: work
+
+# The jurisdiction can be a single item or a list. The FHIR Shorthand
+# code syntax can be used here.
+jurisdiction: urn:iso:std:iso:3166#US "United States of America"
+
+# The dependencies property corresponds to IG.dependsOn. They key is the
+# package id and the value is the version (or dev/current).
+dependencies:
+  hl7.fhir.us.core: 3.1.0
+
+# The global property corresponds to the IG.global property, but it
+# uses the type as the YAML key and the profile as its value. Since
+# FHIR does not explicitly disallow more than one profile per type,
+# neither do we; the value can be a single profile URL or an array
+# of profile URLs.
+global:
+  Patient: http://example.org/fhir/StructureDefinition/my-patient-profile
+  Encounter: http://example.org/fhir/StructureDefinition/my-encounter-profile
+
+# The resources property corresponds to IG.definition.resource.
+# SUSHI can auto-generate all of the resource entries based on
+# the FSH definitions and/or information in any user-provided
+# JSON resource files. If the generated entries are not
+# sufficient or complete, however, the author can add entries
+# here. If the reference matches a generated entry, it will
+# replace the generated entry. If it doesn't match any generated
+# entries, it will be added to the generated entries. The format
+# follows IG.definition.resource with the following differences:
+#   * use IG.definition.resource.reference.reference as the YAML key
+#   * specify "omit" to omit a FSH-generated resource from the
+#     resource list.
+#   * groupingId can be used, but top-level groups syntax may be a
+#     better option (see below).
+# The following are simple examples to demonstrate what this might
+# look like:
+resources:
+  Patient/my-example-patient:
+    name: My Example Patient
+    description: An example Patient
+    exampleBoolean: true
+  Patient/bad-example: omit
+
+# Groups can control certain aspects of the IG generation.  The IG
+# documentation recommends that authors use the default groups that
+# are provided by the templating framework, but if authors want to
+# use their own instead, they can use the mechanism below.  This will
+# create IG.definition.grouping entries and associate the individual
+# resource entries with the corresponding groupIds.
+groups:
+  GroupA:
+    description: The Alpha Group
+    resources:
+    - StructureDefinition/animal-patient
+    - StructureDefinition/arm-procedure
+  GroupB:
+    description: The Beta Group
+    resources:
+    - StructureDefinition/bark-control
+    - StructureDefinition/bee-sting
+
+# The pages property corresponds to IG.definition.page. SUSHI can
+# auto-generate the page list, but if the author includes pages in
+# this file, it is assumed that the author will fully manage the
+# pages section and SUSHI will not generate any page entries.
+# The page file name is used as the key. If title is not provided,
+# then the title will be generated from the file name.  If a
+# generation value is not provided, it will be inferred from the
+# file name extension.  Any subproperties that are valid filenames
+# with supported extensions (e.g., .md/.xml) will be treated as
+# sub-pages.
+pages:
+  index.md:
+    title: Example Home
+  implementation.xml:
+  examples.xml:
+    title: Examples Overview
+    simpleExamples.xml:
+    complexExamples.xml:
+
+# The menu property will be used to generate the input/menu.xml file.
+# The menu is represented as a simple structure where the YAML key
+# is the menu item name and the value is the URL. The IG publisher
+# currently only supports one level deep on sub-menus.
+# TO CONSIDER: If no menu data is provided, can we generate the menu
+# based on the pages order or should we just generate a very standard
+# menu (since there may be too many pages to fit in a menu).
+menu:
+  Home: index.html
+  Artifacts:
+    Profiles: artifacts.html#2
+    Extensions: artifacts.html#3
+    Value Sets: artifacts.html#4
+  Downloads: downloads.html
+  History: http://hl7.org/fhir/us/example/history.html
+
+# The parameters property represents IG.definition.parameter. Rather
+# than a list of code/value pairs (as in the ImplementationGuide
+# resource, the code is the YAML key. If a parameter allows repeating
+# values, the value in the YAML should be a sequence/array. For a
+# partial list of allowed parameters see:
+# https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+parameters:
+  excludettl: true
+  validation: [allow-any-extensions, no-broken-links]
+
+# The history property corresponds to package-list.json. SUSHI will
+# use the existing top-level properties in its config to populate the
+# top-level package-list.json properties: packageId, canonical, title,
+# and introduction. Authors that wish to provide different values can
+# supply them as properties under history. All other properties under
+# history are assumed to be versions.
+history:
+  # The current version is special. If the author provides only a
+  # single value, it is assumed to be the URL path to the current
+  # build. The following default values will then be used:
+  #   desc: Continuous Integration Build (latest in version control)
+  #   status: ci-build
+  #   current: true
+  current: http://build.fhir.org/ig/HL7/example-ig/
+  # All other versions need each of their values fully specified.
+  # See: https://confluence.hl7.org/pages/viewpage.action?pageId=66928420#FHIRIGPackageListdoco-PublicationObject
+  1.0.0:
+    fhirversion: 4.0.1
+    date: 2020-03-06
+    desc: STU 1 Release
+    path: https://hl7.org/fhir/us/example/STU1/
+    status: trial-use
+    sequence: STU 1
+    current: true
+  0.9.1:
+    fhirversion: 4.0.0
+    date: 2019-06-10
+    desc: Initial STU ballot (Sep 2019 Ballot)
+    path: https://hl7.org/fhir/us/example/2019Sep/
+    status: ballot
+    sequence: STU 1
+
+# The ImplementationGuide resource defines several other properties
+# not represented above. These properties can be used as-is and
+# should follow the format defined in ImplementationGuide:
+# * experimental
+# * useContext
+# * copyright
+# * definition.template (but use a top-level "templates" property)

--- a/test/import/fixtures/minimal-config.yaml
+++ b/test/import/fixtures/minimal-config.yaml
@@ -1,0 +1,7 @@
+id: fhir.us.minimal
+url: http://hl7.org/fhir/us/minimal
+name: MinimalIG
+status: draft
+version: 1.0.0
+fhirVersion: 4.0.1
+template: hl7.fhir.template#0.0.5

--- a/test/utils/MasterFisher.test.ts
+++ b/test/utils/MasterFisher.test.ts
@@ -10,7 +10,7 @@ import path from 'path';
 describe('MasterFisher', () => {
   let fisher: MasterFisher;
   beforeAll(() => {
-    const config = {
+    const packageJSON = {
       name: 'test',
       canonical: 'http://example.org',
       version: '0.0.1'
@@ -35,9 +35,9 @@ describe('MasterFisher', () => {
     );
     doc1.profiles.get('Practitioner').id = 'my-dr';
     doc1.profiles.get('Practitioner').parent = 'Practitioner';
-    const tank = new FSHTank([doc1], config);
+    const tank = new FSHTank([doc1], packageJSON);
 
-    const pkg = new Package(config);
+    const pkg = new Package(packageJSON);
     const profile3 = new StructureDefinition();
     profile3.name = 'Profile3';
     profile3.id = 'profile3';


### PR DESCRIPTION
This PR renames the old `Config` type to `PackageJSON` and adds a new `Configuration` type.  This will hopefully reduce confusion and make it easier to know which config we're talking about (while they both exist).

The new `Configuration` type is not hooked into anywhere -- it is just an unused type at this point.  I wanted to get this into the code now so that the rest of the team can begin implementing exporters for it.  This type is not a 1:1 mapping to the YAML format, as I felt that would make the file harder for us to use with the exporters; so instead it's designed to be a little friendlier with the exporters.

I'm working on a `YAMLConfiguration` type that resembles the exact JSON you would receive from parsing a YAML file directly and also working on an importer that will convert the `YAMLConfiguration` format to the friendlier `Configuration` format.  As it turns out, it's way more tedious than expected and TypeScript is maybe not my friend right now.  All that will come in a separate PR. But the rest of the team shouldn't need that to get started on exporters and unit tests!

Also note that this PR is set to merge into a `config-yaml` branch.  Since the new config is kind of a big feature, I don't want to release parts of it before all of it is ready -- so I propose that all config-related features get merged into `config-yaml`, and once everything is done, we'll merge `config-yaml` into `master`.  Of course, if you think this is a bad idea, let me know!