### PR TITLE
Allow fixing values on slices with no discriminators

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1172,7 +1172,7 @@ export class ElementDefinition {
     parentSlices.forEach(parentSlice => {
       const slicedElement = parentSlice.slicedElement();
       if (
-        slicedElement.slicing.discriminator.some(
+        slicedElement.slicing.discriminator?.some(
           d =>
             `${slicedElement.path}${d.path === '$this' ? '' : `.${d.path}`}` === this.path &&
             ['value', 'pattern'].includes(d.type)

--- a/test/fhirtypes/ElementDefinition.fixValue.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixValue.test.ts
@@ -166,6 +166,17 @@ describe('ElementDefinition', () => {
       expect(catMouseCoding.patternCoding).toEqual({ code: 'cheese' });
       expect(catMouseCoding.min).toBe(2); // We do not try to decrease min to 1
     });
+
+    it('should not ensure that minimum cardinality is 1 when fixing a value with no parent slice discriminator', () => {
+      const cat = medicationRequest.elements.find(e => e.id === 'MedicationRequest.category');
+      cat.slicing = { rules: 'open' };
+      cat.addSlice('mouse');
+      const catMouseCoding = medicationRequest.findElementByPath('category[mouse].coding', fisher);
+      expect(catMouseCoding.min).toBe(0);
+      catMouseCoding.fixValue(new FshCode('cheese'));
+      expect(catMouseCoding.patternCoding).toEqual({ code: 'cheese' });
+      expect(catMouseCoding.min).toBe(0); // We do not increase min, since no discriminator
+    });
   });
 
   describe('#fixedByDirectParent', () => {


### PR DESCRIPTION
This fixes https://github.com/FHIR/sushi/issues/362. 

This was a new bug introduced in 0.12.0 that causes SUSHI to log an error when trying to fix a value on a slice for which the corresponding slicing does not have a discriminator. The issue contains a fully detailed example of this situation.

To test this, you can use the example shown in the issue to compare running SUSHI on that example on this branch, versus running SUSHI on that example on master. On master you will see the incorrect error message, and on this branch you should not. I also added a test of this situation.