### PR TITLE
Set jest maxWorkers to 4 (performance tuning)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "rm -rf dist && tsc && cp -r src/ig/files dist/ig/files",
     "build:watch": "tsc -w",
     "build:grammar": "bash antlr/gradlew -p antlr generateGrammarSource",
-    "test": "jest --coverage",
+    "test": "jest --maxWorkers=4 --coverage",
     "test:watch": "npm run test -- --watchAll",
     "coverage": "opener coverage/lcov-report/index.html",
     "lint": "tsc && eslint \"**/*.{js,ts}\"",


### PR DESCRIPTION
Jest has some recommendations for improving test speed in CI here: https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server

I tested these locally and found that --runInBand was slower, but --maxWorkers=4 reduced average test time from 30-35 sec down to 20 -25 sec.