### PR TITLE
Remove inline instances from IG.json

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -455,26 +455,28 @@ export class IGExporter {
       this.pkg.instances,
       instance => instance.id ?? instance._instanceMeta.name
     );
-    instances.forEach(instance => {
-      const resource: ImplementationGuideDefinitionResource = {
-        reference: {
-          reference: `${instance.resourceType}/${instance.id ?? instance._instanceMeta.name}`
-        },
-        name: instance._instanceMeta.title ?? instance._instanceMeta.name,
-        description: instance._instanceMeta.description
-      };
-      if (instance._instanceMeta.usage === 'Example') {
-        const exampleUrl = instance.meta?.profile?.find(url => this.pkg.fish(url, Type.Profile));
-        if (exampleUrl) {
-          resource.exampleCanonical = exampleUrl;
+    instances
+      .filter(instance => instance._instanceMeta.usage !== 'Inline')
+      .forEach(instance => {
+        const resource: ImplementationGuideDefinitionResource = {
+          reference: {
+            reference: `${instance.resourceType}/${instance.id ?? instance._instanceMeta.name}`
+          },
+          name: instance._instanceMeta.title ?? instance._instanceMeta.name,
+          description: instance._instanceMeta.description
+        };
+        if (instance._instanceMeta.usage === 'Example') {
+          const exampleUrl = instance.meta?.profile?.find(url => this.pkg.fish(url, Type.Profile));
+          if (exampleUrl) {
+            resource.exampleCanonical = exampleUrl;
+          } else {
+            resource.exampleBoolean = true;
+          }
         } else {
-          resource.exampleBoolean = true;
+          resource.exampleBoolean = false;
         }
-      } else {
-        resource.exampleBoolean = false;
-      }
-      this.ig.definition.resource.push(resource);
-    });
+        this.ig.definition.resource.push(resource);
+      });
   }
 
   /**

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -48,6 +48,9 @@ describe('IGExporter', () => {
         if (f.endsWith('.json')) {
           const instanceDef = InstanceDefinition.fromJSON(fs.readJSONSync(path.join(examples, f)));
           // since instance meta isn't encoded in the JSON, add some here (usually done in the FSH import)
+          if (instanceDef.id === 'patient-example-three') {
+            instanceDef._instanceMeta.usage = 'Inline';
+          }
           if (instanceDef.id === 'patient-example-two') {
             instanceDef._instanceMeta.title = 'Another Patient Example';
             instanceDef._instanceMeta.description = 'Another example of a Patient';

--- a/test/ig/fixtures/simple-ig/examples/Patient-example-three.json
+++ b/test/ig/fixtures/simple-ig/examples/Patient-example-three.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-example-three",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "code": "2160-3",
+            "system": "urn:oid:2.16.840.1.113883.6.238"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "value": "1032702"
+    }
+  ],
+  "name": [
+    {
+      "family": "Shaw",
+      "given": ["Amy", "V."]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #366 

When Instances were specified as `#inline`, they were correctly not being written to JSON files, but references to these resources were incorrectly still being added to the IG.json. Then the IG Publisher would crash, because it expects the resources defined in IG.json to exist, but no JSON file for these resources exists. This fixes that by not adding `#inline` resources to the IG.json. One way to test is to checkout https://github.com/FHIR/sushi/commit/2b5bddfb5bf4ecfa5057cb8501b39fb64afae448 and run the tests in IGExporter.test.ts that now test with an `#inline` resource. The tests will fail, because a reference to the Instance does get added to the IG.json. Then checkout this branch, and you will see that the test passes because the instance is not added.

Another good test is to use the example referenced in the issue, and ensure that you can build that example on this branch, and successfully build using the IG Publisher. On master, you should be able to successfully build the same example using SUSHI, but the IG Publisher step should fail, because the reference to the `#inline` resource will still be added to IG.json.