### PR TITLE
Override inline instances

### DIFF
--- a/src/errors/InvalidResourceTypeError.ts
+++ b/src/errors/InvalidResourceTypeError.ts
@@ -1,0 +1,8 @@
+import { Annotated } from './Annotated';
+
+export class InvalidResourceTypeError extends Error implements Annotated {
+  specReferences = ['https://www.hl7.org/fhir/resourcelist.html'];
+  constructor(public resourceType: string, public elementType: string) {
+    super(`A resourceType of ${resourceType} cannot be set on an element of type ${elementType}.`);
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -39,3 +39,4 @@ export * from './MultipleStandardsStatusError';
 export * from './InvalidMappingError';
 export * from './InvalidFHIRIdError';
 export * from './ParentDeclaredAsProfileNameError';
+export * from './InvalidResourceTypeError';

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -50,7 +50,7 @@ export class InstanceExporter implements Fishable {
       if (r.isResource && r.fixedValue instanceof InstanceDefinition) {
         inlineResourcePaths.push({
           path: r.path,
-          instanceOf: r.fixedValue.resourceType
+          instanceOf: r.fixedValue.meta?.profile[0] ?? r.fixedValue.resourceType
         });
       }
       if (r.path.endsWith('.resourceType') && typeof r.fixedValue === 'string') {

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -45,6 +45,21 @@ export class InstanceExporter implements Fishable {
       }
       return true;
     });
+    const inlineResourcePaths: { path: string; instanceOf: string }[] = [];
+    rules.forEach(r => {
+      if (r.isResource && r.fixedValue instanceof InstanceDefinition) {
+        inlineResourcePaths.push({
+          path: r.path,
+          instanceOf: r.fixedValue.resourceType
+        });
+      }
+      if (r.path.endsWith('.resourceType') && typeof r.fixedValue === 'string') {
+        inlineResourcePaths.push({
+          path: splitOnPathPeriods(r.path).slice(0, -1).join('.'),
+          instanceOf: r.fixedValue
+        });
+      }
+    });
 
     // When fixing values, things happen in the order:
     // 1 - Validate values for rules that are on the instance
@@ -57,14 +72,28 @@ export class InstanceExporter implements Fishable {
     const ruleMap: Map<string, { pathParts: PathPart[]; fixedValue: any }> = new Map();
     rules.forEach(rule => {
       try {
-        const { fixedValue, pathParts } = instanceOfStructureDefinition.validateValueAtPath(
+        const matchingInlineResourcePaths = inlineResourcePaths.filter(
+          i =>
+            rule.path.startsWith(i.path) &&
+            rule.path !== i.path &&
+            rule.path != `${i.path}.resourceType`
+        );
+        const inlineResourceTypes: string[] = [];
+        matchingInlineResourcePaths.forEach(match => {
+          inlineResourceTypes[splitOnPathPeriods(match.path).length - 1] = match.instanceOf;
+        });
+        const validatedRule = instanceOfStructureDefinition.validateValueAtPath(
           rule.path,
           rule.fixedValue,
           this.fisher,
-          rule.units
+          rule.units,
+          inlineResourceTypes
         );
         // Record each valid rule in a map
-        ruleMap.set(rule.path, { pathParts, fixedValue });
+        ruleMap.set(rule.path, {
+          pathParts: validatedRule.pathParts,
+          fixedValue: validatedRule.fixedValue
+        });
       } catch (e) {
         logger.error(e.message, rule.sourceInfo);
       }

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -27,6 +27,10 @@ export class InstanceExporter implements Fishable {
     instanceOfStructureDefinition: StructureDefinition
   ): InstanceDefinition {
     let rules = fshInstanceDef.rules.map(r => cloneDeep(r));
+    // Normalize all rules to not use the optional [0] index
+    rules.forEach(r => {
+      r.path = r.path.replace(/\[0+\]/g, '');
+    });
     rules = rules.map(r => replaceReferences(r, this.tank, this.fisher));
     // Convert strings in fixedValueRules to instances
     rules = rules.filter(r => {

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -525,7 +525,7 @@ export class StructureDefinition {
         pathPart.primitive = true;
       }
 
-      // If we have inlineResourceTypes at this pathPart, we need to validate using that
+      // If we have inlineResourceTypes at this pathPart, we need to validate recursively using that
       // inline resource type, not the original type of the currentElement
       if (
         inlineResourceTypes.length > 0 &&
@@ -547,7 +547,7 @@ export class StructureDefinition {
               value,
               fisher,
               units,
-              inlineResourceTypes.slice(1)
+              inlineResourceTypes.slice(i + 1)
             );
             return {
               fixedValue: validatedInlineResource.fixedValue,

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -531,9 +531,13 @@ export class StructureDefinition {
         inlineResourceTypes.length > 0 &&
         inlineResourceTypes[i] &&
         currentElement.type?.length === 1 &&
-        isInheritedResource(inlineResourceTypes[i], currentElement.type[0].code, fisher)
+        isInheritedResource(inlineResourceTypes[i], currentElement.type[0].code, fisher, true)
       ) {
-        const inlineResourceJSON = fisher.fishForFHIR(inlineResourceTypes[i], Type.Resource);
+        const inlineResourceJSON = fisher.fishForFHIR(
+          inlineResourceTypes[i],
+          Type.Resource,
+          Type.Profile
+        );
         if (inlineResourceJSON) {
           const inlineResourceStructDef = StructureDefinition.fromJSON(inlineResourceJSON);
           const inlinePath = this.assembleFSHPath(pathParts.slice(i + 1));

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -311,19 +311,30 @@ export function getAllImpliedPaths(element: ElementDefinition, path: string): st
  * @param {string} resourceType - The resourceType to test inheritance of
  * @param {string} type - The original type being inherited from
  * @param {Fishable} fisher - A fisher for finding FHIR definitions
+ * @param {boolean} allowProfile - True if profiles of inherited resource should be allowed
  * @returns {boolean} true if resourceType is a valid sub-type of type, false otherwise
  */
-export function isInheritedResource(resourceType: string, type: string, fisher: Fishable): boolean {
-  const resource = fisher.fishForFHIR(resourceType, Type.Resource);
-  return (
-    resource &&
-    (type === 'Resource' ||
+export function isInheritedResource(
+  resourceType: string,
+  type: string,
+  fisher: Fishable,
+  allowProfile = false
+): boolean {
+  const types = allowProfile ? [Type.Resource, Type.Profile] : [Type.Resource];
+  const resource = fisher.fishForFHIR(resourceType, ...types);
+  if (resource) {
+    if (allowProfile) {
+      resourceType = resource.resourceType;
+    }
+    return (
+      type === 'Resource' ||
       (type === 'DomainResource' &&
         // These are the only 3 resources not inherited from DomainResource
         // https://www.hl7.org/fhir/domainresource.html#bnr
         !['Bundle', 'Parameters', 'Binary'].includes(resourceType)) ||
-      type === resourceType)
-  );
+      type === resourceType
+    );
+  }
 }
 
 const nameRegex = /^[A-Z]([A-Za-z0-9_]){0,254}$/;

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -304,6 +304,28 @@ export function getAllImpliedPaths(element: ElementDefinition, path: string): st
   return finalPaths;
 }
 
+/**
+ * Tests if resourceType is a valid FHIR resource that is a subtype of type. This is the case
+ * if type is Resource, or if type is DomainResource and resourceType is one of the resources
+ * that inherits from DomainResource, or if type is equal to resourceType.
+ * @param {string} resourceType - The resourceType to test inheritance of
+ * @param {string} type - The original type being inherited from
+ * @param {Fishable} fisher - A fisher for finding FHIR definitions
+ * @returns {boolean} true if resourceType is a valid sub-type of type, false otherwise
+ */
+export function isInheritedResource(resourceType: string, type: string, fisher: Fishable): boolean {
+  const resource = fisher.fishForFHIR(resourceType, Type.Resource);
+  return (
+    resource &&
+    (type === 'Resource' ||
+      (type === 'DomainResource' &&
+        // These are the only 3 resources not inherited from DomainResource
+        // https://www.hl7.org/fhir/domainresource.html#bnr
+        !['Bundle', 'Parameters', 'Binary'].includes(resourceType)) ||
+      type === resourceType)
+  );
+}
+
 const nameRegex = /^[A-Z]([A-Za-z0-9_]){0,254}$/;
 
 export class HasName {

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -1535,6 +1535,38 @@ describe('InstanceExporter', () => {
           }
         ]);
       });
+
+      it('should override an inline profile on an instance', () => {
+        const inlineBundle = new Instance('MyBundle');
+        inlineBundle.instanceOf = 'TestBundle';
+        doc.instances.set(inlineBundle.name, inlineBundle);
+
+        const bundleRule = new FixedValueRule('contained[0]');
+        bundleRule.fixedValue = 'MyBundle';
+        bundleRule.isResource = true;
+        const birthDateRule = new FixedValueRule(
+          'contained[0].entry[PatientsOnly].resource.birthDate'
+        );
+        birthDateRule.fixedValue = '2000-02-24';
+        // contained[0] = MyBundle
+        // contained[0].entry[PatientsOnly].resource.birthDate = "2000-02-24"
+        patientInstance.rules.push(bundleRule, birthDateRule);
+        const exported = exportInstance(patientInstance);
+        expect(exported.contained).toEqual([
+          {
+            id: 'MyBundle',
+            meta: { profile: ['http://example.com/StructureDefinition/TestBundle'] },
+            resourceType: 'Bundle',
+            entry: [
+              {
+                resource: {
+                  birthDate: '2000-02-24'
+                }
+              }
+            ]
+          }
+        ]);
+      });
     });
   });
 

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -1514,7 +1514,7 @@ describe('InstanceExporter', () => {
         patientRule.isResource = true;
         const birthDateRule = new FixedValueRule('contained[0].entry[0].resource.birthDate');
         birthDateRule.fixedValue = '2000-02-24';
-        // * contained[0].resourceType = Bundle
+        // * contained[0].resourceType = "Bundle"
         // * contained[0].entry[0].resource = MyInlinePatient
         // * contained[0].entry[0].resource.birthDate = "2000-02-24"
         patientInstance.rules.push(bundleRule, patientRule, birthDateRule);

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -1388,61 +1388,6 @@ describe('InstanceExporter', () => {
       );
     });
 
-    it('should fix an inline resource to an instance', () => {
-      const inlineInstance = new Instance('MyInlinePatient');
-      inlineInstance.instanceOf = 'Patient';
-      const fixedValRule = new FixedValueRule('active');
-      fixedValRule.fixedValue = true;
-      inlineInstance.rules.push(fixedValRule); // * active = true
-      doc.instances.set(inlineInstance.name, inlineInstance);
-
-      const inlineRule = new FixedValueRule('contained[0]');
-      inlineRule.fixedValue = 'MyInlinePatient';
-      inlineRule.isResource = true;
-      patientInstance.rules.push(inlineRule); // * contained[0] = MyInlinePatient
-
-      const exported = exportInstance(patientInstance);
-      expect(exported.contained).toEqual([
-        { resourceType: 'Patient', id: 'MyInlinePatient', active: true }
-      ]);
-    });
-
-    it('should fix an inline resource to an instance element with a specific type', () => {
-      const inlineInstance = new Instance('MyInlinePatient');
-      inlineInstance.instanceOf = 'Patient';
-      const fixedValRule = new FixedValueRule('active');
-      fixedValRule.fixedValue = true;
-      inlineInstance.rules.push(fixedValRule);
-      // * active = true
-      doc.instances.set(inlineInstance.name, inlineInstance);
-
-      const caretRule = new CaretValueRule('entry');
-      caretRule.caretPath = 'slicing.discriminator.type';
-      caretRule.value = new FshCode('value');
-      const containsRule = new ContainsRule('entry');
-      containsRule.items = [{ name: 'PatientsOnly' }];
-      const cardRule = new CardRule('entry[PatientsOnly]');
-      cardRule.min = 0;
-      cardRule.max = '1';
-      const typeRule = new OnlyRule('entry[PatientsOnly].resource');
-      typeRule.types = [{ type: 'Patient' }];
-      // * entry ^slicing.discriminator.type = #value
-      // * entry contains Patient 0..1
-      // * entry[PatientsOnly].resource only Patient
-      bundle.rules.push(caretRule, containsRule, cardRule, typeRule);
-
-      const bundleValRule = new FixedValueRule('entry[PatientsOnly].resource');
-      bundleValRule.fixedValue = 'MyInlinePatient';
-      bundleValRule.isResource = true;
-      // * entry[PatientsOnly].resource = MyInlinePatient
-      bundleInstance.rules.push(bundleValRule);
-
-      const exported = exportInstance(bundleInstance);
-      expect(exported.entry[0]).toEqual({
-        resource: { resourceType: 'Patient', id: 'MyInlinePatient', active: true }
-      });
-    });
-
     it('should only export an instance once', () => {
       const bundleInstance = new Instance('MyBundle');
       bundleInstance.instanceOf = 'Bundle';
@@ -1468,19 +1413,128 @@ describe('InstanceExporter', () => {
       expect(exportedBundledPatient).toHaveLength(1);
     });
 
-    it('should log an error when fixing an inline resource that does not exist to an instance', () => {
-      const inlineRule = new FixedValueRule('contained[0]')
-        .withFile('FakeInstance.fsh')
-        .withLocation([1, 2, 3, 4]);
-      inlineRule.fixedValue = 'MyFakePatient';
-      inlineRule.isResource = true;
-      patientInstance.rules.push(inlineRule); // * contained[0] = MyFakePatient
+    describe('#Inline Instances', () => {
+      beforeEach(() => {
+        const inlineInstance = new Instance('MyInlinePatient');
+        inlineInstance.instanceOf = 'Patient';
+        const fixedValRule = new FixedValueRule('active');
+        fixedValRule.fixedValue = true;
+        inlineInstance.rules.push(fixedValRule);
+        // * active = true
+        doc.instances.set(inlineInstance.name, inlineInstance);
 
-      const exported = exportInstance(patientInstance);
-      expect(exported.contained).toBeUndefined();
-      expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Cannot find definition for Instance: MyFakePatient. Skipping rule.*File: FakeInstance.fsh.*Line: 1 - 3\D*/s
-      );
+        const caretRule = new CaretValueRule('entry');
+        caretRule.caretPath = 'slicing.discriminator.type';
+        caretRule.value = new FshCode('value');
+        const containsRule = new ContainsRule('entry');
+        containsRule.items = [{ name: 'PatientsOnly' }];
+        const cardRule = new CardRule('entry[PatientsOnly]');
+        cardRule.min = 0;
+        cardRule.max = '1';
+        const typeRule = new OnlyRule('entry[PatientsOnly].resource');
+        typeRule.types = [{ type: 'Patient' }];
+        // * entry ^slicing.discriminator.type = #value
+        // * entry contains Patient 0..1
+        // * entry[PatientsOnly].resource only Patient
+        bundle.rules.push(caretRule, containsRule, cardRule, typeRule);
+      });
+
+      it('should fix an inline resource to an instance', () => {
+        const inlineRule = new FixedValueRule('contained[0]');
+        inlineRule.fixedValue = 'MyInlinePatient';
+        inlineRule.isResource = true;
+        patientInstance.rules.push(inlineRule); // * contained[0] = MyInlinePatient
+
+        const exported = exportInstance(patientInstance);
+        expect(exported.contained).toEqual([
+          { resourceType: 'Patient', id: 'MyInlinePatient', active: true }
+        ]);
+      });
+
+      it('should fix an inline resource to an instance element with a specific type', () => {
+        const bundleValRule = new FixedValueRule('entry[PatientsOnly].resource');
+        bundleValRule.fixedValue = 'MyInlinePatient';
+        bundleValRule.isResource = true;
+        // * entry[PatientsOnly].resource = MyInlinePatient
+        bundleInstance.rules.push(bundleValRule);
+
+        const exported = exportInstance(bundleInstance);
+        expect(exported.entry[0]).toEqual({
+          resource: { resourceType: 'Patient', id: 'MyInlinePatient', active: true }
+        });
+      });
+
+      it('should log an error when fixing an inline resource that does not exist to an instance', () => {
+        const inlineRule = new FixedValueRule('contained[0]')
+          .withFile('FakeInstance.fsh')
+          .withLocation([1, 2, 3, 4]);
+        inlineRule.fixedValue = 'MyFakePatient';
+        inlineRule.isResource = true;
+        patientInstance.rules.push(inlineRule); // * contained[0] = MyFakePatient
+
+        const exported = exportInstance(patientInstance);
+        expect(exported.contained).toBeUndefined();
+        expect(loggerSpy.getLastMessage('error')).toMatch(
+          /Cannot find definition for Instance: MyFakePatient. Skipping rule.*File: FakeInstance.fsh.*Line: 1 - 3\D*/s
+        );
+      });
+
+      it('should override a fixed inline resource on an instance', () => {
+        const inlineRule = new FixedValueRule('contained[0]');
+        inlineRule.fixedValue = 'MyInlinePatient';
+        inlineRule.isResource = true;
+        const overrideRule = new FixedValueRule('contained[0].birthDate');
+        overrideRule.fixedValue = '2000-02-24';
+        // * contained[0] = MyInlinePatient
+        // * contained[0].birthDate = 2000-02-24
+        patientInstance.rules.push(inlineRule, overrideRule);
+        const exported = exportInstance(patientInstance);
+        expect(exported.contained).toEqual([
+          { resourceType: 'Patient', id: 'MyInlinePatient', active: true, birthDate: '2000-02-24' }
+        ]);
+      });
+
+      it('should override a fixed via resourceType inline resource on an instance', () => {
+        const inlineRule = new FixedValueRule('contained[0].resourceType');
+        inlineRule.fixedValue = 'Patient';
+        const overrideRule = new FixedValueRule('contained[0].birthDate');
+        overrideRule.fixedValue = '2000-02-24';
+        // * contained[0].resourceType = "Patient"
+        // * contained[0].birthDate = 2000-02-24
+        patientInstance.rules.push(inlineRule, overrideRule);
+        const exported = exportInstance(patientInstance);
+        expect(exported.contained).toEqual([{ resourceType: 'Patient', birthDate: '2000-02-24' }]);
+      });
+
+      it('should override a nested fixed inline resource on an instance', () => {
+        const bundleRule = new FixedValueRule('contained[0].resourceType');
+        bundleRule.fixedValue = 'Bundle';
+        const patientRule = new FixedValueRule('contained[0].entry[0].resource');
+        patientRule.fixedValue = 'MyInlinePatient';
+        patientRule.isResource = true;
+        const birthDateRule = new FixedValueRule('contained[0].entry[0].resource.birthDate');
+        birthDateRule.fixedValue = '2000-02-24';
+        // * contained[0].resourceType = Bundle
+        // * contained[0].entry[0].resource = MyInlinePatient
+        // * contained[0].entry[0].resource.birthDate = "2000-02-24"
+        patientInstance.rules.push(bundleRule, patientRule, birthDateRule);
+        const exported = exportInstance(patientInstance);
+        expect(exported.contained).toEqual([
+          {
+            resourceType: 'Bundle',
+            entry: [
+              {
+                resource: {
+                  resourceType: 'Patient',
+                  id: 'MyInlinePatient',
+                  active: true,
+                  birthDate: '2000-02-24'
+                }
+              }
+            ]
+          }
+        ]);
+      });
     });
   });
 

--- a/test/fhirtypes/ElementDefinition.checkFixResource.test.ts
+++ b/test/fhirtypes/ElementDefinition.checkFixResource.test.ts
@@ -30,14 +30,14 @@ describe('ElementDefinition', () => {
   describe('#checkFixResource', () => {
     it('should return a resource when it can be fixed', () => {
       const contained = observation.elements.find(e => e.id === 'Observation.contained');
-      const value = contained.checkFixResource(inlineInstance);
+      const value = contained.checkFixResource(inlineInstance, fisher);
       expect(value.resourceType).toBe('Patient');
     });
 
     it('should throw NoSingleTypeError when element has multiple types', () => {
       const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
       expect(() => {
-        valueX.checkFixResource(inlineInstance);
+        valueX.checkFixResource(inlineInstance, fisher);
       }).toThrow(
         'Cannot fix Resource value on this element since this element does not have a single type'
       );
@@ -46,7 +46,7 @@ describe('ElementDefinition', () => {
     it('should throw MismatchedTypeError when the value is fixed to a non-Resource', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
       expect(() => {
-        status.checkFixResource(inlineInstance);
+        status.checkFixResource(inlineInstance, fisher);
       }).toThrow(
         'Cannot fix Patient value: MyInlineInstance. Value does not match element type: code'
       );

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -1213,6 +1213,24 @@ describe('StructureDefinition', () => {
         ]);
       });
 
+      it('should allow overriding a Resource with a Profile', () => {
+        const unit = 'slugs';
+        const {
+          fixedValue,
+          pathParts
+        } = respRate.validateValueAtPath('contained[0].valueQuantity.unit', unit, fisher, false, [
+          'http://hl7.org/fhir/StructureDefinition/resprate',
+          null,
+          null
+        ]);
+        expect(fixedValue).toBe('slugs');
+        expect(pathParts).toEqual([
+          { base: 'contained', brackets: ['0'] },
+          { base: 'valueQuantity' },
+          { base: 'unit', primitive: true }
+        ]);
+      });
+
       it('should not allow overriding a Resource constrained to Patient with a non-Patient path', () => {
         const system = 'http://hello.com';
         expect(() =>

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -1213,6 +1213,29 @@ describe('StructureDefinition', () => {
         ]);
       });
 
+      it('should allow overriding a Resource with a Patient within a Resource overriden by a Bundle within a Bundle', () => {
+        const gender = new FshCode('F');
+        const {
+          fixedValue,
+          pathParts
+        } = respRate.validateValueAtPath(
+          'contained[0].entry[0].resource.entry[0].resource.gender',
+          gender,
+          fisher,
+          false,
+          ['Bundle', null, 'Bundle', null, 'Patient', null]
+        );
+        expect(fixedValue).toBe('F');
+        expect(pathParts).toEqual([
+          { base: 'contained', brackets: ['0'] },
+          { base: 'entry', brackets: ['0'] },
+          { base: 'resource' },
+          { base: 'entry', brackets: ['0'] },
+          { base: 'resource' },
+          { base: 'gender', primitive: true }
+        ]);
+      });
+
       it('should allow overriding a Resource with a Profile', () => {
         const unit = 'slugs';
         const {
@@ -1238,7 +1261,7 @@ describe('StructureDefinition', () => {
         ).toThrow('Cannot resolve element from path: contained[0].system');
       });
 
-      it('should not allow overriding a Resource constrained to Patient with a non-Patient inside a Resource', () => {
+      it('should not allow overriding a Resource constrained to Patient with a non-Patient path inside a Resource', () => {
         const system = 'http://hello.com';
         expect(() =>
           respRate.validateValueAtPath(
@@ -1331,6 +1354,12 @@ describe('StructureDefinition', () => {
             fisher
           )
         ).toThrow('A resourceType of Resource cannot be set on an element of type Patient.');
+      });
+
+      it('should not allow a profile resourceType to be set on a Resource element', () => {
+        expect(() =>
+          respRate.validateValueAtPath('contained[0].resourceType', 'resprate', fisher)
+        ).toThrow('A resourceType of resprate cannot be set on an element of type Resource');
       });
 
       it('should not allow an invalid FHIR resourceType to be set on a choice element', () => {

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -1154,6 +1154,82 @@ describe('StructureDefinition', () => {
           respRate.validateValueAtPath('contained[PatientsOnly][0]', instanceDef, fisher)
         ).toThrow(/Bundle.*OfJoy.*Patient/);
       });
+
+      // resourceType
+      it('should allow a valid FHIR resourceType to be set on a Resource element', () => {
+        const { fixedValue, pathParts } = respRate.validateValueAtPath(
+          'contained[0].resourceType',
+          'Patient',
+          fisher
+        );
+        expect(fixedValue).toBe('Patient');
+        expect(pathParts).toEqual([
+          { base: 'contained', brackets: ['0'] },
+          { base: 'resourceType' }
+        ]);
+      });
+
+      it('should allow a valid FHIR resourceType to be set on a DomainResource element', () => {
+        const { fixedValue, pathParts } = respRate.validateValueAtPath(
+          'contained[DomainsOnly][0].resourceType',
+          'Patient',
+          fisher
+        );
+        expect(fixedValue).toBe('Patient');
+        expect(pathParts).toEqual([
+          { base: 'contained', brackets: ['DomainsOnly', '0'] },
+          { base: 'resourceType' }
+        ]);
+      });
+
+      it('should allow a valid FHIR resourceType to be set on a Patient element', () => {
+        const { fixedValue, pathParts } = respRate.validateValueAtPath(
+          'contained[PatientsOnly][0].resourceType',
+          'Patient',
+          fisher
+        );
+        expect(fixedValue).toBe('Patient');
+        expect(pathParts).toEqual([
+          { base: 'contained', brackets: ['PatientsOnly', '0'] },
+          { base: 'resourceType' }
+        ]);
+      });
+
+      it('should not allow a resourceType to be set on a non-Resource element', () => {
+        expect(() => {
+          respRate.validateValueAtPath('code.resourceType', 'CodeableConcept', fisher);
+        }).toThrow(
+          'A resourceType of CodeableConcept cannot be set on an element of type CodeableConcept.'
+        );
+      });
+
+      it('should not allow an invalid FHIR resourceType to be set on a DomainResource element', () => {
+        expect(() =>
+          respRate.validateValueAtPath('contained[DomainsOnly][0].resourceType', 'Bundle', fisher)
+        ).toThrow('A resourceType of Bundle cannot be set on an element of type DomainResource.');
+      });
+
+      it('should not allow an invalid FHIR resourceType to be set on a Patient element', () => {
+        expect(() =>
+          respRate.validateValueAtPath(
+            'contained[PatientsOnly][0].resourceType',
+            'Resource',
+            fisher
+          )
+        ).toThrow('A resourceType of Resource cannot be set on an element of type Patient.');
+      });
+
+      it('should not allow an invalid FHIR resourceType to be set on a choice element', () => {
+        expect(() =>
+          respRate.validateValueAtPath('component.value[x].resourceType', 'Patient', fisher)
+        ).toThrow('Cannot resolve element from path: component.value[x].resourceType');
+      });
+
+      it('should not allow a resourceType to be set at the top level of the instance', () => {
+        expect(() => respRate.validateValueAtPath('resourceType', 'Patient', fisher)).toThrow(
+          'Cannot resolve element from path: resourceType'
+        );
+      });
     });
   });
 


### PR DESCRIPTION
This addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-342.

This PR enables the user to do something like this on an instance:
```
Instance: MyBundle
InstanceOf: Bundle
* entry[0].resource = MyPatient
* entry[0].resource.name.given = "Bob"
```
An instance `MyPatient` is placed on another instance, `MyBundle` in this case, and then values within `MyPatient` are modified within the context of `MyBundle`. The original values of the `MyPatient` instance should remain unchanged. 

This also made it clear that users need to be able to set `resourceType` on an element of type resource. For example, the following alternative to what is shown above could be done to get the same results:
```
Instance: MyBundle
InstanceOf: Bundle
* entry[0].resource.resourceType = "Patient"
* entry[0].resource.id = "SomePatientId"
* entry[0].resource.name.given = "Bob"
```
The `resourceType` property is a special field that has to be added because of the serialization to JSON, https://www.hl7.org/fhir/json.html#xml, so this needed special handling. 

The user should now be able to inline assign valid elements a `resourceType` or a predefined inline instance, and then modify the fields on that instance in the same way as if that instance was being defined directly and not inline.