### PR TITLE
Fix applying mapping to elements with undefined mapping

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1448,12 +1448,17 @@ export class ElementDefinition {
     if (!idRegex.test(identity)) {
       throw new InvalidFHIRIdError(identity);
     }
-    this.mapping.push({
+    const mapping = {
       identity,
       map,
       ...(comment && { comment }),
       ...(language && { language: language.code })
-    });
+    };
+    if (this.mapping) {
+      this.mapping.push(mapping);
+    } else {
+      this.mapping = [mapping];
+    }
   }
 
   /**

--- a/test/fhirtypes/ElementDefinition.applyMapping.test.ts
+++ b/test/fhirtypes/ElementDefinition.applyMapping.test.ts
@@ -35,6 +35,18 @@ describe('ElementDefinition', () => {
       expect(mapping.language).toBe('myLanguageCode');
     });
 
+    it('should apply a mapping on an element which does not have one', () => {
+      const id = observation.elements.find(e => e.id === 'Observation.id');
+      expect(id.mapping).toBeUndefined();
+      id.applyMapping('myId', 'myMap', 'myComment', new FshCode('myLanguageCode'));
+      expect(id.mapping.length).toBe(1);
+      const mapping = id.mapping[0];
+      expect(mapping.identity).toBe('myId');
+      expect(mapping.map).toBe('myMap');
+      expect(mapping.comment).toBe('myComment');
+      expect(mapping.language).toBe('myLanguageCode');
+    });
+
     it('should apply a mapping without a comment and language', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
       const originalLength = status.mapping.length;


### PR DESCRIPTION
This fixes https://github.com/FHIR/sushi/issues/372.

The example given in the issue description fails when running SUSHI on master, because the `id` element does not yet have an existing `mapping` property. This fixes that bug by allowing a `mapping` to be applied, even if the element does not have a `mapping` array currently defined. The test added in https://github.com/FHIR/sushi/commit/57f4f06de78f243faa00f41a0667b19a9201edcd tests this situation, and should fail on that commit. However, on https://github.com/FHIR/sushi/commit/3842e51558a02daa57acb0f019729255faf22ff1 the test should pass.

You can also compare the results of running SUSHI on that example using this branch, versus running SUSHI on that example using master. On master you should see an error, but there should be no errors on this branch.