### PR TITLE
Import config.yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -302,6 +302,14 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
@@ -1563,6 +1571,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/valid-url/-/valid-url-1.0.3.tgz",
       "integrity": "sha512-+33x29mg+ecU88ODdWpqaie2upIuRkhujVLA7TuJjM823cNMbeggfI6NhxewaRaRF8dy+g33e4uIg/m5Mb3xDQ==",
+      "dev": true
+    },
+    "@types/yaml": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/yaml/-/yaml-1.2.0.tgz",
+      "integrity": "sha512-GW8b9qM+ebgW3/zjzPm0I1NxMvLaz/YKT9Ph6tTb+Fkeyzd9yLTvQ6ciQ2MorTRmb/qXmfjMerRpG4LviixaqQ==",
       "dev": true
     },
     "@types/yargs": {
@@ -6021,14 +6035,6 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        }
       }
     },
     "jsbn": {
@@ -6838,6 +6844,11 @@
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
       "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
       "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -8256,6 +8267,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.3.tgz",
+      "integrity": "sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==",
+      "requires": {
+        "@babel/runtime": "^7.8.7"
+      }
     },
     "yargs": {
       "version": "15.3.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/tar": "^4.0.3",
     "@types/temp": "^0.8.34",
     "@types/valid-url": "^1.0.3",
+    "@types/yaml": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
     "acorn": "^7.1.1",
@@ -82,6 +83,7 @@
     "temp": "^0.9.1",
     "title-case": "^3.0.2",
     "valid-url": "^1.0.9",
-    "winston": "^3.2.1"
+    "winston": "^3.2.1",
+    "yaml": "^1.8.3"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import program from 'commander';
 import cloneDeep from 'lodash/cloneDeep';
-import { importText, FSHTank, RawFSH } from './import';
+import { importText, FSHTank, RawFSH, importConfiguration } from './import';
 import { exportFHIR, Package } from './export';
 import { IGExporter } from './ig';
 import { logger, stats, Type } from './utils';
@@ -22,6 +22,7 @@ import {
 } from './utils';
 import { pad, padStart, sample, padEnd } from 'lodash';
 import chalk from 'chalk';
+import { Configuration } from './fshtypes';
 
 app();
 
@@ -84,6 +85,18 @@ async function app() {
     program.help();
   }
 
+  // If the config.yaml file exists, parse it; otherwise skip for now (until we fully support it)
+  let config: Configuration;
+  const configPath = path.join(input, 'config.yaml');
+  if (fs.existsSync(configPath)) {
+    const configYaml = fs.readFileSync(configPath, 'utf8');
+    try {
+      config = importConfiguration(configYaml, configPath);
+    } catch (e) {
+      process.exit(1);
+    }
+  }
+
   // Check that package.json exists
   const packagePath = path.join(input, 'package.json');
   if (!fs.existsSync(packagePath)) {
@@ -141,7 +154,7 @@ async function app() {
   logger.info('Importing FSH text...');
   const docs = importText(rawFSHes);
 
-  const tank = new FSHTank(docs, packageJSON);
+  const tank = new FSHTank(docs, packageJSON, config);
   await Promise.all(dependencyDefs);
 
   // Check for StructureDefinition

--- a/src/export/Package.ts
+++ b/src/export/Package.ts
@@ -1,5 +1,5 @@
 import { StructureDefinition, InstanceDefinition, ValueSet, CodeSystem } from '../fhirtypes';
-import { PackageJSON } from '../fshtypes';
+import { PackageJSON, Configuration } from '../fshtypes';
 import { Fishable, Type, Metadata } from '../utils/Fishable';
 
 export class Package implements Fishable {
@@ -9,7 +9,7 @@ export class Package implements Fishable {
   public readonly valueSets: ValueSet[] = [];
   public readonly codeSystems: CodeSystem[] = [];
 
-  constructor(public readonly packageJSON: PackageJSON) {}
+  constructor(public readonly packageJSON: PackageJSON, public readonly config?: Configuration) {}
 
   fish(
     item: string,

--- a/src/export/exportFHIR.ts
+++ b/src/export/exportFHIR.ts
@@ -11,7 +11,7 @@ import { MasterFisher } from '../utils';
  * @returns {Package} - the Package structure returned from processing the FSH definitions
  */
 export function exportFHIR(tank: FSHTank, FHIRDefs: FHIRDefinitions): Package {
-  const pkg = new Package(tank.packageJSON);
+  const pkg = new Package(tank.packageJSON, tank.config);
   const fisher = new MasterFisher(tank, FHIRDefs, pkg);
   const exporter = new FHIRExporter(tank, pkg, fisher);
   return exporter.export();

--- a/src/fhirtypes/ImplementationGuide.ts
+++ b/src/fhirtypes/ImplementationGuide.ts
@@ -1,9 +1,8 @@
 import { ContactDetail, UsageContext } from './metaDataTypes';
-import { CodeableConcept, Reference } from './dataTypes';
+import { CodeableConcept, Reference, DomainResource } from './dataTypes';
 
-export type ImplementationGuide = {
+export type ImplementationGuide = DomainResource & {
   resourceType: 'ImplementationGuide';
-  id: string;
   url: string;
   version?: string;
   name: string;

--- a/src/fhirtypes/dataTypes.ts
+++ b/src/fhirtypes/dataTypes.ts
@@ -62,7 +62,7 @@ export type Extension = {
  * @see {@link http://hl7.org/fhir/R4/datatypes.html#Identifier}
  */
 export type Identifier = {
-  use?: string;
+  use?: 'usual' | 'official' | 'temp' | 'secondary' | 'old';
   type?: CodeableConcept;
   system?: string;
   value?: string;
@@ -76,7 +76,7 @@ export type Identifier = {
  * @see {@link http://hl7.org/fhir/R4/narrative.html#Narrative}
  */
 export type Narrative = {
-  status: string;
+  status: 'generated' | 'extensions' | 'additional' | 'empty';
   div: string;
 };
 
@@ -121,7 +121,7 @@ export function validatePeriod(period: Period): void {
  */
 export type Quantity = {
   value?: number;
-  comparator?: string;
+  comparator?: '<' | '<=' | '>=' | '>';
   unit?: string;
   system?: string;
   code?: string;
@@ -193,4 +193,16 @@ export type Resource = {
   meta?: Meta;
   implicitRules?: string;
   language?: string;
+};
+
+/**
+ * Represents the FHIR R4 data type DomainResource.
+ *
+ * @see {@link http://hl7.org/fhir/R4/domainresource.html#resource}
+ */
+export type DomainResource = Resource & {
+  text?: Narrative;
+  contained?: any[];
+  extension?: Extension[];
+  modifierExtension?: Extension[];
 };

--- a/src/fhirtypes/metaDataTypes.ts
+++ b/src/fhirtypes/metaDataTypes.ts
@@ -1,4 +1,4 @@
-import { ContactPoint, CodeableConcept, Quantity, Coding, Reference } from './dataTypes';
+import { ContactPoint, CodeableConcept, Quantity, Coding, Range, Reference } from './dataTypes';
 
 /**
  * Represents the FHIR R4 metadata type ContactDetail.

--- a/src/fshtypes/Configuration.ts
+++ b/src/fshtypes/Configuration.ts
@@ -19,6 +19,7 @@ import {
  * ambiguities (like singular vs list representations) and normalizes closer to the intended
  * export formats.
  *
+ * @see YAMLConfiguration
  * @see {@link http://hl7.org/fhir/R4/implementationguide.html}
  * @see {@link https://build.fhir.org/ig/FHIR/ig-guidance/using-templates.html#igroot}
  * @see {@link https://confluence.hl7.org/display/FHIR/NPM+Package+Specification}
@@ -161,7 +162,7 @@ export type ConfigurationHistoryItem = {
     | 'trial-use'
     | 'update'
     | 'normative'
-    | 'trial=use+normative';
+    | 'trial-use+normative';
   sequence?: string;
   fhirversion?: string;
   current?: boolean;

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -56,6 +56,7 @@ import {
 import isEqual from 'lodash/isEqual';
 import sortBy from 'lodash/sortBy';
 import upperFirst from 'lodash/upperFirst';
+import { parseCodeLexeme } from './parseCodeLexeme';
 
 enum SdMetadataKey {
   Id = 'Id',
@@ -792,25 +793,9 @@ export class FSHImporter extends FSHVisitor {
   }
 
   private parseCodeLexeme(conceptText: string, parentCtx: ParserRuleContext): FshCode {
-    const splitPoint = conceptText.match(/(^|[^\\])(\\\\)*#/);
-    let system: string, code: string;
-    if (splitPoint == null) {
-      system = '';
-      code = conceptText.slice(1);
-    } else {
-      system = conceptText.slice(0, splitPoint.index) + splitPoint[0].slice(0, -1);
-      code = conceptText.slice(splitPoint.index + splitPoint[0].length);
-    }
-    system = system.replace(/\\\\/g, '\\').replace(/\\#/g, '#');
-    if (code.startsWith('"')) {
-      code = code
-        .slice(1, code.length - 1)
-        .replace(/\\\\/g, '\\')
-        .replace(/\\"/g, '"');
-    }
-    const concept = new FshCode(code);
-    if (system.length > 0) {
-      concept.system = this.aliasAwareValue(parentCtx, system);
+    const concept = parseCodeLexeme(conceptText);
+    if (concept.system?.length > 0) {
+      concept.system = this.aliasAwareValue(parentCtx, concept.system);
     }
     return concept;
   }

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -7,7 +7,8 @@ import {
   FshCodeSystem,
   Invariant,
   RuleSet,
-  Mapping
+  Mapping,
+  Configuration
 } from '../fshtypes';
 import flatMap from 'lodash/flatMap';
 import { PackageJSON } from '../fshtypes/PackageJSON';
@@ -17,7 +18,7 @@ export class FSHTank implements Fishable {
   constructor(
     public readonly docs: FSHDocument[],
     public readonly packageJSON: PackageJSON,
-    public readonly root?: string
+    public readonly config?: Configuration
   ) {}
 
   /**

--- a/src/import/YAMLConfiguration.ts
+++ b/src/import/YAMLConfiguration.ts
@@ -19,7 +19,7 @@ import {
 } from '../fhirtypes';
 
 /**
- * RawConfiguration follows the proposed configuration format for FSH and incorporates aspects
+ * YAMLConfiguration follows the proposed configuration format for FSH and incorporates aspects
  * of the ImplementationGuide, ig.ini, package.json, package-list.json, and menu.xml formats.
  *
  * This format is intended to be represented using YAML but is transformed into JSON for our use.

--- a/src/import/YAMLConfiguration.ts
+++ b/src/import/YAMLConfiguration.ts
@@ -1,0 +1,380 @@
+import {
+  UsageContext,
+  ImplementationGuideDefinitionTemplate,
+  Meta,
+  Narrative,
+  ImplementationGuideDefinitionResource,
+  ImplementationGuideStatus,
+  ContactPoint,
+  ContactDetail,
+  ImplementationGuideDefinitionPage,
+  ImplementationGuideDefinitionPageGeneration,
+  Quantity,
+  ImplementationGuide,
+  ImplementationGuideDependsOn,
+  ImplementationGuideGlobal,
+  ImplementationGuideDefinitionGrouping,
+  Reference,
+  Identifier
+} from '../fhirtypes';
+
+/**
+ * RawConfiguration follows the proposed configuration format for FSH and incorporates aspects
+ * of the ImplementationGuide, ig.ini, package.json, package-list.json, and menu.xml formats.
+ *
+ * This format is intended to be represented using YAML but is transformed into JSON for our use.
+ *
+ * @see {@link http://hl7.org/fhir/R4/implementationguide.html}
+ * @see {@link https://build.fhir.org/ig/FHIR/ig-guidance/using-templates.html#igroot}
+ * @see {@link https://confluence.hl7.org/display/FHIR/NPM+Package+Specification}
+ * @see {@link https://confluence.hl7.org/pages/viewpage.action?pageId=66928420#FHIRIGPackageListdoco-PublicationObject}
+ * @see {@link https://github.com/FHIR/sample-ig/blob/master/input/includes/menu.xml}
+ */
+export type YAMLConfiguration = {
+  id: ImplementationGuide['id']; // string
+  meta?: YAMLConfigurationMeta;
+  implicitRules?: ImplementationGuide['implicitRules']; // string
+  language?: ImplementationGuide['language']; // string (shorthand code syntax can be used here)
+  text?: YAMLConfigurationNarrative;
+  contained?: ImplementationGuide['contained']; // any[]
+  extension?: ImplementationGuide['extension']; // Extension[]
+  modifierExtension?: ImplementationGuide['modifierExtension']; // Extension[]
+  url: ImplementationGuide['url']; // string
+  version:
+    | ImplementationGuide['version'] // string
+    | number; // YAML will parse some versions (e.g., 1.2) as numbers
+  name: ImplementationGuide['name']; // string;
+  title?: ImplementationGuide['title']; // string;
+  status: YAMLConfigurationStatus;
+  experimental?: ImplementationGuide['experimental']; // boolean;
+  date?:
+    | ImplementationGuide['date'] // string
+    | number; // YAML will parse year-only dates as numbers
+
+  // The publisher can be a single item or a list, each with a name and optional url and/or email.
+  // The first publisher's name will be used as IG.publisher.  The contact details and/or
+  // additional publishers will be translated into IG.contact values.
+  publisher?: YAMLConfigurationPublisher | YAMLConfigurationPublisher[];
+
+  // Those who need more control or want to add additional details to the contact values can use
+  // contact directly and follow the format outlined in the ImplementationGuide resource and
+  // ContactDetail. A single item or a list can be provided.
+  contact?: YAMLConfigurationContactDetail | YAMLConfigurationContactDetail[];
+
+  description?: ImplementationGuide['description']; // string
+
+  // useContext can be a single item or a list.
+  useContext?: YAMLConfigurationUsageContext | YAMLConfigurationUsageContext[];
+
+  // The jurisdiction can be a single item or a list. The Shorthand code syntax can be used here.
+  jurisdiction?: YAMLConfigurationJurisdiction | YAMLConfigurationJurisdiction[];
+
+  copyright?: ImplementationGuide['copyright']; // string
+
+  // SUSHI will use id as both id and packageId in the IG unless a specific packageId is specified
+  packageId?: ImplementationGuide['packageId']; // string
+
+  license?: ImplementationGuide['license']; // string
+
+  // Although fhirVersions is 0..* in the ImplementationGuide resource, it can be a single item OR
+  // an array here (but so far SUSHI only supports 4.0.1 anyway).
+  fhirVersion:
+    | ImplementationGuide['fhirVersion'][0] // string
+    | ImplementationGuide['fhirVersion']; // string[]
+
+  // The dependencies property corresponds to IG.dependsOn. They key is the package id and the
+  // value is the version (or dev/current).
+  dependencies?: YAMLConfigurationDependencyMap;
+
+  // The global property corresponds to the IG.global property, but it uses the type as the YAML
+  // key and the profile as its value. Since FHIR does not explicitly disallow more than one
+  // profile per type, neither do we; the value can be a single profile URL or an array of profile
+  // URLs.
+  global?: YAMLConfigurationGlobalMap;
+
+  // Groups can control certain aspects of the IG generation.  The IG documentation recommends that
+  // authors use the default groups that are provided by the templating framework, but if authors
+  // want to use their own instead, they can use the mechanism below.  This will create
+  // IG.definition.grouping entries and associate the individual resource entries with the
+  // corresponding groupIds.
+  groups?: YAMLConfigurationGroupMap;
+
+  // The resources property corresponds to IG.definition.resource. SUSHI can auto-generate all of
+  // the resource entries based on the FSH definitions and/or information in any user-provided
+  // JSON resource files. If the generated entries are not sufficient or complete, however, the
+  // author can add entries here. If the reference matches a generated entry, it will replace the
+  // generated entry. If it doesn't match any generated entries, it will be added to the generated
+  // entries. The format follows IG.definition.resource with the following differences:
+  // * use IG.definition.resource.reference.reference as the YAML key (so reference is optional)
+  // * specify "omit" to omit a FSH-generated resource from the resource list.
+  // * groupingId can be used, but top-level groups syntax may be a better option (see below).
+  resources?: YAMLConfigurationResourceMap;
+
+  // The pages property corresponds to IG.definition.page. SUSHI can auto-generate the page list,
+  // but if the author includes pages in this file, it is assumed that the author will fully manage
+  // the pages section and SUSHI will not generate any page entries. The page file name is used as
+  // the key. If title is not provided, then the title will be generated from the file name.  If a
+  // generation value is not provided, it will be inferred from the file name extension.  Any
+  // subproperties that are valid filenames with supported extensions (e.g., .md/.xml) will be
+  // treated as sub-pages.
+  pages?: YAMLConfigurationPageTree;
+
+  // The parameters property represents IG.definition.parameter. Rather than a list of code/value
+  // pairs (as in the ImplementationGuide resource, the code is the YAML key. If a parameter allows
+  // repeating values, the value in the YAML should be a sequence/array. For a partial list of
+  // allowed parameters see: https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+  parameters?: YAMLConfigurationParameterMap;
+
+  // The templates property corresponds 1:1 with IG.definition.template. The templates value can be
+  // a single item or a list. Note that the pluralized name 'templates' refers to the
+  // IG.definiton.template definitions; the singularized name 'template' refers to the specific
+  // template to use for this IG.
+  templates?: ImplementationGuideDefinitionTemplate | ImplementationGuideDefinitionTemplate[];
+
+  // The template property will be copied into the ig.ini file. If the value of template is "none",
+  // then only the resources will be generated (with no supporting ImplementationGuide sources).
+  template: string;
+
+  // The following two lines correspond to items that used to be in ig.ini but were recently moved
+  // to IG.definition.parameter. For consistency within this file, the names are represented using
+  // camelcase, but if authors use the formal parameter names, SUSHI will recognize them as well.
+  // In either case, they'll be copied to the IG JSON using the formal names.
+  copyrightYear?: string | number; // YAML will parse years as numbers
+  copyrightyear?: string | number; // YAML will parse years as numbers
+  releaseLabel?: string;
+  releaselabel?: string;
+
+  // The menu property will be used to generate the input/menu.xml file. The menu is represented as
+  // a simple structure where the YAML key is the menu item name and the value is the URL. The IG
+  // publisher currently only supports one level deep on sub-menus.
+  // TO CONSIDER: If no menu data is provided, can we generate the menu based on the pages order
+  // or should we just generate a very standard menu (since there may be too many pages to fit in
+  // a menu)?
+  menu?: YAMLConfigurationMenuTree;
+
+  // The history property corresponds to package-list.json. SUSHI will use the existing top-level
+  // properties in its config to populate the top-level package-list.json properties: package-id,
+  // canonical, title, and introduction. Authors that wish to provide different values can supply
+  // them as properties under history. All other properties under history are assumed to be
+  // versions.
+  //
+  // The current version is special. If the author provides only a single string value, it is
+  // assumed to be the URL path to the current build. The following default values will then be
+  // used:
+  // * desc: Continuous Integration Build (latest in version control)
+  // * status: ci-build
+  // * current: true
+  history?: YAMLConfigurationHistory;
+};
+
+export type YAMLConfigurationMeta = {
+  versionId?: Meta['versionId']; // string
+  lastUpdated?: Meta['lastUpdated']; // string
+  source?: Meta['source']; // string
+  profile?: Meta['profile']; // string[]
+  security?: (Meta['security'][0] | string)[]; // (Coding | string)[]
+  tag?: (Meta['tag'][0] | string)[]; // (Coding | string)[]
+};
+
+export type YAMLConfigurationNarrative = {
+  status:
+    | Narrative['status'] // 'generated', 'extensions', 'additional', 'empty
+    | '#generated'
+    | '#extensions'
+    | '#additional'
+    | '#empty';
+  div: string;
+};
+
+export type YAMLConfigurationStatus =
+  | ImplementationGuideStatus // 'draft', 'active', 'retired', 'unknown'
+  | '#draft'
+  | '#active'
+  | '#retired'
+  | '#unknown';
+
+export type YAMLConfigurationPublisher = {
+  name: ImplementationGuide['publisher']; // string
+  url?: ContactPoint['value']; // string
+  email?: ContactPoint['value']; // string
+};
+
+export type YAMLConfigurationContactDetail = {
+  name?: ContactDetail['name']; // string
+  telecom?: YAMLConfigurationContactPoint[];
+};
+
+export type YAMLConfigurationContactPoint = {
+  system?:
+    | ContactPoint['system'] // 'phone', 'fax', 'email', 'pager', 'url', 'sms', 'other'
+    | '#phone'
+    | '#fax'
+    | '#email'
+    | '#pager'
+    | '#url'
+    | '#sms'
+    | '#other';
+  value?: ContactPoint['value']; // string
+  use?:
+    | ContactPoint['use'] // 'home', 'work', 'temp', 'old', 'mobile'
+    | '#home'
+    | '#work'
+    | '#temp'
+    | '#old'
+    | '#mobile';
+  rank?: ContactPoint['rank']; // number
+  period?: ContactPoint['period']; // Period
+};
+
+export type YAMLConfigurationUsageContext = {
+  code:
+    | UsageContext['code'] // Coding
+    | string;
+  valueCodeableConcept?:
+    | UsageContext['valueCodeableConcept'] // CodeableConcept
+    | string;
+  valueQuantity?: YAMLConfigurationQuantity | string; // special FSH quantity syntax (e.g., 50 'mm')
+  valueRange?: YAMLConfigurationRange;
+  valueReference?: YAMLConfigurationReference;
+};
+
+export type YAMLConfigurationQuantity = {
+  value?: Quantity['value']; // number
+  comparator?:
+    | Quantity['comparator'] // '<', '<=', '>=', '>'
+    | '#<'
+    | '#<='
+    | '#>='
+    | '#>';
+  unit?: Quantity['unit']; // string
+  system?: Quantity['system']; // string
+  code?: Quantity['code']; // string
+};
+
+export type YAMLConfigurationRange = {
+  low?: YAMLConfigurationQuantity | string; // special FSH quantity syntax (e.g., 50 'mm')
+  high?: YAMLConfigurationQuantity | string; // special FSH quantity syntax (e.g., 50 'mm')
+};
+
+export type YAMLConfigurationReference = {
+  reference?: Reference['reference']; // string
+  type?: Reference['type']; // string
+  identifier?: YAMLConfigurationIdentifier;
+  display?: Reference['display']; // string
+};
+
+export type YAMLConfigurationIdentifier = {
+  use?:
+    | Identifier['use'] // 'usual', 'official', 'temp', 'secondary', 'old'
+    | '#usual'
+    | '#official'
+    | '#temp'
+    | '#old';
+  type?:
+    | Identifier['type'] // CodeableConcept
+    | string;
+  system?: Identifier['system']; // string
+  value?: Identifier['value']; // string
+  period?: Identifier['period']; // Period
+  assigner?: YAMLConfigurationReference;
+};
+
+export type YAMLConfigurationJurisdiction =
+  | ImplementationGuide['jurisdiction'][0] // CodeableConcept
+  | string;
+
+export type YAMLConfigurationDependencyMap = {
+  [key: string]:
+    | ImplementationGuideDependsOn['version'] // string
+    | number; // YAML will parse some versions as numbers (e.g., 1.2)
+};
+
+export type YAMLConfigurationGlobalMap = {
+  [key: string]:
+    | ImplementationGuideGlobal['profile'] // string
+    | ImplementationGuideGlobal['profile'][]; // string[]
+};
+
+export type YAMLConfigurationGroupMap = {
+  [key: string]: {
+    description?: ImplementationGuideDefinitionGrouping['description']; // string
+    resources: string[];
+  };
+};
+
+export type YAMLConfigurationResourceMap = {
+  [key: string]: 'omit' | '#omit' | YAMLConfigurationResource;
+};
+
+export type YAMLConfigurationResource = {
+  reference?: ImplementationGuideDefinitionResource['reference']; // Reference
+  fhirVersion?:
+    | ImplementationGuideDefinitionResource['fhirVersion'] // string[]
+    | ImplementationGuideDefinitionResource['fhirVersion'][0]; // string
+  name?: ImplementationGuideDefinitionResource['name']; // string
+  description?: ImplementationGuideDefinitionResource['description']; // string
+  exampleBoolean?: ImplementationGuideDefinitionResource['exampleBoolean']; // boolean
+  exampleCanonical?: ImplementationGuideDefinitionResource['exampleCanonical']; // canonical
+  groupingId?: ImplementationGuideDefinitionResource['groupingId']; // string
+};
+
+export type YAMLConfigurationPageTree = {
+  [key: string]: YAMLConfigurationPage;
+};
+
+export type YAMLConfigurationPage = null | {
+  title?: ImplementationGuideDefinitionPage['title']; // string
+  generation?:
+    | ImplementationGuideDefinitionPageGeneration // 'html', 'markdown', 'xml', 'generated'
+    | '#html'
+    | '#markdown'
+    | '#xml'
+    | '#generated';
+  [key: string]: YAMLConfigurationPage | string; // string allowed so title/generation work
+};
+
+export type YAMLConfigurationParameterMap = {
+  // YAML will parse some of parameter values as numbers or booleans
+  [key: string]: string | number | boolean | (string | number | boolean)[];
+};
+
+export type YAMLConfigurationMenuTree = {
+  [key: string]: string | YAMLConfigurationMenuTree;
+};
+
+export type YAMLConfigurationHistory = {
+  'package-id'?: string;
+  canonical?: string;
+  title?: string;
+  introduction?: string;
+  current: YAMLConfigurationHistoryItem;
+  [key: string]: YAMLConfigurationHistoryItem;
+};
+
+export type YAMLConfigurationHistoryItem =
+  | string
+  | {
+      date?: string | number; // YAML will parse year-only dates as numbers
+      desc?: string;
+      path: string;
+      changes?: string;
+      status?:
+        | 'ci-build'
+        | '#ci-build'
+        | 'preview'
+        | '#preview'
+        | 'ballot'
+        | '#ballot'
+        | 'trial-use'
+        | '#trial-use'
+        | 'update'
+        | '#update'
+        | 'normative'
+        | '#normative'
+        | 'trial=use+normative'
+        | '#trial=use+normative';
+
+      sequence?: string;
+      fhirversion?: string;
+      current?: boolean;
+    };

--- a/src/import/importConfiguration.ts
+++ b/src/import/importConfiguration.ts
@@ -1,0 +1,713 @@
+import YAML from 'yaml';
+import {
+  YAMLConfiguration,
+  YAMLConfigurationPage,
+  YAMLConfigurationMenuTree,
+  YAMLConfigurationDependencyMap,
+  YAMLConfigurationGlobalMap,
+  YAMLConfigurationGroupMap,
+  YAMLConfigurationResourceMap,
+  YAMLConfigurationPageTree,
+  YAMLConfigurationMeta,
+  YAMLConfigurationUsageContext,
+  YAMLConfigurationQuantity,
+  YAMLConfigurationNarrative,
+  YAMLConfigurationRange,
+  YAMLConfigurationReference,
+  YAMLConfigurationIdentifier
+} from './YAMLConfiguration';
+import {
+  Configuration,
+  ConfigurationGroup,
+  ConfigurationResource,
+  ConfigurationMenuItem,
+  ConfigurationHistory,
+  ConfigurationHistoryItem
+} from '../fshtypes/Configuration';
+import { logger } from '../utils/FSHLogger';
+import { parseCodeLexeme } from './parseCodeLexeme';
+import {
+  ImplementationGuideGlobal,
+  ImplementationGuideDefinitionPage,
+  ImplementationGuideDefinitionParameter,
+  ContactDetail,
+  ImplementationGuideDependsOn,
+  Meta,
+  Coding,
+  Narrative,
+  ContactPoint,
+  CodeableConcept,
+  UsageContext,
+  Quantity,
+  Range,
+  Identifier,
+  Reference,
+  ImplementationGuideDefinitionTemplate
+} from '../fhirtypes';
+import { FshCode } from '../fshtypes';
+
+const MINIMAL_CONFIG_PROPERTIES = ['id', 'version', 'url', 'fhirVersion'];
+
+/**
+ * Imports the YAML Configuration format (as a YAML string or already parsed JSON) and returns
+ * the normalized FSH Configuration object.
+ * @param {YAMLConfiguration | string} yaml - the YAML config as a string or JSON document
+ * @returns {Configuration} - the FSH configuration representing the parsed config
+ */
+export function importConfiguration(yaml: YAMLConfiguration | string, file: string): Configuration {
+  if (typeof yaml === 'string') {
+    return importConfiguration(YAML.parse(yaml) as YAMLConfiguration, file);
+  }
+
+  // There are a few properties that are absolutely required if we are to have *any* success at all
+  if (
+    MINIMAL_CONFIG_PROPERTIES.some(
+      // @ts-ignore Element implicitly has an 'any' type
+      p => yaml[p] == null || (Array.isArray(yaml[p]) && yaml[p].length === 0)
+    )
+  ) {
+    logger.error(
+      'SUSHI minimally requires the following configuration properties to start processing FSH: ' +
+        MINIMAL_CONFIG_PROPERTIES.join(', ') +
+        '.',
+      { file }
+    );
+    throw new Error('Minimal config not met');
+  }
+
+  const config: Configuration = {
+    filePath: file,
+    id: yaml.id, // minimum config property
+    meta: parseMeta(yaml.meta, file),
+    implicitRules: yaml.implicitRules,
+    language: parseSimpleCode(yaml.language, 'language', file),
+    text: parseText(yaml.text, file),
+    contained: yaml.contained,
+    extension: yaml.extension,
+    modifierExtension: yaml.modifierExtension,
+    url: yaml.url, // minimum config property
+    version: normalizeToString(yaml.version), // minimum config property
+    name: required(yaml.name, 'name', file),
+    title: yaml.title,
+    status: parseCodeWithRequiredValues(
+      required(yaml.status, 'status', file),
+      ['draft', 'active', 'retired', 'unknown'],
+      'status',
+      file
+    ),
+    experimental: yaml.experimental,
+    date: normalizeToString(yaml.date),
+    publisher: normalizeToArray(yaml.publisher)?.[0]?.name,
+    contact: parseContact(yaml, file),
+    description: yaml.description,
+    useContext: parseUsageContext(yaml.useContext, file),
+    jurisdiction: parseJurisdiction(yaml.jurisdiction, file),
+    copyright: yaml.copyright,
+    packageId: yaml.packageId ?? yaml.id,
+    license: parseSimpleCode(yaml.license, 'license', file),
+    fhirVersion: normalizeToArray(yaml.fhirVersion)?.map(v =>
+      parseSimpleCode(v, 'fhirVersion', file)
+    ), // minimum config property
+    dependencies: parseDependencies(yaml.dependencies),
+    global: parseGlobal(yaml.global),
+    groups: parseGroups(yaml.groups),
+    resources: parseResources(yaml.resources, file),
+    pages: parsePages(yaml.pages, file),
+    parameters: parseParameters(yaml),
+    templates: parseTemplates(yaml.templates, file),
+    template: required(yaml.template, 'template', file),
+    menu: parseMenu(yaml.menu),
+    history: parseHistory(yaml, file)
+  };
+
+  // Remove all undefined variables (mainly helpful for test assertions)
+  removeUndefinedValues(config);
+
+  return config;
+}
+
+function required<T>(value: T, property: string, file: string): T {
+  if (value == null || (Array.isArray(value) && value.length === 0)) {
+    logger.error(`Configuration missing required property: ${property}`, { file });
+  }
+  return value;
+}
+
+function normalizeToString(yamlValue: any): string {
+  if (yamlValue == null) {
+    return;
+  }
+  return `${yamlValue}`;
+}
+
+function normalizeToArray<T>(yamlValue?: T | T[]): T[] | null | undefined {
+  if (yamlValue == null) {
+    return;
+  }
+  return Array.isArray(yamlValue) ? yamlValue : [yamlValue];
+}
+
+function parseSimpleCode(yamlCode: string, property: string, file: string): string {
+  return yamlCode?.startsWith('#') ? parseFshCode(yamlCode, property, file)?.code : yamlCode;
+}
+
+function parseFshCode(yamlCode: string, property: string, file: string): FshCode {
+  // If it has a display, we need to split it out and handle it separately
+  const m = yamlCode.match(/^(.*\S)(\s+"(([^"]|\\")*)")$/);
+  if (m) {
+    const concept = parseCodeLexeme(m[1]);
+    concept.display = m[3].replace('\\"', '"');
+    return concept;
+  }
+  const concept = parseCodeLexeme(yamlCode);
+  if (concept.system == null && concept.code === '') {
+    logger.error(`Invalid code format for ${property}: ${yamlCode}`, { file });
+    // don't return an invalid code
+    return;
+  }
+  return concept;
+}
+
+function parseCodingArray(codings: (Coding | string)[], property: string, file: string): Coding[] {
+  if (codings == null) {
+    return;
+  }
+  const result = codings?.map(c => parseCoding(c, property, file)).filter(c => c != null);
+  if (result.length === 0 && codings.length > 0) {
+    // in the case that all inputs were invalid, return undefined instead of empty array
+    return;
+  }
+  return result;
+}
+
+function parseCoding(coding: Coding | string, property: string, file: string): Coding {
+  if (coding == null) {
+    return;
+  }
+  if (typeof coding === 'string') {
+    return parseFshCode(coding, property, file)?.toFHIRCoding();
+  }
+  // It's a coding object
+  const fixed: Coding = {
+    ...coding,
+    version: normalizeToString(coding.version),
+    code: parseSimpleCode(coding.code, property, file)
+  };
+  return removeUndefinedValues(fixed);
+}
+
+function parseCodeableConceptArray(
+  concepts: (CodeableConcept | string)[],
+  property: string,
+  file: string
+): CodeableConcept[] {
+  if (concepts == null) {
+    return;
+  }
+  const result = concepts?.map(c => parseCodeableConcept(c, property, file)).filter(c => c != null);
+  if (result.length === 0 && concepts.length > 0) {
+    // in the case that all inputs were invalid, return undefined instead of empty array
+    return;
+  }
+  return result;
+}
+
+function parseCodeableConcept(
+  concept: CodeableConcept | string,
+  property: string,
+  file: string
+): CodeableConcept {
+  if (concept == null) {
+    return;
+  }
+  if (typeof concept === 'string') {
+    const coding = parseCoding(concept, property, file);
+    if (coding == null) {
+      // return undefined instead of an empty concept
+      return;
+    }
+    return {
+      coding: [coding]
+    };
+  }
+  // It's a CodeableConcept object
+  const fixed: CodeableConcept = {
+    ...concept,
+    coding: parseCodingArray(concept.coding, property, file)
+  };
+  return removeUndefinedValues(fixed);
+}
+
+function parseCodeWithRequiredValues<T extends string>(
+  yamlCode: string,
+  allowedValues: T[],
+  property: string,
+  file: string
+): T {
+  if (yamlCode == null) {
+    return;
+  }
+
+  const code = parseSimpleCode(yamlCode, property, file);
+  const match = allowedValues.find(c => c === code);
+  if (match) {
+    return match;
+  }
+  logger.error(
+    `Invalid ${property} value: '${code}'. Must be one of: ${allowedValues
+      .map(c => `'${c}'`)
+      .join(',')}.`,
+    {
+      file
+    }
+  );
+}
+
+function parseQuantity(
+  yamlQuantity: YAMLConfigurationQuantity | string,
+  property: string,
+  file: string
+): Quantity {
+  if (yamlQuantity == null) {
+    return;
+  }
+  if (typeof yamlQuantity === 'string') {
+    const m = yamlQuantity.match(/^(\d*(\.\d+)?)(\s+'([^']+)')?$/);
+    if (m == null) {
+      logger.error(`Invalid ${property} value: ${yamlQuantity}`, { file });
+      return;
+    }
+    const quantity: Quantity = {
+      value: parseFloat(m[1])
+    };
+    if (m[4] && m[4].length > 0) {
+      quantity.system = 'http://unitsofmeasure.org';
+      quantity.code = m[4];
+    }
+    return quantity;
+  }
+  const quantity: Quantity = {
+    ...yamlQuantity,
+    code: parseSimpleCode(yamlQuantity.code, `${property}.code`, file),
+    comparator: parseCodeWithRequiredValues(
+      yamlQuantity.comparator,
+      ['<', '<=', '>=', '>'],
+      `${property}.comparator`,
+      file
+    )
+  };
+  removeUndefinedValues(quantity);
+  return quantity;
+}
+
+function parseRange(yamlRange: YAMLConfigurationRange, property: string, file: string): Range {
+  if (yamlRange == null) {
+    return;
+  }
+  const range: Range = {
+    ...yamlRange,
+    low: parseQuantity(yamlRange.low, `${property}.low`, file),
+    high: parseQuantity(yamlRange.high, `${property}.high`, file)
+  };
+  removeUndefinedValues(range);
+  return range;
+}
+
+function parseReference(
+  yamlReference: YAMLConfigurationReference,
+  property: string,
+  file: string
+): Reference {
+  if (yamlReference == null) {
+    return;
+  }
+  const reference: Reference = {
+    ...yamlReference,
+    identifier: parseIdentifier(yamlReference.identifier, `${property}.identifier`, file)
+  };
+  removeUndefinedValues(reference);
+  return reference;
+}
+
+function parseIdentifier(
+  yamlIdentifier: YAMLConfigurationIdentifier,
+  property: string,
+  file: string
+): Identifier {
+  if (yamlIdentifier == null) {
+    return;
+  }
+  const identifier: Identifier = {
+    ...yamlIdentifier,
+    use: parseCodeWithRequiredValues(
+      yamlIdentifier.use,
+      ['usual', 'official', 'temp', 'secondary', 'old'],
+      `${property}.use`,
+      file
+    ),
+    type: parseCodeableConcept(yamlIdentifier.type, `${property}.type`, file),
+    assigner: parseReference(yamlIdentifier.assigner, `${property}.assigner`, file)
+  };
+  removeUndefinedValues(identifier);
+  return identifier;
+}
+
+function parseMeta(yamlMeta: YAMLConfigurationMeta, file: string): Meta {
+  if (yamlMeta == null) {
+    return;
+  }
+
+  const fixed = {
+    ...yamlMeta,
+    security: parseCodingArray(yamlMeta.security, 'meta.security', file),
+    tag: parseCodingArray(yamlMeta.tag, 'meta.tag', file)
+  };
+  return removeUndefinedValues(fixed);
+}
+
+function parseText(yamlText: YAMLConfigurationNarrative, file: string): Narrative {
+  if (yamlText == null) {
+    return;
+  }
+
+  const fixed: Narrative = {
+    ...yamlText,
+    status: parseCodeWithRequiredValues(
+      yamlText.status,
+      ['generated', 'extensions', 'additional', 'empty'],
+      'text.status',
+      file
+    )
+  };
+  return removeUndefinedValues(fixed);
+}
+
+function parseContact(yamlConfig: YAMLConfiguration, file: string): ContactDetail[] {
+  const contacts: ContactDetail[] = [];
+  const publishers = normalizeToArray(yamlConfig.publisher);
+  if (publishers) {
+    publishers.forEach((p, i) => {
+      const contact: ContactDetail = { name: p.name };
+      if (p.url || p.email) {
+        contact.telecom = [];
+        if (p.url) {
+          contact.telecom.push({ system: 'url', value: p.url });
+        }
+        if (p.email) {
+          contact.telecom.push({ system: 'email', value: p.email });
+        }
+      } else if (i === 0) {
+        // This was the first publisher and there was no additional contact detail, so skip it
+        return;
+      }
+      contacts.push(contact);
+    });
+  }
+  if (yamlConfig.contact) {
+    contacts.push(
+      ...normalizeToArray(yamlConfig.contact).map(yamlContact => {
+        const contact: ContactDetail = {
+          ...yamlContact,
+          telecom: normalizeToArray(yamlContact.telecom).map(yamlTelecom => {
+            const contactPoint: ContactPoint = {
+              ...yamlTelecom,
+              system: parseCodeWithRequiredValues(
+                yamlTelecom.system,
+                ['phone', 'fax', 'email', 'pager', 'url', 'sms', 'other'],
+                'contact.telecom.system',
+                file
+              ),
+              use: parseCodeWithRequiredValues(
+                yamlTelecom.use,
+                ['home', 'work', 'temp', 'old', 'mobile'],
+                'contact.telecom.use',
+                file
+              )
+            };
+            removeUndefinedValues(contactPoint);
+            return contactPoint;
+          })
+        };
+        if (contact.telecom.length === 0) {
+          delete contact.telecom;
+        }
+        return contact;
+      })
+    );
+  }
+  if (contacts.length === 0) {
+    return;
+  }
+  return contacts;
+}
+
+function parseUsageContext(
+  yamlUsageContext: YAMLConfigurationUsageContext | YAMLConfigurationUsageContext[],
+  file: string
+): UsageContext[] {
+  return normalizeToArray(yamlUsageContext)?.map(yaml => {
+    const usageContext: UsageContext = {
+      code: parseCoding(required(yaml.code, 'useContext.code', file), 'useContext.code', file),
+      valueCodeableConcept: parseCodeableConcept(
+        yaml.valueCodeableConcept,
+        'useContext.valueCodeableConcept',
+        file
+      ),
+      valueQuantity: parseQuantity(yaml.valueQuantity, 'useContext.valueQuantity', file),
+      valueRange: parseRange(yaml.valueRange, 'useContext.valueRange', file),
+      valueReference: parseReference(yaml.valueReference, 'useContext.valueReference', file)
+    };
+    required(
+      yaml.valueCodeableConcept ?? yaml.valueQuantity ?? yaml.valueRange ?? yaml.valueReference,
+      'useContext.value[x]',
+      file
+    );
+    removeUndefinedValues(usageContext);
+    return usageContext;
+  });
+}
+
+function parseJurisdiction(
+  yamlJurisdiction: CodeableConcept | string | (CodeableConcept | string)[],
+  file: string
+): CodeableConcept[] {
+  return parseCodeableConceptArray(normalizeToArray(yamlJurisdiction), 'jurisdiction', file);
+}
+
+function parseDependencies(
+  yamlDependencies: YAMLConfigurationDependencyMap
+): ImplementationGuideDependsOn[] {
+  if (yamlDependencies == null) {
+    return;
+  }
+  return Object.entries(yamlDependencies).map(([packageId, version]) => {
+    return { packageId, version: `${version}` };
+  });
+}
+
+function parseGlobal(yamlGlobal: YAMLConfigurationGlobalMap): ImplementationGuideGlobal[] {
+  if (yamlGlobal == null) {
+    return;
+  }
+  const global: ImplementationGuideGlobal[] = [];
+  for (const [type, profiles] of Object.entries(yamlGlobal)) {
+    normalizeToArray(profiles).forEach(profile => global.push({ type, profile }));
+  }
+  return global;
+}
+
+function parseGroups(yamlGroups: YAMLConfigurationGroupMap): ConfigurationGroup[] {
+  if (yamlGroups == null) {
+    return;
+  }
+  return Object.entries(yamlGroups).map(([name, details]) => {
+    return { name, ...details };
+  });
+}
+
+function parseResources(
+  yamlResources: YAMLConfigurationResourceMap,
+  file: string
+): ConfigurationResource[] {
+  if (yamlResources == null) {
+    return;
+  }
+  return Object.entries(yamlResources).map(([reference, details]) => {
+    if (details === 'omit' || details === '#omit') {
+      return { reference: { reference }, omit: true };
+    }
+    return {
+      reference: { reference },
+      ...details,
+      fhirVersion: normalizeToArray(details.fhirVersion)?.map(v =>
+        parseSimpleCode(v, `resource[${reference}].fhirVersion`, file)
+      )
+    };
+  });
+}
+
+function parsePages(
+  yamlPages: YAMLConfigurationPageTree,
+  file: string
+): ImplementationGuideDefinitionPage[] {
+  if (yamlPages == null) {
+    return;
+  }
+  return Object.entries(yamlPages).map(([nameUrl, details]) => {
+    return parsePage(nameUrl, details, `pages[${nameUrl}]`, file);
+  });
+}
+
+function parsePage(
+  nameUrl: string,
+  details: YAMLConfigurationPage,
+  property: string,
+  file: string
+): ImplementationGuideDefinitionPage {
+  const page: ImplementationGuideDefinitionPage = { nameUrl };
+  if (details?.title) {
+    page.title = details.title;
+  }
+  if (details?.generation) {
+    page.generation = parseCodeWithRequiredValues(
+      details.generation,
+      ['html', 'markdown', 'xml', 'generated'],
+      `${property}.generation`,
+      file
+    );
+  }
+  if (details != null) {
+    Object.entries(details).forEach(([key, value]) => {
+      if (key == 'title' || key == 'generation') {
+        return;
+      }
+      if (page.page == null) {
+        page.page = [];
+      }
+      page.page.push(parsePage(key, value as YAMLConfigurationPage, `${property}[${key}]`, file));
+    });
+  }
+  return page;
+}
+
+function parseParameters(yamlConfig: YAMLConfiguration): ImplementationGuideDefinitionParameter[] {
+  const parameters: ImplementationGuideDefinitionParameter[] = [];
+  if (yamlConfig.copyrightYear || yamlConfig.copyrightyear) {
+    parameters.push({
+      code: 'copyrightyear',
+      value: `${yamlConfig.copyrightYear ?? yamlConfig.copyrightyear}`
+    });
+  }
+  if (yamlConfig.releaseLabel || yamlConfig.releaselabel) {
+    parameters.push({
+      code: 'releaselabel',
+      value: `${yamlConfig.releaseLabel ?? yamlConfig.releaselabel}`
+    });
+  }
+  if (yamlConfig.parameters) {
+    for (const [code, values] of Object.entries(yamlConfig.parameters)) {
+      normalizeToArray(values).forEach(value => parameters.push({ code, value: `${value}` }));
+    }
+  } else if (parameters.length === 0) {
+    return; // return undefined rather than an empty []
+  }
+  return parameters;
+}
+
+function parseTemplates(
+  yamlTemplates: ImplementationGuideDefinitionTemplate | ImplementationGuideDefinitionTemplate[],
+  file: string
+): ImplementationGuideDefinitionTemplate[] {
+  return normalizeToArray(yamlTemplates)?.map(t => {
+    const template: ImplementationGuideDefinitionTemplate = {
+      ...t,
+      code: parseSimpleCode(required(t.code, 'templates.code', file), 'templates.code', file),
+      source: required(t.source, 'templates.source', file)
+    };
+    removeUndefinedValues(template);
+    return template;
+  });
+}
+
+function parseMenu(yamlMenu: YAMLConfigurationMenuTree): ConfigurationMenuItem[] {
+  if (yamlMenu == null) {
+    return;
+  }
+  return Object.entries(yamlMenu).map(([name, value]) => {
+    const item: ConfigurationMenuItem = { name };
+    if (typeof value === 'string') {
+      item.url = value;
+    } else {
+      item.subMenu = parseMenu(value);
+    }
+    return item;
+  });
+}
+
+function parseHistory(yamlConfig: YAMLConfiguration, file: string): ConfigurationHistory {
+  const yamlHistory = yamlConfig['history'];
+  if (yamlHistory == null) {
+    return;
+  }
+  const history: ConfigurationHistory = {
+    'package-id': yamlHistory['package-id'] ?? yamlConfig.packageId ?? yamlConfig.id,
+    canonical: yamlHistory.canonical ?? yamlConfig.url,
+    title: yamlHistory.title ?? yamlConfig.title,
+    introduction: yamlHistory.introduction ?? yamlConfig.description,
+    list: []
+  };
+  if (yamlHistory.current) {
+    if (typeof yamlHistory.current === 'string') {
+      history.list.push({
+        version: 'current',
+        desc: 'Continuous Integration Build (latest in version control)',
+        path: yamlHistory.current,
+        status: 'ci-build',
+        current: true
+      });
+    } else {
+      history.list.push({
+        version: 'current',
+        date: normalizeToString(yamlHistory.current.date),
+        desc:
+          yamlHistory.current.desc ?? 'Continuous Integration Build (latest in version control)',
+        path: yamlHistory.current.path,
+        changes: yamlHistory.current.changes,
+        status: parseCodeWithRequiredValues(
+          yamlHistory.current.status ?? 'ci-build',
+          allowedHistoryStatus,
+          'history[current].status',
+          file
+        ),
+        sequence: yamlHistory.current.sequence,
+        fhirversion: yamlHistory.current.fhirversion,
+        current: yamlHistory.current.current ?? true
+      });
+    }
+  }
+  for (const [key, value] of Object.entries(yamlHistory)) {
+    if (['package-id', 'canonical', 'title', 'introduction', 'current'].indexOf(key) !== -1) {
+      continue;
+    }
+    const item = value as ConfigurationHistoryItem;
+    history.list.push({
+      version: key,
+      date: required(item.date, `history[${key}].date`, file),
+      desc: required(item.desc, `history[${key}].desc`, file),
+      path: required(item.path, `history[${key}].path`, file),
+      changes: item.changes,
+      status: parseCodeWithRequiredValues(
+        required(item.status, `history[${key}].status`, file),
+        allowedHistoryStatus,
+        `history[${key}].status`,
+        file
+      ),
+      sequence: required(item.sequence, `history[${key}].sequence`, file),
+      fhirversion: required(item.fhirversion, `history[${key}].fhirVersion`, file),
+      current: item.current
+    });
+  }
+  history.list.forEach(item => removeUndefinedValues(item));
+  return history;
+}
+
+const allowedHistoryStatus: ConfigurationHistoryItem['status'][] = [
+  'ci-build',
+  'preview',
+  'ballot',
+  'trial-use',
+  'update',
+  'normative',
+  'trial-use+normative'
+];
+
+function removeUndefinedValues<T extends object>(incoming: T): T {
+  Object.keys(incoming).forEach((k: string) => {
+    // @ts-ignore Element implicitly has an 'any' type
+    if (typeof incoming[k] === 'undefined') {
+      // @ts-ignore Element implicitly has an 'any' type
+      delete incoming[k];
+    }
+  });
+  return incoming;
+}

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -4,3 +4,6 @@ export * from './FSHImporter';
 export * from './importText';
 export * from './parserContexts';
 export * from './RawFSH';
+export * from './importConfiguration';
+export * from './YAMLConfiguration';
+export * from './parseCodeLexeme';

--- a/src/import/parseCodeLexeme.ts
+++ b/src/import/parseCodeLexeme.ts
@@ -1,0 +1,33 @@
+import { FshCode } from '../fshtypes';
+
+/**
+ * Parses the FSH code string and creates a FshCode, accomodating for escaped # and quoted codes.
+ * NOTE: This does not accomodate aliases for the code system.  Alias checking should be done after
+ * this parse. In addition, this handles only the system and code (not display)
+ *
+ * @param {string} conceptText - a concept in FSH syntax but with display excluded
+ * @returns {FshCode} the parse FshCode
+ */
+export function parseCodeLexeme(conceptText: string): FshCode {
+  const splitPoint = conceptText.match(/(^|[^\\])(\\\\)*#/);
+  let system: string, code: string;
+  if (splitPoint == null) {
+    system = '';
+    code = conceptText.startsWith('#') ? conceptText.slice(1) : '';
+  } else {
+    system = conceptText.slice(0, splitPoint.index) + splitPoint[0].slice(0, -1);
+    code = conceptText.slice(splitPoint.index + splitPoint[0].length);
+  }
+  system = system.replace(/\\\\/g, '\\').replace(/\\#/g, '#');
+  if (code.startsWith('"')) {
+    code = code
+      .slice(1, code.length - 1)
+      .replace(/\\\\/g, '\\')
+      .replace(/\\"/g, '"');
+  }
+  const concept = new FshCode(code);
+  if (system.length > 0) {
+    concept.system = system;
+  }
+  return concept;
+}

--- a/test/export/FHIRExporter.test.ts
+++ b/test/export/FHIRExporter.test.ts
@@ -4,18 +4,43 @@ import { FHIRDefinitions } from '../../src/fhirdefs';
 
 describe('FHIRExporter', () => {
   it('should output empty results with empty input', () => {
-    const input = new FSHTank([], {
-      name: 'test',
-      version: '0.0.1',
-      canonical: 'http://example.com'
-    });
-    const result = exportFHIR(input, new FHIRDefinitions());
-    expect(result).toEqual(
-      new Package({
+    const input = new FSHTank(
+      [],
+      {
         name: 'test',
         version: '0.0.1',
         canonical: 'http://example.com'
-      })
+      },
+      {
+        filePath: 'config.yaml',
+        id: 'test',
+        version: '0.0.1',
+        url: 'http://example.com',
+        name: 'Test',
+        status: 'draft',
+        fhirVersion: ['4.0.1'],
+        template: 'hl7.fhir.template#0.0.5'
+      }
+    );
+    const result = exportFHIR(input, new FHIRDefinitions());
+    expect(result).toEqual(
+      new Package(
+        {
+          name: 'test',
+          version: '0.0.1',
+          canonical: 'http://example.com'
+        },
+        {
+          filePath: 'config.yaml',
+          id: 'test',
+          version: '0.0.1',
+          url: 'http://example.com',
+          name: 'Test',
+          status: 'draft',
+          fhirVersion: ['4.0.1'],
+          template: 'hl7.fhir.template#0.0.5'
+        }
+      )
     );
   });
 });

--- a/test/import/YAMLConfiguration.test.ts
+++ b/test/import/YAMLConfiguration.test.ts
@@ -1,0 +1,122 @@
+import path from 'path';
+import 'jest-extended';
+import fs from 'fs-extra';
+import YAML from 'yaml';
+import { YAMLConfiguration } from '../../src/import/YAMLConfiguration';
+
+describe('YAMLConfiguration', () => {
+  describe('#yaml-parse', () => {
+    it('should parse the YAML correctly', () => {
+      const configYAML = fs.readFileSync(
+        path.join(__dirname, 'fixtures', 'example-config.yaml'),
+        'utf8'
+      );
+      const config: YAMLConfiguration = YAML.parse(configYAML);
+      expect(config.id).toBe('fhir.us.example');
+      expect(config.url).toBe('http://hl7.org/fhir/us/example');
+      expect(config.name).toBe('ExampleIG');
+      expect(config.title).toBe(
+        'HL7 FHIR Implementation Guide: Example IG Release 1 - US Realm | STU1'
+      );
+      expect(config.description).toBe(
+        'Example IG exercises many of the fields in a SUSHI configuration.'
+      );
+      expect(config.status).toBe('active');
+      expect(config.license).toBe('CC0-1.0');
+      expect(config.date).toBe('2020-02-26');
+      expect(config.version).toBe('1.0.0');
+      expect(config.fhirVersion).toBe('4.0.1');
+      expect(config.template).toBe('hl7.fhir.template#0.0.5');
+      expect(config.copyrightYear).toBe('2019+');
+      expect(config.releaseLabel).toBe('STU1');
+      expect(config.publisher).toEqual({
+        name: 'HL7 FHIR Management Group',
+        url: 'http://www.hl7.org/Special/committees/fhirmg',
+        email: 'fmg@lists.HL7.org'
+      });
+      expect(config.contact).toEqual([
+        {
+          name: 'Bob Smith',
+          telecom: [
+            {
+              system: 'email',
+              value: 'bobsmith@example.org',
+              use: 'work'
+            }
+          ]
+        }
+      ]);
+      expect(config.jurisdiction).toBe('urn:iso:std:iso:3166#US "United States of America"');
+      expect(config.dependencies).toEqual({
+        'hl7.fhir.us.core': '3.1.0'
+      });
+      expect(config.global).toEqual({
+        Patient: 'http://example.org/fhir/StructureDefinition/my-patient-profile',
+        Encounter: 'http://example.org/fhir/StructureDefinition/my-encounter-profile'
+      });
+      expect(config.resources).toEqual({
+        'Patient/my-example-patient': {
+          name: 'My Example Patient',
+          description: 'An example Patient',
+          exampleBoolean: true
+        },
+        'Patient/bad-example': 'omit'
+      });
+      expect(config.groups).toEqual({
+        GroupA: {
+          description: 'The Alpha Group',
+          resources: ['StructureDefinition/animal-patient', 'StructureDefinition/arm-procedure']
+        },
+        GroupB: {
+          description: 'The Beta Group',
+          resources: ['StructureDefinition/bark-control', 'StructureDefinition/bee-sting']
+        }
+      });
+      expect(config.pages).toEqual({
+        'index.md': {
+          title: 'Example Home'
+        },
+        'implementation.xml': null,
+        'examples.xml': {
+          title: 'Examples Overview',
+          'simpleExamples.xml': null,
+          'complexExamples.xml': null
+        }
+      });
+      expect(config.menu).toEqual({
+        Home: 'index.html',
+        Artifacts: {
+          Profiles: 'artifacts.html#2',
+          Extensions: 'artifacts.html#3',
+          'Value Sets': 'artifacts.html#4'
+        },
+        Downloads: 'downloads.html',
+        History: 'http://hl7.org/fhir/us/example/history.html'
+      });
+      expect(config.parameters).toEqual({
+        excludettl: true,
+        validation: ['allow-any-extensions', 'no-broken-links']
+      });
+      expect(config.history).toEqual({
+        current: 'http://build.fhir.org/ig/HL7/example-ig/',
+        '1.0.0': {
+          fhirversion: '4.0.1',
+          date: '2020-03-06',
+          desc: 'STU 1 Release',
+          path: 'https://hl7.org/fhir/us/example/STU1/',
+          status: 'trial-use',
+          sequence: 'STU 1',
+          current: true
+        },
+        '0.9.1': {
+          fhirversion: '4.0.0',
+          date: '2019-06-10',
+          desc: 'Initial STU ballot (Sep 2019 Ballot)',
+          path: 'https://hl7.org/fhir/us/example/2019Sep/',
+          status: 'ballot',
+          sequence: 'STU 1'
+        }
+      });
+    });
+  });
+});

--- a/test/import/importConfiguration.test.ts
+++ b/test/import/importConfiguration.test.ts
@@ -1,0 +1,2033 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { loggerSpy } from '../testhelpers/loggerSpy';
+import { importConfiguration, YAMLConfiguration } from '../../src/import';
+import { Configuration } from '../../src/fshtypes';
+
+describe('importConfiguration', () => {
+  let minYAML: YAMLConfiguration;
+  beforeEach(() => {
+    minYAML = {
+      id: 'fhir.us.minimal',
+      url: 'http://hl7.org/fhir/us/minimal',
+      name: 'MinimalIG',
+      status: 'draft',
+      version: '1.0.0',
+      fhirVersion: ['4.0.1'],
+      template: 'hl7.fhir.template#0.0.5'
+    };
+    loggerSpy.reset();
+  });
+
+  it('should import minimal config', () => {
+    const yamlPath = path.join(__dirname, 'fixtures', 'minimal-config.yaml');
+    const yaml = fs.readFileSync(yamlPath, 'utf8');
+    const actual = importConfiguration(yaml, yamlPath);
+    const expected: Configuration = {
+      filePath: yamlPath,
+      id: 'fhir.us.minimal',
+      url: 'http://hl7.org/fhir/us/minimal',
+      name: 'MinimalIG',
+      status: 'draft',
+      version: '1.0.0',
+      fhirVersion: ['4.0.1'],
+      template: 'hl7.fhir.template#0.0.5',
+      packageId: 'fhir.us.minimal'
+    };
+    expect(actual).toEqual(expected);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
+  });
+
+  it('should import example config', () => {
+    const yamlPath = path.join(__dirname, 'fixtures', 'example-config.yaml');
+    const yaml = fs.readFileSync(yamlPath, 'utf8');
+    const actual = importConfiguration(yaml, yamlPath);
+    const expected: Configuration = {
+      filePath: yamlPath,
+      id: 'fhir.us.example',
+      url: 'http://hl7.org/fhir/us/example',
+      name: 'ExampleIG',
+      title: 'HL7 FHIR Implementation Guide: Example IG Release 1 - US Realm | STU1',
+      description: 'Example IG exercises many of the fields in a SUSHI configuration.',
+      status: 'active',
+      packageId: 'fhir.us.example',
+      license: 'CC0-1.0',
+      date: '2020-02-26',
+      version: '1.0.0',
+      fhirVersion: ['4.0.1'],
+      template: 'hl7.fhir.template#0.0.5',
+      publisher: 'HL7 FHIR Management Group',
+      contact: [
+        {
+          name: 'HL7 FHIR Management Group',
+          telecom: [
+            { system: 'url', value: 'http://www.hl7.org/Special/committees/fhirmg' },
+            { system: 'email', value: 'fmg@lists.HL7.org' }
+          ]
+        },
+        {
+          name: 'Bob Smith',
+          telecom: [{ system: 'email', value: 'bobsmith@example.org', use: 'work' }]
+        }
+      ],
+      jurisdiction: [
+        {
+          coding: [
+            { code: 'US', system: 'urn:iso:std:iso:3166', display: 'United States of America' }
+          ]
+        }
+      ],
+      dependencies: [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }],
+      global: [
+        {
+          type: 'Patient',
+          profile: 'http://example.org/fhir/StructureDefinition/my-patient-profile'
+        },
+        {
+          type: 'Encounter',
+          profile: 'http://example.org/fhir/StructureDefinition/my-encounter-profile'
+        }
+      ],
+      resources: [
+        {
+          reference: { reference: 'Patient/my-example-patient' },
+          name: 'My Example Patient',
+          description: 'An example Patient',
+          exampleBoolean: true
+        },
+        { reference: { reference: 'Patient/bad-example' }, omit: true }
+      ],
+      groups: [
+        {
+          name: 'GroupA',
+          description: 'The Alpha Group',
+          resources: ['StructureDefinition/animal-patient', 'StructureDefinition/arm-procedure']
+        },
+        {
+          name: 'GroupB',
+          description: 'The Beta Group',
+          resources: ['StructureDefinition/bark-control', 'StructureDefinition/bee-sting']
+        }
+      ],
+      pages: [
+        { nameUrl: 'index.md', title: 'Example Home' },
+        { nameUrl: 'implementation.xml' },
+        {
+          nameUrl: 'examples.xml',
+          title: 'Examples Overview',
+          page: [{ nameUrl: 'simpleExamples.xml' }, { nameUrl: 'complexExamples.xml' }]
+        }
+      ],
+      menu: [
+        { name: 'Home', url: 'index.html' },
+        {
+          name: 'Artifacts',
+          subMenu: [
+            { name: 'Profiles', url: 'artifacts.html#2' },
+            { name: 'Extensions', url: 'artifacts.html#3' },
+            { name: 'Value Sets', url: 'artifacts.html#4' }
+          ]
+        },
+        { name: 'Downloads', url: 'downloads.html' },
+        { name: 'History', url: 'http://hl7.org/fhir/us/example/history.html' }
+      ],
+      parameters: [
+        { code: 'copyrightyear', value: '2019+' },
+        { code: 'releaselabel', value: 'STU1' },
+        { code: 'excludettl', value: 'true' },
+        { code: 'validation', value: 'allow-any-extensions' },
+        { code: 'validation', value: 'no-broken-links' }
+      ],
+      history: {
+        'package-id': 'fhir.us.example',
+        canonical: 'http://hl7.org/fhir/us/example',
+        title: 'HL7 FHIR Implementation Guide: Example IG Release 1 - US Realm | STU1',
+        introduction: 'Example IG exercises many of the fields in a SUSHI configuration.',
+        list: [
+          {
+            version: 'current',
+            desc: 'Continuous Integration Build (latest in version control)',
+            path: 'http://build.fhir.org/ig/HL7/example-ig/',
+            status: 'ci-build',
+            current: true
+          },
+          {
+            version: '1.0.0',
+            fhirversion: '4.0.1',
+            date: '2020-03-06',
+            desc: 'STU 1 Release',
+            path: 'https://hl7.org/fhir/us/example/STU1/',
+            status: 'trial-use',
+            sequence: 'STU 1',
+            current: true
+          },
+          {
+            version: '0.9.1',
+            fhirversion: '4.0.0',
+            date: '2019-06-10',
+            desc: 'Initial STU ballot (Sep 2019 Ballot)',
+            path: 'https://hl7.org/fhir/us/example/2019Sep/',
+            status: 'ballot',
+            sequence: 'STU 1'
+          }
+        ]
+      }
+    };
+    expect(actual).toEqual(expected);
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
+  });
+
+  describe('#id', () => {
+    it('should import id as-is', () => {
+      minYAML.id = 'my-id';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.id).toBe('my-id');
+    });
+    it('should report an error and throw if id is missing', () => {
+      delete minYAML.id;
+      expect(() => importConfiguration(minYAML, 'test-config.yaml')).toThrow(
+        'Minimal config not met'
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /SUSHI minimally requires the following configuration properties to start processing FSH: id, version, url, fhirVersion\.\s*File: test-config\.yaml/
+      );
+    });
+  });
+
+  describe('#meta', () => {
+    it('should support fhir syntax for meta coded properties', () => {
+      minYAML.meta = {
+        security: [{ system: 'http://foo.org', code: 'bar', display: 'FooBar' }],
+        tag: [{ system: 'http://foo.org', code: 'baz', display: 'FooBaz' }]
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.meta).toEqual({
+        security: [{ system: 'http://foo.org', code: 'bar', display: 'FooBar' }],
+        tag: [{ system: 'http://foo.org', code: 'baz', display: 'FooBaz' }]
+      });
+    });
+    it('should support FSH syntax for meta coded properties', () => {
+      minYAML.meta = {
+        security: ['http://foo.org#bar "FooBar"'],
+        tag: ['http://foo.org#baz "FooBaz"']
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.meta).toEqual({
+        security: [{ system: 'http://foo.org', code: 'bar', display: 'FooBar' }],
+        tag: [{ system: 'http://foo.org', code: 'baz', display: 'FooBaz' }]
+      });
+    });
+    it('should report invalid FSH syntax for meta coded properties', () => {
+      minYAML.meta = {
+        security: ['foobar'],
+        tag: ['foobaz']
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(
+        /Invalid code format for meta\.security: foobar\s*File: test-config\.yaml/
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid code format for meta\.tag: foobaz\s*File: test-config\.yaml/
+      );
+      expect(config.meta).toEqual({});
+    });
+  });
+
+  describe('#implicitRules', () => {
+    it('should import implicitRules as-is', () => {
+      minYAML.implicitRules = 'http://foo.org/bar';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.implicitRules).toBe('http://foo.org/bar');
+    });
+  });
+
+  describe('#language', () => {
+    it('should support string for language', () => {
+      minYAML.language = 'en';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.language).toBe('en');
+    });
+    it('should support code syntax for language', () => {
+      minYAML.language = '#en';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.language).toBe('en');
+    });
+  });
+
+  describe('#text', () => {
+    it('should support fhir syntax for text.status', () => {
+      minYAML.text = {
+        status: 'empty',
+        div: '<div></div>'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.text).toEqual({
+        status: 'empty',
+        div: '<div></div>'
+      });
+    });
+    it('should support FSH syntax for text.status', () => {
+      minYAML.text = {
+        status: '#empty',
+        div: '<div></div>'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.text).toEqual({
+        status: 'empty',
+        div: '<div></div>'
+      });
+    });
+    it('should report invalid text.status code', () => {
+      minYAML.text = {
+        // @ts-ignore Type '"whoknows"' is not assignable to type '"empty" | "generated" ...'
+        status: 'whoknows',
+        div: '<div></div>'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid text\.status value: 'whoknows'\. Must be one of: 'generated','extensions','additional','empty'\.\s*File: test-config\.yaml/
+      );
+      expect(config.text.status).toBeUndefined();
+    });
+  });
+
+  describe('#contained', () => {
+    // NOTE: special FSH syntax concepts/quantities aren't available in contained resources
+    it('should import contained as-is', () => {
+      minYAML.contained = [
+        {
+          resourceType: 'Patient',
+          id: 'bob',
+          active: true
+        }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.contained).toEqual([
+        {
+          resourceType: 'Patient',
+          id: 'bob',
+          active: true
+        }
+      ]);
+    });
+  });
+
+  describe('#extension', () => {
+    it('should import extension as-is', () => {
+      minYAML.extension = [
+        {
+          url: 'http://extension.org/my-extension',
+          // @ts-ignore Type '{ url: string; valueBoolean: boolean; }' is not assignable ...
+          valueBoolean: true
+        }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.extension).toEqual([
+        {
+          url: 'http://extension.org/my-extension',
+          valueBoolean: true
+        }
+      ]);
+    });
+  });
+
+  describe('#modifierExtension', () => {
+    it('should import modifierExtension as-is', () => {
+      minYAML.modifierExtension = [
+        {
+          url: 'http://extension.org/my-modifier-extension',
+          // @ts-ignore Type '{ url: string; valueBoolean: boolean; }' is not assignable ...
+          valueBoolean: true
+        }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.modifierExtension).toEqual([
+        {
+          url: 'http://extension.org/my-modifier-extension',
+          valueBoolean: true
+        }
+      ]);
+    });
+  });
+
+  describe('#url', () => {
+    it('should import url as-is', () => {
+      minYAML.url = 'http://foo.org/some-url';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.url).toBe('http://foo.org/some-url');
+    });
+    it('should report an error and throw if url is missing', () => {
+      delete minYAML.url;
+      expect(() => importConfiguration(minYAML, 'test-config.yaml')).toThrow(
+        'Minimal config not met'
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /SUSHI minimally requires the following configuration properties to start processing FSH: id, version, url, fhirVersion\.\s*File: test-config\.yaml/
+      );
+    });
+  });
+
+  describe('#version', () => {
+    it('should support a single-component version when YAML parses it as a number', () => {
+      // @ts-ignore Type '1' is not assignable to type 'string'
+      minYAML.version = 1; // YAML parse will interpret 1 as a number, not a string
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.version).toBe('1');
+    });
+    it('should support a two-component version when YAML parses it as a number', () => {
+      minYAML.version = 1.2; // YAML parse will interpret 1.2 as a number, not a string
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.version).toBe('1.2');
+    });
+    it('should report an error and throw if version is missing', () => {
+      delete minYAML.version;
+      expect(() => importConfiguration(minYAML, 'test-config.yaml')).toThrow(
+        'Minimal config not met'
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /SUSHI minimally requires the following configuration properties to start processing FSH: id, version, url, fhirVersion\.\s*File: test-config\.yaml/
+      );
+    });
+  });
+
+  describe('#name', () => {
+    it('should import name as-is', () => {
+      minYAML.name = 'MyIG';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.name).toBe('MyIG');
+    });
+    it('should report an error if name is missing', () => {
+      delete minYAML.name;
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: name\s*File: test-config\.yaml/
+      );
+      expect(config.name).toBeUndefined();
+    });
+  });
+
+  describe('#title', () => {
+    it('should import title as-is', () => {
+      minYAML.title = 'My IG';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.title).toBe('My IG');
+    });
+  });
+
+  describe('#status', () => {
+    it('should support string for status', () => {
+      minYAML.status = 'draft';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.status).toBe('draft');
+    });
+    it('should support code syntax for status', () => {
+      minYAML.status = '#draft';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.status).toBe('draft');
+    });
+    it('should report invalid status code', () => {
+      // @ts-ignore Type '"whoknows"' is not assignable to type 'YAMLConfigurationStatus'.
+      minYAML.status = 'married';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid status value: 'married'\. Must be one of: 'draft','active','retired','unknown'\.\s*File: test-config\.yaml/
+      );
+      expect(config.status).toBeUndefined();
+    });
+    it('should report an error if status is missing', () => {
+      delete minYAML.status;
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: status\s*File: test-config\.yaml/
+      );
+      expect(config.status).toBeUndefined();
+    });
+  });
+
+  describe('#experimental', () => {
+    it('should import experimental as-is', () => {
+      minYAML.experimental = true;
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.experimental).toBe(true);
+    });
+  });
+
+  describe('#date', () => {
+    it('should support a year-only date when YAML parses it as a number', () => {
+      // @ts-ignore Type '2000' is not assignable to type 'string'
+      minYAML.date = 2000; // YAML parse will interpret 2000 as a number, not a string
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.date).toBe('2000');
+    });
+  });
+
+  describe('#publisher', () => {
+    it('should convert single publisher with name only to publisher only', () => {
+      minYAML.publisher = { name: 'Bob' };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.publisher).toBe('Bob');
+      expect(config.contact).toBeUndefined();
+    });
+    it('should convert single publisher with name and contact info to publisher and contact', () => {
+      minYAML.publisher = { name: 'Bob', email: 'bob@example.org', url: 'http://bob.example.org' };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.publisher).toBe('Bob');
+      expect(config.contact).toEqual([
+        {
+          name: 'Bob',
+          telecom: [
+            { system: 'url', value: 'http://bob.example.org' },
+            { system: 'email', value: 'bob@example.org' }
+          ]
+        }
+      ]);
+    });
+    it('should convert multiple publishers to publisher and contacts', () => {
+      minYAML.publisher = [
+        { name: 'Bob', email: 'bob@example.org', url: 'http://bob.example.org' },
+        { name: 'Sue', email: 'sue@example.org', url: 'http://sue.example.org' }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.publisher).toBe('Bob');
+      expect(config.contact).toEqual([
+        {
+          name: 'Bob',
+          telecom: [
+            { system: 'url', value: 'http://bob.example.org' },
+            { system: 'email', value: 'bob@example.org' }
+          ]
+        },
+        {
+          name: 'Sue',
+          telecom: [
+            { system: 'url', value: 'http://sue.example.org' },
+            { system: 'email', value: 'sue@example.org' }
+          ]
+        }
+      ]);
+    });
+  });
+
+  describe('#contact', () => {
+    it('should convert single-item contact to an array', () => {
+      minYAML.contact = { name: 'Bob', telecom: [{ system: 'email', value: 'bob@example.com' }] };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.contact).toEqual([
+        { name: 'Bob', telecom: [{ system: 'email', value: 'bob@example.com' }] }
+      ]);
+    });
+    it('should support contact as an array', () => {
+      minYAML.contact = [{ name: 'Bob', telecom: [{ system: 'email', value: 'bob@example.com' }] }];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.contact).toEqual([
+        { name: 'Bob', telecom: [{ system: 'email', value: 'bob@example.com' }] }
+      ]);
+    });
+    it('should translate codes for contact.telecom.use/system', () => {
+      minYAML.contact = {
+        name: 'Bob',
+        telecom: [{ system: '#email', value: 'bob@example.com', use: '#work' }]
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.contact).toEqual([
+        { name: 'Bob', telecom: [{ system: 'email', value: 'bob@example.com', use: 'work' }] }
+      ]);
+    });
+    it('should report invalid telecom codes', () => {
+      minYAML.contact = {
+        name: 'Bob',
+        // @ts-ignore Type ... is not assignable to type ...
+        telecom: [{ system: '#carrier-pidgeon', value: 'bob@example.com', use: '#whateva' }]
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(
+        /Invalid contact\.telecom\.system value: 'carrier-pidgeon'\. Must be one of: 'phone','fax','email','pager','url','sms','other'\.\s*File: test-config\.yaml/
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid contact\.telecom\.use value: 'whateva'\. Must be one of: 'home','work','temp','old','mobile'\.\s*File: test-config\.yaml/
+      );
+      expect(config.contact[0].telecom[0].system).toBeUndefined();
+      expect(config.contact[0].telecom[0].use).toBeUndefined();
+    });
+    it('should put contacts after publisher contact details', () => {
+      minYAML.publisher = { name: 'Bob', email: 'bob@example.org', url: 'http://bob.example.org' };
+      minYAML.contact = {
+        name: 'Frank',
+        telecom: [{ system: 'email', value: 'frank@example.com' }]
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.publisher).toBe('Bob');
+      expect(config.contact).toEqual([
+        {
+          name: 'Bob',
+          telecom: [
+            { system: 'url', value: 'http://bob.example.org' },
+            { system: 'email', value: 'bob@example.org' }
+          ]
+        },
+        { name: 'Frank', telecom: [{ system: 'email', value: 'frank@example.com' }] }
+      ]);
+    });
+  });
+
+  describe('#description', () => {
+    it('should copy description as-is', () => {
+      minYAML.description = 'This is a great IG. Really great. The best.';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.description).toBe('This is a great IG. Really great. The best.');
+    });
+  });
+
+  describe('#useContext', () => {
+    it('should convert single-item useContext to an array', () => {
+      minYAML.useContext = {
+        code: {
+          system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+          code: 'gender',
+          display: 'Gender'
+        },
+        valueCodeableConcept: {
+          coding: [
+            {
+              system: 'http://hl7.org/fhir/administrative-gender',
+              code: 'female',
+              display: 'Female'
+            }
+          ]
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'gender',
+            display: 'Gender'
+          },
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/administrative-gender',
+                code: 'female',
+                display: 'Female'
+              }
+            ]
+          }
+        }
+      ]);
+    });
+    it('should support useContext as an array', () => {
+      minYAML.useContext = [
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'gender',
+            display: 'Gender'
+          },
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/administrative-gender',
+                code: 'female',
+                display: 'Female'
+              }
+            ]
+          }
+        }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'gender',
+            display: 'Gender'
+          },
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/administrative-gender',
+                code: 'female',
+                display: 'Female'
+              }
+            ]
+          }
+        }
+      ]);
+    });
+    it('should translate codes for code and valueCodeableConcept', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#gender "Gender"',
+        valueCodeableConcept: 'http://hl7.org/fhir/administrative-gender#female "Female"'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'gender',
+            display: 'Gender'
+          },
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/administrative-gender',
+                code: 'female',
+                display: 'Female'
+              }
+            ]
+          }
+        }
+      ]);
+    });
+    it('should report invalid FSH syntax for code and valueCodeableConcept', () => {
+      minYAML.useContext = {
+        code: 'gender',
+        valueCodeableConcept: 'female'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(
+        /Invalid code format for useContext\.code: gender\s*File: test-config\.yaml/
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid code format for useContext\.valueCodeableConcept: female\s*File: test-config\.yaml/
+      );
+      expect(config.useContext).toEqual([{}]);
+    });
+    it('should translate codes for valueQuantity', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#age "Age Range"',
+        // technically "age" uses valueRange, but no other contexts used valueQuantity either, so...
+        valueQuantity: {
+          code: '#a',
+          system: 'http://unitsofmeasure.org',
+          value: 50,
+          comparator: '#>='
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'age',
+            display: 'Age Range'
+          },
+          valueQuantity: {
+            code: 'a',
+            system: 'http://unitsofmeasure.org',
+            value: 50,
+            comparator: '>='
+          }
+        }
+      ]);
+    });
+    // useContext should support FSH quantity syntax for quantity properties
+    it('should translate quantity for valueQuantity', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#age "Age Range"',
+        // technically "age" uses valueRange, but no other contexts used valueQuantity either, so...
+        valueQuantity: "50 'a'"
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'age',
+            display: 'Age Range'
+          },
+          valueQuantity: {
+            code: 'a',
+            system: 'http://unitsofmeasure.org',
+            value: 50
+          }
+        }
+      ]);
+    });
+    it('should report invalid FSH syntax for quantity', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#age "Age Range"',
+        // technically "age" uses valueRange, but no other contexts used valueQuantity either, so...
+        valueQuantity: '50 a' // NOTE: missing '' around unit
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid useContext\.valueQuantity value: 50 a\s*File: test-config\.yaml/
+      );
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'age',
+            display: 'Age Range'
+          }
+        }
+      ]);
+    });
+    it('should report invalid quantity.comparator code', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#age "Age Range"',
+        // technically "age" uses valueRange, but no other contexts used valueQuantity either, so...
+        valueQuantity: {
+          code: '#a',
+          system: 'http://unitsofmeasure.org',
+          value: 50,
+          // @ts-ignore Type '"!="' is not assignable to type '"<" | "<=" | ">=" | ">" | "#<" | ...'.
+          comparator: '!='
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid useContext\.valueQuantity\.comparator value: '!='\. Must be one of: '<','<=','>=','>'\.\s*File: test-config\.yaml/
+      );
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'age',
+            display: 'Age Range'
+          },
+          valueQuantity: {
+            code: 'a',
+            system: 'http://unitsofmeasure.org',
+            value: 50
+          }
+        }
+      ]);
+    });
+    it('should translate codes for valueRange', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#age "Age Range"',
+        valueRange: {
+          low: {
+            code: '#a',
+            system: 'http://unitsofmeasure.org',
+            value: 50
+          },
+          high: {
+            code: '#a',
+            system: 'http://unitsofmeasure.org',
+            value: 65
+          }
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'age',
+            display: 'Age Range'
+          },
+          valueRange: {
+            low: {
+              code: 'a',
+              system: 'http://unitsofmeasure.org',
+              value: 50
+            },
+            high: {
+              code: 'a',
+              system: 'http://unitsofmeasure.org',
+              value: 65
+            }
+          }
+        }
+      ]);
+    });
+    it('should translate quantity for valueQuantity', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#age "Age Range"',
+        valueRange: { low: "50 'a'", high: "65 'a'" }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'age',
+            display: 'Age Range'
+          },
+          valueRange: {
+            low: {
+              code: 'a',
+              system: 'http://unitsofmeasure.org',
+              value: 50
+            },
+            high: {
+              code: 'a',
+              system: 'http://unitsofmeasure.org',
+              value: 65
+            }
+          }
+        }
+      ]);
+    });
+    it('should report invalid FSH syntax for range low / high quantity', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#age "Age Range"',
+        valueRange: { low: '50 a', high: '65 a' }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(
+        /Invalid useContext\.valueRange\.low value: 50 a\s*File: test-config\.yaml/
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid useContext\.valueRange\.high value: 65 a\s*File: test-config\.yaml/
+      );
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'age',
+            display: 'Age Range'
+          },
+          valueRange: {}
+        }
+      ]);
+    });
+    it('should translate codes for valueReference', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#venue "Clinical Venue"',
+        valueReference: {
+          identifier: {
+            use: '#official',
+            type: 'http://terminology.hl7.org/CodeSystem/v2-0203#PRN "Provider number"',
+            value: '123',
+            assigner: {
+              identifier: {
+                use: '#temp',
+                type: 'http://terminology.hl7.org/CodeSystem/v2-0203#TAX "Tax ID number"',
+                value: 'abc'
+              }
+            }
+          }
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'venue',
+            display: 'Clinical Venue'
+          },
+          valueReference: {
+            identifier: {
+              use: 'official',
+              type: {
+                coding: [
+                  {
+                    system: 'http://terminology.hl7.org/CodeSystem/v2-0203',
+                    code: 'PRN',
+                    display: 'Provider number'
+                  }
+                ]
+              },
+              value: '123',
+              assigner: {
+                identifier: {
+                  use: 'temp',
+                  type: {
+                    coding: [
+                      {
+                        system: 'http://terminology.hl7.org/CodeSystem/v2-0203',
+                        code: 'TAX',
+                        display: 'Tax ID number'
+                      }
+                    ]
+                  },
+                  value: 'abc'
+                }
+              }
+            }
+          }
+        }
+      ]);
+    });
+    it('should report invalid FSH syntax for identifier.type', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#venue "Clinical Venue"',
+        valueReference: {
+          identifier: {
+            use: '#official',
+            type: 'PRN',
+            value: '123',
+            assigner: {
+              identifier: {
+                use: '#temp',
+                type: 'TAX',
+                value: 'abc'
+              }
+            }
+          }
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(
+        /Invalid code format for useContext\.valueReference\.identifier\.type: PRN\s*File: test-config\.yaml/
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid code format for useContext\.valueReference\.identifier\.assigner\.identifier\.type: TAX\s*File: test-config\.yaml/
+      );
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'venue',
+            display: 'Clinical Venue'
+          },
+          valueReference: {
+            identifier: {
+              use: 'official',
+              value: '123',
+              assigner: {
+                identifier: {
+                  use: 'temp',
+                  value: 'abc'
+                }
+              }
+            }
+          }
+        }
+      ]);
+    });
+    it('should report invalid FSH identifier.use codes', () => {
+      minYAML.useContext = {
+        code: 'http://terminology.hl7.org/CodeSystem/usage-context-type#venue "Clinical Venue"',
+        valueReference: {
+          identifier: {
+            // @ts-ignore Type '"#myob"' is not assignable to type '"temp" | "old" | "#temp" | ...'.
+            use: '#myob',
+            value: '123',
+            assigner: {
+              identifier: {
+                // @ts-ignore Type '"#the-usual"' is not assignable to type '"temp" | "old" | ...'.
+                use: '#the-usual',
+                value: 'abc'
+              }
+            }
+          }
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(
+        /Invalid useContext\.valueReference\.identifier\.use value: 'myob'\. Must be one of: 'usual','official','temp','secondary','old'\.\s*File: test-config\.yaml/
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid useContext\.valueReference\.identifier\.assigner\.identifier\.use value: 'the-usual'\. Must be one of: 'usual','official','temp','secondary','old'\.\s*File: test-config\.yaml/
+      );
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'venue',
+            display: 'Clinical Venue'
+          },
+          valueReference: {
+            identifier: {
+              value: '123',
+              assigner: {
+                identifier: {
+                  value: 'abc'
+                }
+              }
+            }
+          }
+        }
+      ]);
+    });
+    it('should report an error if useContext.code is missing', () => {
+      // @ts-ignore Type '...' is not assignable to type ...
+      minYAML.useContext = {
+        valueCodeableConcept: {
+          coding: [
+            {
+              system: 'http://hl7.org/fhir/administrative-gender',
+              code: 'female',
+              display: 'Female'
+            }
+          ]
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: useContext\.code\s*File: test-config\.yaml/
+      );
+      expect(config.useContext).toEqual([
+        {
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/administrative-gender',
+                code: 'female',
+                display: 'Female'
+              }
+            ]
+          }
+        }
+      ]);
+    });
+    it('should report an error if useContext.value[x] is missing', () => {
+      // @ts-ignore Type '...' is not assignable to type ...
+      minYAML.useContext = {
+        code: {
+          system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+          code: 'gender',
+          display: 'Gender'
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: useContext\.value\[x\]\s*File: test-config\.yaml/
+      );
+      expect(config.useContext).toEqual([
+        {
+          code: {
+            system: 'http://terminology.hl7.org/CodeSystem/usage-context-type',
+            code: 'gender',
+            display: 'Gender'
+          }
+        }
+      ]);
+    });
+  });
+
+  describe('#jurisdiction', () => {
+    it('should convert single-item jurisdiction to an array', () => {
+      minYAML.jurisdiction = {
+        coding: [
+          {
+            code: 'US',
+            system: 'urn:iso:std:iso:3166',
+            display: 'United States of America'
+          }
+        ]
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.jurisdiction).toEqual([
+        {
+          coding: [
+            { code: 'US', system: 'urn:iso:std:iso:3166', display: 'United States of America' }
+          ]
+        }
+      ]);
+    });
+    it('should support jurisdiction as an array', () => {
+      minYAML.jurisdiction = [
+        {
+          coding: [
+            { code: 'US', system: 'urn:iso:std:iso:3166', display: 'United States of America' }
+          ]
+        }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.jurisdiction).toEqual([
+        {
+          coding: [
+            { code: 'US', system: 'urn:iso:std:iso:3166', display: 'United States of America' }
+          ]
+        }
+      ]);
+    });
+    it('should translate jurisdiction codes', () => {
+      minYAML.jurisdiction = ['urn:iso:std:iso:3166#US "United States of America"'];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.jurisdiction).toEqual([
+        {
+          coding: [
+            { code: 'US', system: 'urn:iso:std:iso:3166', display: 'United States of America' }
+          ]
+        }
+      ]);
+    });
+    it('should report invalid FSH syntax for jurisdiction', () => {
+      minYAML.jurisdiction = ['merica'];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid code format for jurisdiction: merica\s*File: test-config\.yaml/
+      );
+      expect(config.jurisdiction).toBeUndefined();
+    });
+  });
+
+  describe('#copyright', () => {
+    it('should copy copyright as-is', () => {
+      minYAML.copyright = 'Copyright Scaly Productions 2020';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.copyright).toBe('Copyright Scaly Productions 2020');
+    });
+  });
+
+  describe('#packageId', () => {
+    it('should use the id as packageId when packageId is not provided', () => {
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.packageId).toBe('fhir.us.minimal');
+    });
+    it('should use the packageId when it is provided', () => {
+      minYAML.packageId = 'diff.package.id';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.id).toBe('fhir.us.minimal');
+      expect(config.packageId).toBe('diff.package.id');
+    });
+  });
+
+  describe('#license', () => {
+    // license supports string or code syntax
+    it('should support string for license', () => {
+      minYAML.license = 'CC0-1.0';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.license).toBe('CC0-1.0');
+    });
+    it('should support code syntax for license', () => {
+      minYAML.license = '#CC0-1.0';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.license).toBe('CC0-1.0');
+    });
+  });
+
+  describe('#fhirVersion', () => {
+    it('should support fhirVersion as an array', () => {
+      minYAML.fhirVersion = ['4.0.1', '3.0.2'];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.fhirVersion).toEqual(['4.0.1', '3.0.2']);
+    });
+    it('should convert single-item fhirVersion to an array', () => {
+      minYAML.fhirVersion = '4.0.1';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.fhirVersion).toEqual(['4.0.1']);
+    });
+    it('should support FSH syntax for fhirVersion', () => {
+      // because... fhirVersion is actually a code!
+      minYAML.fhirVersion = ['#4.0.1'];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.fhirVersion).toEqual(['4.0.1']);
+    });
+    it('should report an error and throw if fhirVersion is missing', () => {
+      delete minYAML.fhirVersion;
+      expect(() => importConfiguration(minYAML, 'test-config.yaml')).toThrow(
+        'Minimal config not met'
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /SUSHI minimally requires the following configuration properties to start processing FSH: id, version, url, fhirVersion\.\s*File: test-config\.yaml/
+      );
+    });
+    it('should report an error and throw if fhirVersion is an empty array', () => {
+      minYAML.fhirVersion = [];
+      expect(() => importConfiguration(minYAML, 'test-config.yaml')).toThrow(
+        'Minimal config not met'
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /SUSHI minimally requires the following configuration properties to start processing FSH: id, version, url, fhirVersion\.\s*File: test-config\.yaml/
+      );
+    });
+  });
+
+  describe('#dependencies', () => {
+    it('should convert the dependencies map to a list', () => {
+      minYAML.dependencies = {
+        foo: '1.2.3',
+        bar: '4.5.6'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.dependencies).toEqual([
+        { packageId: 'foo', version: '1.2.3' },
+        { packageId: 'bar', version: '4.5.6' }
+      ]);
+    });
+    it('should convert the dependencies map to a list when YAML imports version as a number', () => {
+      minYAML.dependencies = {
+        // @ts-ignore Type '1' is not assignable to type 'string'
+        foo: 1, // YAML parse will interpret 1 as a number, not a string
+        // @ts-ignore Type '2.3' is not assignable to type 'string'
+        bar: 2.3 // YAML parse will interpret 2.3 as a number, not a string
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.dependencies).toEqual([
+        { packageId: 'foo', version: '1' },
+        { packageId: 'bar', version: '2.3' }
+      ]);
+    });
+  });
+
+  describe('#global', () => {
+    it('should convert the global map to a list', () => {
+      minYAML.global = {
+        Patient: 'http://example.org/fhir/StructureDefinition/my-patient-profile',
+        Encounter: 'http://example.org/fhir/StructureDefinition/my-encounter-profile'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.global).toEqual([
+        {
+          type: 'Patient',
+          profile: 'http://example.org/fhir/StructureDefinition/my-patient-profile'
+        },
+        {
+          type: 'Encounter',
+          profile: 'http://example.org/fhir/StructureDefinition/my-encounter-profile'
+        }
+      ]);
+    });
+    it('should convert the global array values to a list items', () => {
+      minYAML.global = {
+        Patient: [
+          'http://example.org/fhir/StructureDefinition/my-patient-profile',
+          'http://example.org/fhir/StructureDefinition/my-other-patient-profile'
+        ],
+        Encounter: [
+          'http://example.org/fhir/StructureDefinition/my-encounter-profile',
+          'http://example.org/fhir/StructureDefinition/my-other-encounter-profile'
+        ]
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.global).toEqual([
+        {
+          type: 'Patient',
+          profile: 'http://example.org/fhir/StructureDefinition/my-patient-profile'
+        },
+        {
+          type: 'Patient',
+          profile: 'http://example.org/fhir/StructureDefinition/my-other-patient-profile'
+        },
+        {
+          type: 'Encounter',
+          profile: 'http://example.org/fhir/StructureDefinition/my-encounter-profile'
+        },
+        {
+          type: 'Encounter',
+          profile: 'http://example.org/fhir/StructureDefinition/my-other-encounter-profile'
+        }
+      ]);
+    });
+  });
+
+  describe('#groups', () => {
+    it('should convert the groups map to a list', () => {
+      minYAML.groups = {
+        GroupA: {
+          description: 'The Alpha Group',
+          resources: ['StructureDefinition/animal-patient', 'StructureDefinition/arm-procedure']
+        },
+        GroupB: {
+          description: 'The Beta Group',
+          resources: ['StructureDefinition/bark-control', 'StructureDefinition/bee-sting']
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.groups).toEqual([
+        {
+          name: 'GroupA',
+          description: 'The Alpha Group',
+          resources: ['StructureDefinition/animal-patient', 'StructureDefinition/arm-procedure']
+        },
+        {
+          name: 'GroupB',
+          description: 'The Beta Group',
+          resources: ['StructureDefinition/bark-control', 'StructureDefinition/bee-sting']
+        }
+      ]);
+    });
+  });
+
+  describe('#resources', () => {
+    it('should convert the resources map to a list', () => {
+      minYAML.resources = {
+        'Patient/my-example-patient': {
+          name: 'My Example Patient',
+          description: 'An example Patient',
+          exampleBoolean: true
+        },
+        'Patient/my-other-example-patient': {
+          name: 'My Other Example Patient',
+          description: 'Another example Patient',
+          exampleBoolean: true
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.resources).toEqual([
+        {
+          reference: { reference: 'Patient/my-example-patient' },
+          name: 'My Example Patient',
+          description: 'An example Patient',
+          exampleBoolean: true
+        },
+        {
+          reference: { reference: 'Patient/my-other-example-patient' },
+          name: 'My Other Example Patient',
+          description: 'Another example Patient',
+          exampleBoolean: true
+        }
+      ]);
+    });
+    it('should support resources.[name].fhirVersion as an array', () => {
+      minYAML.resources = {
+        'Patient/my-example-patient': {
+          fhirVersion: ['4.0.1']
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.resources).toEqual([
+        {
+          reference: { reference: 'Patient/my-example-patient' },
+          fhirVersion: ['4.0.1']
+        }
+      ]);
+    });
+    it('should convert single-item resources.[name].fhirVersion to an array', () => {
+      minYAML.resources = {
+        'Patient/my-example-patient': {
+          fhirVersion: '4.0.1'
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.resources).toEqual([
+        {
+          reference: { reference: 'Patient/my-example-patient' },
+          fhirVersion: ['4.0.1']
+        }
+      ]);
+    });
+    it('should support FSH syntax for resource.fhirVersions', () => {
+      minYAML.resources = {
+        'Patient/my-example-patient': {
+          fhirVersion: ['#4.0.1']
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.resources).toEqual([
+        {
+          reference: { reference: 'Patient/my-example-patient' },
+          fhirVersion: ['4.0.1']
+        }
+      ]);
+    });
+    it('should convert omitted resources correctly', () => {
+      minYAML.resources = {
+        'Patient/my-bad-example-patient': 'omit',
+        'Patient/my-other-bad-example-patient': '#omit'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.resources).toEqual([
+        {
+          reference: { reference: 'Patient/my-bad-example-patient' },
+          omit: true
+        },
+        {
+          reference: { reference: 'Patient/my-other-bad-example-patient' },
+          omit: true
+        }
+      ]);
+    });
+  });
+
+  describe('#pages', () => {
+    it('should convert the pages map to a list', () => {
+      minYAML.pages = {
+        'index.md': {
+          title: 'Example Home'
+        },
+        'implementation.xml': null,
+        'examples.xml': {
+          title: 'Examples Overview',
+          'simpleExamples.xml': null,
+          'complexExamples.xml': null
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.pages).toEqual([
+        { nameUrl: 'index.md', title: 'Example Home' },
+        { nameUrl: 'implementation.xml' },
+        {
+          nameUrl: 'examples.xml',
+          title: 'Examples Overview',
+          page: [{ nameUrl: 'simpleExamples.xml' }, { nameUrl: 'complexExamples.xml' }]
+        }
+      ]);
+    });
+    it('should support FSH syntax for pages.[name].generation', () => {
+      minYAML.pages = {
+        'index.md': {
+          title: 'Example Home'
+        },
+        'examples.xml': {
+          title: 'Examples',
+          generation: '#html'
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.pages).toEqual([
+        { nameUrl: 'index.md', title: 'Example Home' },
+        {
+          nameUrl: 'examples.xml',
+          title: 'Examples',
+          generation: 'html'
+        }
+      ]);
+    });
+    it('should report invalid generation codes', () => {
+      minYAML.pages = {
+        'index.md': {
+          title: 'Example Home',
+          // @ts-ignore Type '"electric"' is not assignable to type '"generated" | "#generated" ...'.
+          generation: 'electric'
+        },
+        'examples.xml': {
+          title: 'Examples Overview',
+          'simpleExamples.xml': {
+            // @ts-ignore Type '"gas"' is not assignable to type '"generated" | "#generated" ...'.
+            generation: 'gas'
+          }
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(
+        /Invalid pages\[index\.md\]\.generation value: 'electric'\. Must be one of: 'html','markdown','xml','generated'\.\s*File: test-config\.yaml/
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid pages\[examples\.xml\]\[simpleExamples\.xml\]\.generation value: 'gas'\. Must be one of: 'html','markdown','xml','generated'\.\s*File: test-config\.yaml/
+      );
+      expect(config.pages).toEqual([
+        { nameUrl: 'index.md', title: 'Example Home' },
+        {
+          nameUrl: 'examples.xml',
+          title: 'Examples Overview',
+          page: [{ nameUrl: 'simpleExamples.xml' }]
+        }
+      ]);
+    });
+  });
+
+  describe('#parameters', () => {
+    it('should convert the parameters map to a list', () => {
+      minYAML.parameters = {
+        // @ts-ignore Type 'true' is not assignable to type 'string | string[]'.
+        excludettl: true,
+        validation: 'allow-any-extensions'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.parameters).toEqual([
+        { code: 'excludettl', value: 'true' },
+        { code: 'validation', value: 'allow-any-extensions' }
+      ]);
+    });
+    it('should convert parameter array values to list items', () => {
+      minYAML.parameters = {
+        validation: ['allow-any-extensions', 'no-broken-links']
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.parameters).toEqual([
+        { code: 'validation', value: 'allow-any-extensions' },
+        { code: 'validation', value: 'no-broken-links' }
+      ]);
+    });
+  });
+
+  describe('#templates', () => {
+    it('should support template as an array', () => {
+      // NOTE: I don't know what values would actually be used; I made these up.
+      minYAML.templates = [
+        {
+          code: 'page',
+          source: 'page.xml',
+          scope: 'global'
+        }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.templates).toEqual([
+        {
+          code: 'page',
+          source: 'page.xml',
+          scope: 'global'
+        }
+      ]);
+    });
+    it('should convert single-item templates to an array', () => {
+      // NOTE: I don't know what values would actually be used; I made these up.
+      minYAML.templates = {
+        code: 'page',
+        source: 'page.xml',
+        scope: 'global'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.templates).toEqual([
+        {
+          code: 'page',
+          source: 'page.xml',
+          scope: 'global'
+        }
+      ]);
+    });
+    it('should translate template.code if applicable', () => {
+      // NOTE: I don't know what values would actually be used; I made these up.
+      minYAML.templates = [
+        {
+          code: '#page',
+          source: 'page.xml',
+          scope: 'global'
+        }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.templates).toEqual([
+        {
+          code: 'page',
+          source: 'page.xml',
+          scope: 'global'
+        }
+      ]);
+    });
+    it('should report an error if templates.code is missing', () => {
+      minYAML.templates = [
+        // @ts-ignore Property 'code' is missing in type...
+        {
+          source: 'page.xml',
+          scope: 'global'
+        }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: templates\.code\s*File: test-config\.yaml/
+      );
+      expect(config.templates).toEqual([
+        {
+          source: 'page.xml',
+          scope: 'global'
+        }
+      ]);
+    });
+    it('should report an error if templates.source is missing', () => {
+      minYAML.templates = [
+        // @ts-ignore Property 'source' is missing in type...
+        {
+          code: 'page',
+          scope: 'global'
+        }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: templates\.source\s*File: test-config\.yaml/
+      );
+      expect(config.templates).toEqual([
+        {
+          code: 'page',
+          scope: 'global'
+        }
+      ]);
+    });
+  });
+
+  describe('#template', () => {
+    it('should copy template as-is', () => {
+      minYAML.template = 'hl7.fhir.template#0.0.5';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.template).toBe('hl7.fhir.template#0.0.5');
+    });
+    it('should report an error if template is missing', () => {
+      delete minYAML.template;
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: template\s*File: test-config\.yaml/
+      );
+      expect(config.template).toBeUndefined();
+    });
+  });
+
+  describe('#copyrightYear', () => {
+    it('should convert copyrightYear to a parameter', () => {
+      minYAML.copyrightYear = '2019+';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.parameters).toEqual([{ code: 'copyrightyear', value: '2019+' }]);
+    });
+    it('should convert copyrightyear to a parameter', () => {
+      minYAML.copyrightyear = '2020+';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.parameters).toEqual([{ code: 'copyrightyear', value: '2020+' }]);
+    });
+    it('should support copyrightYear when YAML imports it as a number', () => {
+      // @ts-ignore Type '2020' is not assignable to type 'string'
+      minYAML.copyrightYear = 2020; // YAML parse will interpret 2020 as a number, not a string
+      let config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.parameters).toEqual([{ code: 'copyrightyear', value: '2020' }]);
+      // @ts-ignore Type '2020' is not assignable to type 'string'
+      minYAML.copyrightyear = 2020; // YAML parse will interpret 2020 as a number, not a string
+      config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.parameters).toEqual([{ code: 'copyrightyear', value: '2020' }]);
+    });
+  });
+
+  describe('#releaseLabel', () => {
+    it('should convert releaseLabel to a parameter', () => {
+      minYAML.releaseLabel = 'STU1';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.parameters).toEqual([{ code: 'releaselabel', value: 'STU1' }]);
+    });
+    it('should convert releaselabel to a parameter', () => {
+      minYAML.releaselabel = 'STU2';
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.parameters).toEqual([{ code: 'releaselabel', value: 'STU2' }]);
+    });
+  });
+
+  describe('#menu', () => {
+    it('should convert the menu map to a list', () => {
+      minYAML.menu = {
+        Home: 'index.html',
+        Artifacts: {
+          Profiles: 'artifacts.html#2',
+          Extensions: 'artifacts.html#3',
+          'Value Sets': 'artifacts.html#4'
+        },
+        Downloads: 'downloads.html',
+        History: 'http://hl7.org/fhir/us/example/history.html'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.menu).toEqual([
+        { name: 'Home', url: 'index.html' },
+        {
+          name: 'Artifacts',
+          subMenu: [
+            { name: 'Profiles', url: 'artifacts.html#2' },
+            { name: 'Extensions', url: 'artifacts.html#3' },
+            { name: 'Value Sets', url: 'artifacts.html#4' }
+          ]
+        },
+        { name: 'Downloads', url: 'downloads.html' },
+        { name: 'History', url: 'http://hl7.org/fhir/us/example/history.html' }
+      ]);
+    });
+  });
+
+  describe('#history', () => {
+    it('should use default values for history where applicable', () => {
+      minYAML.title = 'HL7 FHIR Implementation Guide: Minimal IG Release 1 - US Realm | STU1';
+      minYAML.description = 'Minimal IG exercises only required fields in a SUSHI configuration.';
+      minYAML.history = {
+        current: 'http://build.fhir.org/ig/HL7/minimal-ig/'
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.history).toEqual({
+        'package-id': 'fhir.us.minimal',
+        canonical: 'http://hl7.org/fhir/us/minimal',
+        title: 'HL7 FHIR Implementation Guide: Minimal IG Release 1 - US Realm | STU1',
+        introduction: 'Minimal IG exercises only required fields in a SUSHI configuration.',
+        list: [
+          {
+            version: 'current',
+            desc: 'Continuous Integration Build (latest in version control)',
+            path: 'http://build.fhir.org/ig/HL7/minimal-ig/',
+            status: 'ci-build',
+            current: true
+          }
+        ]
+      });
+    });
+    it('should allow mix of default and provide values for history.current', () => {
+      minYAML.title = 'HL7 FHIR Implementation Guide: Minimal IG Release 1 - US Realm | STU1';
+      minYAML.description = 'Minimal IG exercises only required fields in a SUSHI configuration.';
+      minYAML.history = {
+        current: {
+          fhirversion: '4.0.1',
+          date: '2020-04-01',
+          path: 'http://build.fhir.org/ig/HL7/example-ig/',
+          sequence: 'STU 2'
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.history).toEqual({
+        'package-id': 'fhir.us.minimal',
+        canonical: 'http://hl7.org/fhir/us/minimal',
+        title: 'HL7 FHIR Implementation Guide: Minimal IG Release 1 - US Realm | STU1',
+        introduction: 'Minimal IG exercises only required fields in a SUSHI configuration.',
+        list: [
+          {
+            version: 'current',
+            fhirversion: '4.0.1',
+            date: '2020-04-01',
+            desc: 'Continuous Integration Build (latest in version control)',
+            path: 'http://build.fhir.org/ig/HL7/example-ig/',
+            status: 'ci-build',
+            sequence: 'STU 2',
+            current: true
+          }
+        ]
+      });
+    });
+    it('should use provided values for history where applicable', () => {
+      minYAML.title = 'HL7 FHIR Implementation Guide: Minimal IG Release 1 - US Realm | STU1';
+      minYAML.description = 'Minimal IG exercises only required fields in a SUSHI configuration.';
+      minYAML.history = {
+        'package-id': 'fhir.us.other',
+        canonical: 'http://hl7.org/fhir/us/other',
+        title: 'HL7 FHIR Implementation Guide: Other IG Release 1 - US Realm | STU1',
+        introduction: 'Other IG is other than the other IG.',
+        current: {
+          fhirversion: '4.0.1',
+          date: '2020-04-01',
+          desc: 'CI Build Release',
+          path: 'http://build.fhir.org/ig/HL7/example-ig/',
+          status: 'ci-build',
+          sequence: 'STU 2',
+          current: true
+        },
+        '1.0.0': {
+          fhirversion: '4.0.1',
+          date: '2020-03-06',
+          desc: 'STU 1 Release',
+          path: 'https://hl7.org/fhir/us/example/STU1/',
+          status: 'trial-use',
+          sequence: 'STU 1',
+          current: true
+        },
+        '0.9.1': {
+          fhirversion: '4.0.0',
+          date: '2019-06-10',
+          desc: 'Initial STU ballot (Sep 2019 Ballot)',
+          path: 'https://hl7.org/fhir/us/example/2019Sep/',
+          status: 'ballot',
+          sequence: 'STU 1'
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.history).toEqual({
+        'package-id': 'fhir.us.other',
+        canonical: 'http://hl7.org/fhir/us/other',
+        title: 'HL7 FHIR Implementation Guide: Other IG Release 1 - US Realm | STU1',
+        introduction: 'Other IG is other than the other IG.',
+        list: [
+          {
+            version: 'current',
+            fhirversion: '4.0.1',
+            date: '2020-04-01',
+            desc: 'CI Build Release',
+            path: 'http://build.fhir.org/ig/HL7/example-ig/',
+            status: 'ci-build',
+            sequence: 'STU 2',
+            current: true
+          },
+          {
+            version: '1.0.0',
+            fhirversion: '4.0.1',
+            date: '2020-03-06',
+            desc: 'STU 1 Release',
+            path: 'https://hl7.org/fhir/us/example/STU1/',
+            status: 'trial-use',
+            sequence: 'STU 1',
+            current: true
+          },
+          {
+            version: '0.9.1',
+            fhirversion: '4.0.0',
+            date: '2019-06-10',
+            desc: 'Initial STU ballot (Sep 2019 Ballot)',
+            path: 'https://hl7.org/fhir/us/example/2019Sep/',
+            status: 'ballot',
+            sequence: 'STU 1'
+          }
+        ]
+      });
+    });
+    it('should report invalid history.current.status code', () => {
+      minYAML.history = {
+        current: {
+          path: 'http://build.fhir.org/ig/HL7/example-ig/',
+          // @ts-ignore Type '"OK"' is not assignable to type '"ci-build" | "preview" | ... '.
+          status: 'OK'
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid history\[current\]\.status value: 'OK'\. Must be one of: 'ci-build','preview','ballot','trial-use','update','normative','trial-use\+normative'\.\s*File: test-config\.yaml/
+      );
+      expect(config.history.list[0]).toEqual({
+        version: 'current',
+        desc: 'Continuous Integration Build (latest in version control)',
+        path: 'http://build.fhir.org/ig/HL7/example-ig/',
+        current: true
+      });
+    });
+    it('should report invalid history.[version].status code', () => {
+      minYAML.history = {
+        current: 'http://build.fhir.org/ig/HL7/minimal-ig/',
+        '1.0.0': {
+          fhirversion: '4.0.1',
+          date: '2020-03-06',
+          desc: 'STU 1 Release',
+          path: 'https://hl7.org/fhir/us/example/STU1/',
+          // @ts-ignore Type '"ready"' is not assignable to type '"ci-build" | "preview" | ... '.
+          status: 'ready',
+          sequence: 'STU 1',
+          current: true
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Invalid history\[1\.0\.0\]\.status value: 'ready'\. Must be one of: 'ci-build','preview','ballot','trial-use','update','normative','trial-use\+normative'\.\s*File: test-config\.yaml/
+      );
+      expect(config.history.list[1]).toEqual({
+        version: '1.0.0',
+        date: '2020-03-06',
+        desc: 'STU 1 Release',
+        path: 'https://hl7.org/fhir/us/example/STU1/',
+        sequence: 'STU 1',
+        fhirversion: '4.0.1',
+        current: true
+      });
+    });
+    it('should report an error if history.[version].date is missing', () => {
+      minYAML.history = {
+        current: 'http://build.fhir.org/ig/HL7/minimal-ig/',
+        '1.0.0': {
+          fhirversion: '4.0.1',
+          desc: 'STU 1 Release',
+          path: 'https://hl7.org/fhir/us/example/STU1/',
+          status: 'trial-use',
+          sequence: 'STU 1',
+          current: true
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: history\[1\.0\.0\]\.date\s*File: test-config\.yaml/
+      );
+      expect(config.history.list[1]).toEqual({
+        version: '1.0.0',
+        desc: 'STU 1 Release',
+        path: 'https://hl7.org/fhir/us/example/STU1/',
+        status: 'trial-use',
+        sequence: 'STU 1',
+        fhirversion: '4.0.1',
+        current: true
+      });
+    });
+    it('should report an error if history.[version].desc is missing', () => {
+      minYAML.history = {
+        current: 'http://build.fhir.org/ig/HL7/minimal-ig/',
+        '1.0.0': {
+          fhirversion: '4.0.1',
+          date: '2020-03-06',
+          path: 'https://hl7.org/fhir/us/example/STU1/',
+          status: 'trial-use',
+          sequence: 'STU 1',
+          current: true
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: history\[1\.0\.0\]\.desc\s*File: test-config\.yaml/
+      );
+      expect(config.history.list[1]).toEqual({
+        version: '1.0.0',
+        date: '2020-03-06',
+        path: 'https://hl7.org/fhir/us/example/STU1/',
+        status: 'trial-use',
+        sequence: 'STU 1',
+        fhirversion: '4.0.1',
+        current: true
+      });
+    });
+    it('should report an error if history.[version].path is missing', () => {
+      minYAML.history = {
+        current: 'http://build.fhir.org/ig/HL7/minimal-ig/',
+        // @ts-ignore Type '...' is not assignable to type ...
+        '1.0.0': {
+          fhirversion: '4.0.1',
+          date: '2020-03-06',
+          desc: 'STU 1 Release',
+          status: 'trial-use',
+          sequence: 'STU 1',
+          current: true
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: history\[1\.0\.0\]\.path\s*File: test-config\.yaml/
+      );
+      expect(config.history.list[1]).toEqual({
+        version: '1.0.0',
+        date: '2020-03-06',
+        desc: 'STU 1 Release',
+        status: 'trial-use',
+        sequence: 'STU 1',
+        fhirversion: '4.0.1',
+        current: true
+      });
+    });
+    it('should report an error if history.[version].status is missing', () => {
+      minYAML.history = {
+        current: 'http://build.fhir.org/ig/HL7/minimal-ig/',
+        '1.0.0': {
+          fhirversion: '4.0.1',
+          date: '2020-03-06',
+          desc: 'STU 1 Release',
+          path: 'https://hl7.org/fhir/us/example/STU1/',
+          sequence: 'STU 1',
+          current: true
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: history\[1\.0\.0\]\.status\s*File: test-config\.yaml/
+      );
+      expect(config.history.list[1]).toEqual({
+        version: '1.0.0',
+        date: '2020-03-06',
+        desc: 'STU 1 Release',
+        path: 'https://hl7.org/fhir/us/example/STU1/',
+        sequence: 'STU 1',
+        fhirversion: '4.0.1',
+        current: true
+      });
+    });
+    it('should report an error if history.[version].sequence is missing', () => {
+      minYAML.history = {
+        current: 'http://build.fhir.org/ig/HL7/minimal-ig/',
+        '1.0.0': {
+          fhirversion: '4.0.1',
+          date: '2020-03-06',
+          desc: 'STU 1 Release',
+          path: 'https://hl7.org/fhir/us/example/STU1/',
+          status: 'trial-use',
+          current: true
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: history\[1\.0\.0\]\.sequence\s*File: test-config\.yaml/
+      );
+      expect(config.history.list[1]).toEqual({
+        version: '1.0.0',
+        date: '2020-03-06',
+        desc: 'STU 1 Release',
+        path: 'https://hl7.org/fhir/us/example/STU1/',
+        status: 'trial-use',
+        fhirversion: '4.0.1',
+        current: true
+      });
+    });
+    it('should report an error if history.[version].fhirVersion is missing', () => {
+      minYAML.history = {
+        current: 'http://build.fhir.org/ig/HL7/minimal-ig/',
+        '1.0.0': {
+          date: '2020-03-06',
+          desc: 'STU 1 Release',
+          path: 'https://hl7.org/fhir/us/example/STU1/',
+          status: 'trial-use',
+          sequence: 'STU 1',
+          current: true
+        }
+      };
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Configuration missing required property: history\[1\.0\.0\]\.fhirVersion\s*File: test-config\.yaml/
+      );
+      expect(config.history.list[1]).toEqual({
+        version: '1.0.0',
+        date: '2020-03-06',
+        desc: 'STU 1 Release',
+        path: 'https://hl7.org/fhir/us/example/STU1/',
+        status: 'trial-use',
+        sequence: 'STU 1',
+        current: true
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds support for importing a config.yaml file with very permissive user-friendly types and translating it into the more strict Configuration format.

Handles converting shorthand-style codes to code/Coding/CodeableConcept, shorthand-style quantity syntax to Quantity, optional single-item representation of some array values, checking for required properties, validating code values (where feasible), and handling when YAML parses intended string values as non-strings.

This also does some of the initial hookup into the app.  If a config.yaml is present, it will parse it and put it in the tank and export Package object -- but it's not currently being used in the actual export (but perhaps will be helpful to others as they write the exporters).  Note that the FSHTank and Package now have _both_ `packageJSON` and `config`, but once the exporters can handle `config`, we'll remove `packageJSON` from the FSHTank and Package.