### PR TITLE
Fix contained choice bug

### DIFF
--- a/src/errors/FixingNonResourceError.ts
+++ b/src/errors/FixingNonResourceError.ts
@@ -1,0 +1,7 @@
+export class FixingNonResourceError extends Error {
+  constructor(public resourceType: string, public id: string) {
+    super(
+      `Instance ${id} of type ${resourceType} is not an Instance of a Resource. Only Instances of Resources may be assigned to other Instances.`
+    );
+  }
+}

--- a/src/errors/FixingNonResourceError.ts
+++ b/src/errors/FixingNonResourceError.ts
@@ -1,7 +1,7 @@
 export class FixingNonResourceError extends Error {
   constructor(public resourceType: string, public id: string) {
     super(
-      `Instance ${id} of type ${resourceType} is not an Instance of a Resource. Only Instances of Resources may be assigned to other Instances.`
+      `Instance ${id} of type ${resourceType} is not an Instance of a Resource or Profile of a Resource. Only Instances of Resources or Profiles of Resources may be assigned to other Instances.`
     );
   }
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -40,3 +40,4 @@ export * from './InvalidMappingError';
 export * from './InvalidFHIRIdError';
 export * from './ParentDeclaredAsProfileNameError';
 export * from './InvalidResourceTypeError';
+export * from './FixingNonResourceError';

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -84,10 +84,7 @@ export class InstanceExporter implements Fishable {
     rules.forEach(rule => {
       try {
         const matchingInlineResourcePaths = inlineResourcePaths.filter(
-          i =>
-            rule.path.startsWith(i.path) &&
-            rule.path !== i.path &&
-            rule.path != `${i.path}.resourceType`
+          i => rule.path.startsWith(`${i.path}.`) && rule.path !== `${i.path}.resourceType`
         );
         // Generate an array of resourceTypes that matches the path, so if path is
         // a.b.c.d.e, and b is a Bundle and D is a Patient,

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1365,19 +1365,15 @@ export class ElementDefinition {
    * Checks if a resource can be fixed to this element
    * @param {InstanceDefinition} value - The resource to fix
    * @param {Fishable} fisher - A fishable implementation for finding definitions and metadata
-   * @throws {NoSingleTypeError} when the ElementDefinition does not have a single type
    * @throws {MismatchedTypeError} when the ElementDefinition is not of type Resource
    * @returns {InstanceDefinition} the input value when it can be fixed
    */
   checkFixResource(value: InstanceDefinition, fisher: Fishable): InstanceDefinition {
-    if (!this.hasSingleType()) {
-      throw new NoSingleTypeError('Resource');
-    }
-    const type = this.type[0].code;
-    if (isInheritedResource(value.resourceType, type, fisher)) {
+    if (this.type?.some(t => isInheritedResource(value.resourceType, t.code, fisher))) {
       return value;
     } else {
-      throw new MismatchedTypeError(value.resourceType, value.id, type);
+      const typesString = this.type?.map(t => t.code).join(', ');
+      throw new MismatchedTypeError(value.resourceType, value.id, typesString);
     }
   }
 

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -1423,6 +1423,14 @@ describe('InstanceExporter', () => {
         // * active = true
         doc.instances.set(inlineInstance.name, inlineInstance);
 
+        const inlineObservation = new Instance('MyInlineObservation');
+        inlineObservation.instanceOf = 'Observation';
+        const observationValueRule = new FixedValueRule('valueString');
+        observationValueRule.fixedValue = 'Some Observation';
+        inlineObservation.rules.push(observationValueRule);
+        // * valueString = "Some Observation"
+        doc.instances.set(inlineObservation.name, inlineObservation);
+
         const caretRule = new CaretValueRule('entry');
         caretRule.caretPath = 'slicing.discriminator.type';
         caretRule.value = new FshCode('value');
@@ -1448,6 +1456,28 @@ describe('InstanceExporter', () => {
         const exported = exportInstance(patientInstance);
         expect(exported.contained).toEqual([
           { resourceType: 'Patient', id: 'MyInlinePatient', active: true }
+        ]);
+      });
+
+      it('should fix multiple inline resources to an instance', () => {
+        const inlineRule = new FixedValueRule('contained[0]');
+        inlineRule.fixedValue = 'MyInlinePatient';
+        inlineRule.isResource = true;
+        patientInstance.rules.push(inlineRule); // * contained[0] = MyInlinePatient
+
+        const inlineRule2 = new FixedValueRule('contained[1]');
+        inlineRule2.fixedValue = 'MyInlineObservation';
+        inlineRule2.isResource = true;
+        patientInstance.rules.push(inlineRule2); // * contained[1] = MyInlineObservation
+
+        const exported = exportInstance(patientInstance);
+        expect(exported.contained).toEqual([
+          { resourceType: 'Patient', id: 'MyInlinePatient', active: true },
+          {
+            resourceType: 'Observation',
+            id: 'MyInlineObservation',
+            valueString: 'Some Observation'
+          }
         ]);
       });
 

--- a/test/fhirtypes/ElementDefinition.checkFixResource.test.ts
+++ b/test/fhirtypes/ElementDefinition.checkFixResource.test.ts
@@ -39,7 +39,7 @@ describe('ElementDefinition', () => {
       expect(value.resourceType).toBe('Patient');
     });
 
-    it('should throw MismatchedTypeError when the value is fixed to a non-Resource', () => {
+    it('should throw MismatchedTypeError when a Resource is fixed on a non-Resource element', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
       expect(() => {
         status.checkFixResource(inlineInstance, fisher);
@@ -48,12 +48,12 @@ describe('ElementDefinition', () => {
       );
     });
 
-    it('should throw FixingNonResourceError when the value is fixed to a non-Resource', () => {
-      const status = observation.elements.find(e => e.id === 'Observation.category');
+    it('should throw FixingNonResourceError when a non-Resource value is fixed on a non-Resource', () => {
+      const category = observation.elements.find(e => e.id === 'Observation.category');
       expect(() => {
-        status.checkFixResource(inlineCodeable, fisher);
+        category.checkFixResource(inlineCodeable, fisher);
       }).toThrow(
-        'Instance MyCodeable of type CodeableConcept is not an Instance of a Resource. Only Instances of Resources may be assigned to other Instances.'
+        'Instance MyCodeable of type CodeableConcept is not an Instance of a Resource or Profile of a Resource. Only Instances of Resources or Profiles of Resources may be assigned to other Instances.'
       );
     });
   });

--- a/test/fhirtypes/ElementDefinition.checkFixResource.test.ts
+++ b/test/fhirtypes/ElementDefinition.checkFixResource.test.ts
@@ -9,6 +9,7 @@ describe('ElementDefinition', () => {
   let defs: FHIRDefinitions;
   let observation: StructureDefinition;
   let inlineInstance: InstanceDefinition;
+  let inlineCodeable: InstanceDefinition;
   let fisher: TestFisher;
 
   beforeAll(() => {
@@ -25,6 +26,10 @@ describe('ElementDefinition', () => {
     inlineInstance = new InstanceDefinition();
     inlineInstance.resourceType = 'Patient';
     inlineInstance.id = 'MyInlineInstance';
+
+    inlineCodeable = new InstanceDefinition();
+    inlineCodeable.resourceType = 'CodeableConcept';
+    inlineCodeable.id = 'MyCodeable';
   });
 
   describe('#checkFixResource', () => {
@@ -40,6 +45,15 @@ describe('ElementDefinition', () => {
         status.checkFixResource(inlineInstance, fisher);
       }).toThrow(
         'Cannot fix Patient value: MyInlineInstance. Value does not match element type: code'
+      );
+    });
+
+    it('should throw FixingNonResourceError when the value is fixed to a non-Resource', () => {
+      const status = observation.elements.find(e => e.id === 'Observation.category');
+      expect(() => {
+        status.checkFixResource(inlineCodeable, fisher);
+      }).toThrow(
+        'Instance MyCodeable of type CodeableConcept is not an Instance of a Resource. Only Instances of Resources may be assigned to other Instances.'
       );
     });
   });

--- a/test/fhirtypes/ElementDefinition.checkFixResource.test.ts
+++ b/test/fhirtypes/ElementDefinition.checkFixResource.test.ts
@@ -34,15 +34,6 @@ describe('ElementDefinition', () => {
       expect(value.resourceType).toBe('Patient');
     });
 
-    it('should throw NoSingleTypeError when element has multiple types', () => {
-      const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
-      expect(() => {
-        valueX.checkFixResource(inlineInstance, fisher);
-      }).toThrow(
-        'Cannot fix Resource value on this element since this element does not have a single type'
-      );
-    });
-
     it('should throw MismatchedTypeError when the value is fixed to a non-Resource', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
       expect(() => {

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -1184,6 +1184,15 @@ describe('StructureDefinition', () => {
         ).toThrow(/Bundle.*OfJoy.*Patient, Observation/);
       });
 
+      it('should not allow fixing a CodeableConcept type InstanceDefinition to any element', () => {
+        const instanceDef = new InstanceDefinition();
+        instanceDef.id = 'CODES';
+        instanceDef.resourceType = 'CodeableConcept';
+        expect(() => respRate.validateValueAtPath('contained[0]', instanceDef, fisher)).toThrow(
+          /CODES.*CodeableConcept is not an Instance of a Resource/
+        );
+      });
+
       // Overriding elements
       it('should allow replacing parts of a Resource element', () => {
         const language = new FshCode('French');

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -1098,6 +1098,15 @@ describe('StructureDefinition', () => {
         const domainRule = new OnlyRule('contained[DomainsOnly]');
         domainRule.types = [{ type: 'DomainResource' }];
         containedDomains.constrainType(domainRule, fisher);
+
+        contained.addSlice('PatientOrObservation');
+        const containedChoice = respRate.findElementByPath(
+          'contained[PatientOrObservation]',
+          fisher
+        );
+        const choiceRule = new OnlyRule('contained[PatientOrObservation]');
+        choiceRule.types = [{ type: 'Patient' }, { type: 'Observation' }];
+        containedChoice.constrainType(choiceRule, fisher);
       });
 
       it('should allow fixing a Patient type InstanceDefinition to a Resource element', () => {
@@ -1129,6 +1138,17 @@ describe('StructureDefinition', () => {
         expect(fixedValue.resourceType).toBe('Patient');
       });
 
+      it('should allow fixing a Patient type InstanceDefinition to a choice element that includes Patient', () => {
+        const instanceDef = new InstanceDefinition();
+        instanceDef.resourceType = 'Patient';
+        const { fixedValue } = respRate.validateValueAtPath(
+          'contained[PatientOrObservation][0]',
+          instanceDef,
+          fisher
+        );
+        expect(fixedValue.resourceType).toBe('Patient');
+      });
+
       it('should allow fixing a Bundle type InstanceDefinition to a Resource element', () => {
         const instanceDef = new InstanceDefinition();
         instanceDef.id = 'OfJoy';
@@ -1153,6 +1173,15 @@ describe('StructureDefinition', () => {
         expect(() =>
           respRate.validateValueAtPath('contained[PatientsOnly][0]', instanceDef, fisher)
         ).toThrow(/Bundle.*OfJoy.*Patient/);
+      });
+
+      it('should not allow fixing a Bundle type InstanceDefinition to a choice element that does not include Bundle', () => {
+        const instanceDef = new InstanceDefinition();
+        instanceDef.id = 'OfJoy';
+        instanceDef.resourceType = 'Bundle';
+        expect(() =>
+          respRate.validateValueAtPath('contained[PatientOrObservation][0]', instanceDef, fisher)
+        ).toThrow(/Bundle.*OfJoy.*Patient, Observation/);
       });
 
       // Overriding elements


### PR DESCRIPTION
This fixes #377 and the bug that is referenced in the zulip thread linked on #377. It turns out they are actually two separate problems.

We used to be unable to set an element that is a choice of several resources to a specific instance of one of the resources on an Instance. Now if an element on an instance has a choice of several resource types, such as `Patient` or `Observation`, that element can be set to any instance of type `Patient` or `Observation`.

This also fixes a bug with arrays of inline instances. When several inline instances are defined in an array:
```
* contained[0] = medicalHistoryEmpty
* contained[1] = adverseReactionEmpty
* contained[2] = immunizationEmpty
* contained[3] = medicineListEmpty
```
There was a bug with elements in the array beyond the first. The `[0]` index on the first element of the array would be normalized out, so the first path becomes `contained`. Then, because of this bug, we would interpret subsequent elements as children of this path, so we would view them as attempting to override the value of `contained`. This of course caused issues, which are fixed in this PR.