### PR TITLE
On systems with case-sensitive file system a call to JAVA will fail.

### DIFF
--- a/src/ig/files/_genonce.sh
+++ b/src/ig/files/_genonce.sh
@@ -24,12 +24,12 @@ echo "$txoption"
 
 publisher=$input_cache_path/$publisher_jar
 if test -f "$publisher"; then
-	JAVA -jar $publisher -ig ig.ini $txoption $*
+	java -jar $publisher -ig ig.ini $txoption $*
 
 else
 	publisher=../$publisher_jar
 	if test -f "$publisher"; then
-		JAVA -jar $publisher -ig ig.ini $txoption $*
+		java -jar $publisher -ig ig.ini $txoption $*
 	else
 		echo IG Publisher NOT FOUND in input-cache or parent folder.  Please run _updatePublisher.  Aborting...
 	fi


### PR DESCRIPTION
When using the _genonce.sh script on a centos-system I noticed problems with case sensitivity. Will be pushing this to the sample-ig project as well.