### PR TITLE
Return non-zero exit code

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -84,14 +84,15 @@ async function app() {
     files = getFilesRecursive(input);
   } catch {
     logger.error('Invalid path to FSH definition folder.');
-    program.help();
+    program.outputHelp();
+    process.exit(1);
   }
 
   // Check that package.json exists
   const packagePath = path.join(input, 'package.json');
   if (!fs.existsSync(packagePath)) {
     logger.error('No package.json in FSH definition folder.');
-    return;
+    process.exit(1);
   }
 
   // Parse package.json
@@ -100,7 +101,7 @@ async function app() {
     config = fs.readJSONSync(packagePath);
   } catch (e) {
     logger.error(`The package.json file is not valid JSON: ${packagePath}`);
-    return;
+    process.exit(1);
   }
 
   // Ensure FHIR R4 is added as a dependency
@@ -110,7 +111,7 @@ async function app() {
       'The package.json must specify FHIR R4 as a dependency. Be sure to' +
         ' add "hl7.fhir.r4.core": "4.0.1" to the dependencies list.'
     );
-    return;
+    process.exit(1);
   }
 
   // Load external dependencies
@@ -155,7 +156,7 @@ async function app() {
         ' may be corrupt. Local FHIR cache can be found at <home-directory>/.fhir/packages.' +
         ' For more information, see https://wiki.hl7.org/FHIR_Package_Cache#Location.'
     );
-    return;
+    process.exit(1);
   }
 
   logger.info('Converting FSH to FHIR resources...');

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,7 @@ import { pad, padStart, sample, padEnd } from 'lodash';
 import chalk from 'chalk';
 
 app().catch(e => {
-  logger.error(e.message);
+  logger.error(`SUSHI encountered the following unexpected error: ${e.message}`);
   process.exit(1);
 });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,7 +23,10 @@ import {
 import { pad, padStart, sample, padEnd } from 'lodash';
 import chalk from 'chalk';
 
-app();
+app().catch(e => {
+  logger.error(e.message);
+  process.exit(1);
+});
 
 async function app() {
   let input: string;


### PR DESCRIPTION
This PR fixes #375 (https://standardhealthrecord.atlassian.net/browse/CIMPL-356).

The async `app` function will return a promise. We can catch unexpected errors in a `catch` block on the function. Since the fix for this is in `app.ts`, I'm not sure I can write a test for this. However, to test it manually, you can throw an error in `app` before the export begins. On master, the error in the GitHub issue is reported. On this branch, the error message is logged and the process exits with code `1`, which is the code we return if there are any errors in the export.