### PR TITLE
Fix base64Binary regex

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1324,7 +1324,7 @@ export class ElementDefinition {
       (type === 'uri' && /^\S*$/.test(value)) ||
       (type === 'url' && /^\S*$/.test(value)) ||
       (type === 'canonical' && /^\S*$/.test(value)) ||
-      (type === 'base64Binary' && /^(\s*([0-9a-zA-Z\+\=]){4}\s*)+$/.test(value)) ||
+      (type === 'base64Binary' && /^(\s*([0-9a-zA-Z\+\/=]){4}\s*)+$/.test(value)) ||
       (type === 'instant' &&
         /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))$/.test(
           value

--- a/test/fhirtypes/ElementDefinition.fixString.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixString.test.ts
@@ -346,8 +346,8 @@ describe('ElementDefinition', () => {
       const udiCarrierCarrierAIDC = device.elements.find(
         e => e.id === 'Device.udiCarrier.carrierAIDC'
       );
-      udiCarrierCarrierAIDC.fixValue('d293IHNvbWVvbmUgZGVjb2RlZA==');
-      expect(udiCarrierCarrierAIDC.patternBase64Binary).toBe('d293IHNvbWVvbmUgZGVjb2RlZA==');
+      udiCarrierCarrierAIDC.fixValue('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=');
+      expect(udiCarrierCarrierAIDC.patternBase64Binary).toBe('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=');
       expect(udiCarrierCarrierAIDC.fixedBase64Binary).toBeUndefined();
     });
 
@@ -355,8 +355,8 @@ describe('ElementDefinition', () => {
       const udiCarrierCarrierAIDC = device.elements.find(
         e => e.id === 'Device.udiCarrier.carrierAIDC'
       );
-      udiCarrierCarrierAIDC.fixValue('d293IHNvbWVvbmUgZGVjb2RlZA==', true);
-      expect(udiCarrierCarrierAIDC.fixedBase64Binary).toBe('d293IHNvbWVvbmUgZGVjb2RlZA==');
+      udiCarrierCarrierAIDC.fixValue('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=', true);
+      expect(udiCarrierCarrierAIDC.fixedBase64Binary).toBe('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=');
       expect(udiCarrierCarrierAIDC.patternBase64Binary).toBeUndefined();
     });
 
@@ -364,17 +364,17 @@ describe('ElementDefinition', () => {
       const udiCarrierCarrierAIDC = device.elements.find(
         e => e.id === 'Device.udiCarrier.carrierAIDC'
       );
-      udiCarrierCarrierAIDC.fixValue('d293IHNvbWVvbmUgZGVjb2RlZA==');
-      expect(udiCarrierCarrierAIDC.patternBase64Binary).toBe('d293IHNvbWVvbmUgZGVjb2RlZA==');
+      udiCarrierCarrierAIDC.fixValue('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=');
+      expect(udiCarrierCarrierAIDC.patternBase64Binary).toBe('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=');
       expect(() => {
         udiCarrierCarrierAIDC.fixValue('dGhpcyB0b28=');
       }).toThrow(
-        'Cannot fix "dGhpcyB0b28=" to this element; a different base64Binary is already fixed: "d293IHNvbWVvbmUgZGVjb2RlZA==".'
+        'Cannot fix "dGhpcyB0b28=" to this element; a different base64Binary is already fixed: "QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=".'
       );
       expect(() => {
         udiCarrierCarrierAIDC.fixValue('dGhpcyB0b28=', true);
       }).toThrow(
-        'Cannot fix "dGhpcyB0b28=" to this element; a different base64Binary is already fixed: "d293IHNvbWVvbmUgZGVjb2RlZA==".'
+        'Cannot fix "dGhpcyB0b28=" to this element; a different base64Binary is already fixed: "QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=".'
       );
     });
 
@@ -382,12 +382,12 @@ describe('ElementDefinition', () => {
       const udiCarrierCarrierAIDC = device.elements.find(
         e => e.id === 'Device.udiCarrier.carrierAIDC'
       );
-      udiCarrierCarrierAIDC.fixValue('d293IHNvbWVvbmUgZGVjb2RlZA==', true);
-      expect(udiCarrierCarrierAIDC.fixedBase64Binary).toBe('d293IHNvbWVvbmUgZGVjb2RlZA==');
+      udiCarrierCarrierAIDC.fixValue('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=', true);
+      expect(udiCarrierCarrierAIDC.fixedBase64Binary).toBe('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=');
       expect(() => {
         udiCarrierCarrierAIDC.fixValue('dGhpcyB0b28=', true);
       }).toThrow(
-        'Cannot fix "dGhpcyB0b28=" to this element; a different base64Binary is already fixed: "d293IHNvbWVvbmUgZGVjb2RlZA==".'
+        'Cannot fix "dGhpcyB0b28=" to this element; a different base64Binary is already fixed: "QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=".'
       );
     });
 
@@ -395,10 +395,10 @@ describe('ElementDefinition', () => {
       const udiCarrierCarrierAIDC = device.elements.find(
         e => e.id === 'Device.udiCarrier.carrierAIDC'
       );
-      udiCarrierCarrierAIDC.fixValue('d293IHNvbWVvbmUgZGVjb2RlZA==', true);
-      expect(udiCarrierCarrierAIDC.fixedBase64Binary).toBe('d293IHNvbWVvbmUgZGVjb2RlZA==');
+      udiCarrierCarrierAIDC.fixValue('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=', true);
+      expect(udiCarrierCarrierAIDC.fixedBase64Binary).toBe('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=');
       expect(() => {
-        udiCarrierCarrierAIDC.fixValue('d293IHNvbWVvbmUgZGVjb2RlZA==');
+        udiCarrierCarrierAIDC.fixValue('QXJlIHdlIHRoZSBzdWJqZWN0cz8/P+w=');
       }).toThrow(
         'Cannot fix this element using a pattern; as it is already fixed in the StructureDefinition using fixedBase64Binary.'
       );


### PR DESCRIPTION
Fixes #402 by giving us the correct regular expression for `base64Binary`. Also updates the tests so that the tests test a string that contains all classes of characters allowed in a `base64Binary` encoded string.