### PR TITLE
Load dependencies from config.yaml

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -114,7 +114,7 @@ async function app() {
   }
 
   // Ensure FHIR R4 is added as a fhirVersion
-  const dependencies = config.dependencies;
+  const dependencies = config.dependencies ?? [];
   if (!config.fhirVersion.includes('4.0.1')) {
     logger.error(
       'The config.yaml must specify FHIR R4 as a fhirVersion. Be sure to' +


### PR DESCRIPTION
This addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-378.

We now look at config.yaml instead of package.json to determine which packages to load.