### PR TITLE
Drop support for Node 8

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [8, 10, 12]
+        node-version: [10, 12]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more information about the evolving FSH syntax see the [FHIR Shorthand Refer
 
 # Installation for SUSHI Users
 
-SUSHI requires [Node.js](https://nodejs.org/) to be installed on the user's system.  Users should install Node.js 12 (LTS), although earlier LTS versions (8, 10) are also expected to work.
+SUSHI requires [Node.js](https://nodejs.org/) to be installed on the user's system.  Users should install Node.js 12 (LTS), although the previous LTS version (Node.js 10) is also expected to work.
 
 Once Node.js is installed, run the following command to install or update SUSHI:
 
@@ -64,7 +64,7 @@ If the input folder does not contain a sub-folder named "ig-data", then only the
 
 # Installation for Developers
 
-SUSHI is a [TypeScript](https://www.typescriptlang.org/) project.  At a minimum, SUSHI requires [Node.js](https://nodejs.org/) to build, test, and run the CLI.  Developers should install Node.js 12 (LTS), although earlier LTS versions (8, 10) are also expected to work.
+SUSHI is a [TypeScript](https://www.typescriptlang.org/) project.  At a minimum, SUSHI requires [Node.js](https://nodejs.org/) to build, test, and run the CLI.  Developers should install Node.js 12 (LTS), although the previous LTS version (Node.js 10) is also expected to work.
 
 Once Node.js is installed, run the following command from this project's root folder:
 


### PR DESCRIPTION
Several libraries we use no longer support Node 8 in recent updates.  In addition, our CI sometimes struggled with Node 8 for unknown reasons.  We don't need Node 8, and requiring Node 10 or Node 12 is not unreasonable.  So... we are dropping support for Node 8.