### PR TITLE
Config YAML output log

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -987,7 +987,7 @@ export class IGExporter {
     outputJSONSync(igJsonPath, this.ig, { spaces: 2 });
     this.updateOutputLog(
       igJsonPath,
-      [this.configPath, path.join(this.igDataPath, 'ig.ini'), '{all input resources and pages}'],
+      [this.configPath, '{all input resources and pages}'],
       'generated'
     );
     logger.info(`Generated ImplementationGuide-${this.ig.id}.json`);


### PR DESCRIPTION
This fixes one small thing by fixing the reference to ImplementationGuide generated in the output log. As far as I can tell, all other output log references are being correctly handled.