### PR TITLE
Catch and log errors thrown by YAML.parse

### DIFF
--- a/src/import/importConfiguration.ts
+++ b/src/import/importConfiguration.ts
@@ -70,7 +70,13 @@ const IG_ONLY_PROPERTIES = [
  */
 export function importConfiguration(yaml: YAMLConfiguration | string, file: string): Configuration {
   if (typeof yaml === 'string') {
-    const parsed: YAMLConfiguration = YAML.parse(yaml);
+    let parsed: YAMLConfiguration;
+    try {
+      parsed = YAML.parse(yaml);
+    } catch (e) {
+      logger.error(`Error parsing configuration: ${e.message}.`, { file });
+      throw new Error('Invalid configuration YAML');
+    }
     if (typeof parsed !== 'object' || parsed === null) {
       logger.error('Configuration is not a valid YAML object.', { file });
       throw new Error('Invalid configuration YAML');

--- a/test/import/fixtures/invalid-config.yaml
+++ b/test/import/fixtures/invalid-config.yaml
@@ -1,0 +1,10 @@
+id: fhir.us.minimal
+canonical: http://hl7.org/fhir/us/minimal
+name: MinimalIG
+status: draft
+version: 1.0.0
+fhirVersion: 4.0.1
+copyrightYear: 2020+
+releaseLabel: Build CI
+releaseLabel: Invalid Second Label
+template: hl7.fhir.template#0.0.5

--- a/test/import/importConfiguration.test.ts
+++ b/test/import/importConfiguration.test.ts
@@ -197,6 +197,17 @@ describe('importConfiguration', () => {
     );
   });
 
+  it('should report an error and throw on a YAML file with invalid entries', () => {
+    const yamlPath = path.join(__dirname, 'fixtures', 'invalid-config.yaml');
+    const invalidYaml = fs.readFileSync(yamlPath, 'utf8');
+    expect(() => importConfiguration(invalidYaml, 'invalid-config.yaml')).toThrow(
+      'Invalid configuration YAML'
+    );
+    expect(loggerSpy.getLastMessage('error')).toMatch(
+      /Error parsing configuration: Map keys must be unique; "releaseLabel" is repeated\.\s*File: invalid-config\.yaml/
+    );
+  });
+
   describe('#id', () => {
     it('should import id as-is', () => {
       minYAML.id = 'my-id';


### PR DESCRIPTION
Fixes #437. Added a try/catch and a log statement when invalid YAML is parsed.