### PR TITLE
Add id to dependsOn

### DIFF
--- a/src/fhirtypes/ImplementationGuide.ts
+++ b/src/fhirtypes/ImplementationGuide.ts
@@ -1,5 +1,5 @@
 import { ContactDetail, UsageContext } from './metaDataTypes';
-import { CodeableConcept, Reference } from './dataTypes';
+import { CodeableConcept, Reference, BackboneElement } from './dataTypes';
 
 export type ImplementationGuide = {
   resourceType: 'ImplementationGuide';
@@ -26,7 +26,7 @@ export type ImplementationGuide = {
   manifest?: ImplementationGuideManifest;
 };
 
-export type ImplementationGuideDependsOn = {
+export type ImplementationGuideDependsOn = BackboneElement & {
   uri: string;
   packageId?: string;
   version?: string;

--- a/src/fhirtypes/dataTypes.ts
+++ b/src/fhirtypes/dataTypes.ts
@@ -8,6 +8,17 @@ import { FHIRDateTime, validateFHIRDateTime } from './primitiveTypes';
 import { Meta } from './specialTypes';
 
 /**
+ * Represents the FHIR R4 data type BackboneElement.
+ * This is the base definition for elements that have children defined
+ * on a resource.
+ *
+ * @see {@link http://hl7.org/fhir/R4/backboneelement.html}
+ */
+export type BackboneElement = Element & {
+  modifierExtension?: Extension[];
+};
+
+/**
  * Represents the FHIR R4 data type CodeableConcept.
  *
  * @see {@link http://hl7.org/fhir/R4/datatypes.html#CodeableConcept}
@@ -41,6 +52,16 @@ export type ContactPoint = {
   use?: string;
   rank?: number;
   period?: Period;
+};
+
+/**
+ * Represents the FHIR R4 data type Element.
+ *
+ * @see {@link http://hl7.org/fhir/R4/element.html}
+ */
+export type Element = {
+  id?: string;
+  extension?: Extension[];
 };
 
 /**

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -171,6 +171,8 @@ export class IGExporter {
           this.ig.dependsOn.push({
             uri: `${depIG.url}`,
             packageId: depId,
+            // packageId should be alphanumeric or '.', id must be alphanumeric or '_' for IG Publisher, so replace '.' with '_'
+            id: depId.replace(/\./g, '_'),
             version: depVersion
           });
         } else {

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -160,12 +160,14 @@ describe('IGExporter', () => {
         dependsOn: [
           // USCore tests that it works with a package dependency w/ a specific version
           {
+            id: 'hl7_fhir_us_core',
             uri: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core',
             packageId: 'hl7.fhir.us.core',
             version: '3.1.0'
           },
           // VHDir tests that it works with a package dependency w/ "current"
           {
+            id: 'hl7_fhir_uv_vhdir',
             uri: 'http://hl7.org/fhir/uv/vhdir/ImplementationGuide/hl7.core.uv.vhdir',
             packageId: 'hl7.fhir.uv.vhdir',
             version: 'current'


### PR DESCRIPTION
This fixes https://github.com/FHIR/sushi/issues/445.

The id added to the `dependsOn` can be referenced using liquid syntax in markdown files as described here: https://build.fhir.org/ig/FHIR/ig-guidance/using-templates.html#liquid.

The IG Publisher does not allow the `id` to have periods, so we enforce that any periods in the `id` are replaced by `_`. 