### PR TITLE
Don't export sparse differentials

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1901,7 +1901,10 @@ export type ElementDefinitionMapping = {
 /**
  * A barebones and lenient definition of ElementDefinition JSON
  */
-interface LooseElementDefJSON {
+export interface LooseElementDefJSON {
+  id?: string;
+  path?: string;
+  slicing?: ElementDefinitionSlicing;
   type?: ElementDefinitionTypeJSON[];
   binding?: ElementDefinitionBinding;
   // [key: string]: any;

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -383,6 +383,10 @@ export class StructureDefinition {
       // by the standard choice slicing *and* it doesn't have any direct children w/ diffs, don't include
       // it even if it has slices because it makes the diff a bit more confusing and it is supposed to
       // be inferred anyway (see blog reference above).
+      // NOTE: This is a separate 'if' instead of 'else if' because when a sliced choice element has
+      // direct children that have diffs, the sliced choice element will be caught in the 'if' above, but
+      // then is treated like a no-diff. In order to get the no-diff treatment, it needs to be considered
+      // for the logic below (but it would not be if this was an else-if).
       if (
         !hasDiff &&
         (e.children().some(c => cachedHasDiff(c)) ||

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -3693,7 +3693,7 @@ describe('StructureDefinitionExporter', () => {
     ]);
   });
 
-  it('should include slice root and sliceName in a differential when an attribute of the slice is changed', () => {
+  it('should include sliceName in a differential when an attribute of the slice is changed', () => {
     const profile = new Profile('MustSlice');
     profile.parent = 'resprate';
     const mustCode = new FlagRule('code.coding[RespRateCode]');
@@ -3702,7 +3702,7 @@ describe('StructureDefinitionExporter', () => {
     exporter.exportStructDef(profile);
     const sd = pkg.profiles[0];
     const json = sd.toJSON();
-    expect(json.differential.element).toHaveLength(4);
+    expect(json.differential.element).toHaveLength(3);
     expect(json.differential.element).toEqual([
       {
         id: 'Observation',
@@ -3711,10 +3711,6 @@ describe('StructureDefinitionExporter', () => {
       {
         id: 'Observation.code',
         path: 'Observation.code'
-      },
-      {
-        id: 'Observation.code.coding',
-        path: 'Observation.code.coding'
       },
       {
         id: 'Observation.code.coding:RespRateCode',

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -3538,12 +3538,11 @@ describe('StructureDefinitionExporter', () => {
     const sd = pkg.profiles[0];
     const json = sd.toJSON();
 
-    expect(json.differential.element).toHaveLength(1);
-    expect(json.differential.element[0]).toEqual({
-      id: 'Observation.subject',
-      path: 'Observation.subject',
-      min: 1
-    });
+    expect(json.differential.element).toHaveLength(2);
+    expect(json.differential.element).toEqual([
+      { id: 'Observation', path: 'Observation' },
+      { id: 'Observation.subject', path: 'Observation.subject', min: 1 }
+    ]);
   });
 
   it('should correctly generate a diff containing only changed elements when elements are unfolded', () => {
@@ -3568,17 +3567,27 @@ describe('StructureDefinitionExporter', () => {
     const sd = pkg.profiles[0];
     const json = sd.toJSON();
 
-    expect(json.differential.element).toHaveLength(2);
-    expect(json.differential.element[0]).toEqual({
-      id: 'Observation.code.coding',
-      path: 'Observation.code.coding',
-      min: 1
-    });
-    expect(json.differential.element[1]).toEqual({
-      id: 'Observation.code.coding.userSelected',
-      path: 'Observation.code.coding.userSelected',
-      min: 1
-    });
+    expect(json.differential.element).toHaveLength(4);
+    expect(json.differential.element).toEqual([
+      {
+        id: 'Observation',
+        path: 'Observation'
+      },
+      {
+        id: 'Observation.code',
+        path: 'Observation.code'
+      },
+      {
+        id: 'Observation.code.coding',
+        path: 'Observation.code.coding',
+        min: 1
+      },
+      {
+        id: 'Observation.code.coding.userSelected',
+        path: 'Observation.code.coding.userSelected',
+        min: 1
+      }
+    ]);
   });
 
   it('should correctly generate a diff containing only changed elements when elements are sliced', () => {
@@ -3630,56 +3639,61 @@ describe('StructureDefinitionExporter', () => {
     const sd = pkg.profiles[0];
     const json = sd.toJSON();
 
-    const diffs = json.differential.element;
-    expect(diffs).toHaveLength(7);
-    expect(diffs[0]).toEqual({
-      id: 'Observation.component',
-      path: 'Observation.component',
-      slicing: {
-        discriminator: [{ type: 'pattern', path: 'code' }],
-        rules: 'open'
+    expect(json.differential.element).toHaveLength(8);
+    expect(json.differential.element).toEqual([
+      {
+        id: 'Observation',
+        path: 'Observation'
       },
-      comment: 'BP comment'
-    });
-    expect(diffs[1]).toEqual({
-      id: 'Observation.component:SystolicBP',
-      path: 'Observation.component',
-      sliceName: 'SystolicBP',
-      max: '1'
-    });
-    expect(diffs[2]).toEqual({
-      id: 'Observation.component:SystolicBP.code',
-      path: 'Observation.component.code',
-      patternCodeableConcept: {
-        coding: [{ code: '8480-6', system: 'http://loinc.org' }]
+      {
+        id: 'Observation.component',
+        path: 'Observation.component',
+        slicing: {
+          discriminator: [{ type: 'pattern', path: 'code' }],
+          rules: 'open'
+        },
+        comment: 'BP comment'
+      },
+      {
+        id: 'Observation.component:SystolicBP',
+        path: 'Observation.component',
+        sliceName: 'SystolicBP',
+        max: '1'
+      },
+      {
+        id: 'Observation.component:SystolicBP.code',
+        path: 'Observation.component.code',
+        patternCodeableConcept: {
+          coding: [{ code: '8480-6', system: 'http://loinc.org' }]
+        }
+      },
+      {
+        id: 'Observation.component:SystolicBP.value[x]',
+        path: 'Observation.component.value[x]',
+        type: [{ code: 'Quantity' }]
+      },
+      {
+        id: 'Observation.component:DiastolicBP',
+        path: 'Observation.component',
+        sliceName: 'DiastolicBP',
+        max: '1'
+      },
+      {
+        id: 'Observation.component:DiastolicBP.code',
+        path: 'Observation.component.code',
+        patternCodeableConcept: {
+          coding: [{ code: '8462-4', system: 'http://loinc.org' }]
+        }
+      },
+      {
+        id: 'Observation.component:DiastolicBP.value[x]',
+        path: 'Observation.component.value[x]',
+        type: [{ code: 'Quantity' }]
       }
-    });
-    expect(diffs[3]).toEqual({
-      id: 'Observation.component:SystolicBP.value[x]',
-      path: 'Observation.component.value[x]',
-      type: [{ code: 'Quantity' }]
-    });
-    expect(diffs[4]).toEqual({
-      id: 'Observation.component:DiastolicBP',
-      path: 'Observation.component',
-      sliceName: 'DiastolicBP',
-      max: '1'
-    });
-    expect(diffs[5]).toEqual({
-      id: 'Observation.component:DiastolicBP.code',
-      path: 'Observation.component.code',
-      patternCodeableConcept: {
-        coding: [{ code: '8462-4', system: 'http://loinc.org' }]
-      }
-    });
-    expect(diffs[6]).toEqual({
-      id: 'Observation.component:DiastolicBP.value[x]',
-      path: 'Observation.component.value[x]',
-      type: [{ code: 'Quantity' }]
-    });
+    ]);
   });
 
-  it('should include sliceName in a differential when an attribute of the slice is changed', () => {
+  it('should include slice root and sliceName in a differential when an attribute of the slice is changed', () => {
     const profile = new Profile('MustSlice');
     profile.parent = 'resprate';
     const mustCode = new FlagRule('code.coding[RespRateCode]');
@@ -3688,13 +3702,27 @@ describe('StructureDefinitionExporter', () => {
     exporter.exportStructDef(profile);
     const sd = pkg.profiles[0];
     const json = sd.toJSON();
-    expect(json.differential.element).toHaveLength(1);
-    expect(json.differential.element[0]).toEqual({
-      id: 'Observation.code.coding:RespRateCode',
-      path: 'Observation.code.coding',
-      sliceName: 'RespRateCode',
-      mustSupport: true
-    });
+    expect(json.differential.element).toHaveLength(4);
+    expect(json.differential.element).toEqual([
+      {
+        id: 'Observation',
+        path: 'Observation'
+      },
+      {
+        id: 'Observation.code',
+        path: 'Observation.code'
+      },
+      {
+        id: 'Observation.code.coding',
+        path: 'Observation.code.coding'
+      },
+      {
+        id: 'Observation.code.coding:RespRateCode',
+        path: 'Observation.code.coding',
+        sliceName: 'RespRateCode',
+        mustSupport: true
+      }
+    ]);
   });
 
   it.skip('should not change sliceName based on a CaretValueRule', () => {

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -122,13 +122,17 @@ describe('StructureDefinition', () => {
       valueX.min = 1;
 
       const json = observation.toJSON();
-      expect(json.differential.element).toHaveLength(2);
+      expect(json.differential.element).toHaveLength(3);
       expect(json.differential.element[0]).toEqual({
+        id: 'Observation',
+        path: 'Observation'
+      });
+      expect(json.differential.element[1]).toEqual({
         id: 'Observation.code',
         path: 'Observation.code',
         short: 'Special observation code'
       });
-      expect(json.differential.element[1]).toEqual({
+      expect(json.differential.element[2]).toEqual({
         id: 'Observation.value[x]',
         path: 'Observation.value[x]',
         min: 1
@@ -142,18 +146,64 @@ describe('StructureDefinition', () => {
       valueX.min = 1;
 
       const json = observation.toJSON(false);
-      expect(json.differential.element).toHaveLength(2);
+      expect(json.differential.element).toHaveLength(3);
       expect(json.differential.element[0]).toEqual({
+        id: 'Observation',
+        path: 'Observation'
+      });
+      expect(json.differential.element[1]).toEqual({
         id: 'Observation.code',
         path: 'Observation.code',
         short: 'Special observation code'
       });
-      expect(json.differential.element[1]).toEqual({
+      expect(json.differential.element[2]).toEqual({
         id: 'Observation.value[x]',
         path: 'Observation.value[x]',
         min: 1
       });
       expect(json.snapshot).toBeUndefined();
+    });
+
+    it('should contain intermediate elements in differential to avoid sparse differentials', () => {
+      const componentCode = observation.elements.find(e => e.id === 'Observation.component.code');
+      componentCode.short = 'Special component code';
+
+      const json = observation.toJSON();
+      expect(json.differential.element).toHaveLength(3);
+      expect(json.differential.element[0]).toEqual({
+        id: 'Observation',
+        path: 'Observation'
+      });
+      expect(json.differential.element[1]).toEqual({
+        id: 'Observation.component',
+        path: 'Observation.component'
+      });
+      expect(json.differential.element[2]).toEqual({
+        id: 'Observation.component.code',
+        path: 'Observation.component.code',
+        short: 'Special component code'
+      });
+    });
+
+    it('should contain intermediate elements in differential to avoid sparse differentials without generating snapshot', () => {
+      const componentCode = observation.elements.find(e => e.id === 'Observation.component.code');
+      componentCode.short = 'Special component code';
+
+      const json = observation.toJSON(false);
+      expect(json.differential.element).toHaveLength(3);
+      expect(json.differential.element[0]).toEqual({
+        id: 'Observation',
+        path: 'Observation'
+      });
+      expect(json.differential.element[1]).toEqual({
+        id: 'Observation.component',
+        path: 'Observation.component'
+      });
+      expect(json.differential.element[2]).toEqual({
+        id: 'Observation.component.code',
+        path: 'Observation.component.code',
+        short: 'Special component code'
+      });
     });
 
     it('should reflect basic differential for structure definitions with no changes', () => {
@@ -203,8 +253,13 @@ describe('StructureDefinition', () => {
       expect(valueStringSnapshot.sliceName).toEqual('valueString');
       expect(valueStringSnapshot.short).toBe('the string choice');
       // then check that differential has value[x] and shortcut syntax valueQuantity and valueString
-      expect(json.differential.element).toHaveLength(3);
-      const valueXDiff = json.differential.element[0];
+      expect(json.differential.element).toHaveLength(4);
+      const rootDiff = json.differential.element[0];
+      expect(rootDiff).toEqual({
+        id: 'Observation',
+        path: 'Observation'
+      });
+      const valueXDiff = json.differential.element[1];
       expect(valueXDiff).toEqual({
         id: 'Observation.value[x]',
         path: 'Observation.value[x]',
@@ -215,13 +270,13 @@ describe('StructureDefinition', () => {
           rules: 'open'
         }
       });
-      const valueQuantityDiff = json.differential.element[1];
+      const valueQuantityDiff = json.differential.element[2];
       expect(valueQuantityDiff.id).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.path).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.type).toEqual([{ code: 'Quantity' }]);
       expect(valueQuantityDiff.sliceName).toBeUndefined();
       expect(valueQuantitySnapshot.short).toBe('the quantity choice');
-      const valueStringDiff = json.differential.element[2];
+      const valueStringDiff = json.differential.element[3];
       expect(valueStringDiff.id).toBe('Observation.valueString');
       expect(valueStringDiff.path).toBe('Observation.valueString');
       expect(valueStringDiff.type).toEqual([{ code: 'string' }]);
@@ -262,14 +317,19 @@ describe('StructureDefinition', () => {
       expect(valueStringSnapshot.sliceName).toEqual('valueString');
       expect(valueStringSnapshot.short).toBe('the string choice');
       // then check that differential does NOT have value[x] but has shortcut syntax for valueQuantity and valueString
-      expect(json.differential.element).toHaveLength(2);
-      const valueQuantityDiff = json.differential.element[0];
+      expect(json.differential.element).toHaveLength(3);
+      const rootDiff = json.differential.element[0];
+      expect(rootDiff).toEqual({
+        id: 'Observation',
+        path: 'Observation'
+      });
+      const valueQuantityDiff = json.differential.element[1];
       expect(valueQuantityDiff.id).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.path).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.type).toEqual([{ code: 'Quantity' }]);
       expect(valueQuantityDiff.sliceName).toBeUndefined();
       expect(valueQuantitySnapshot.short).toBe('the quantity choice');
-      const valueStringDiff = json.differential.element[1];
+      const valueStringDiff = json.differential.element[2];
       expect(valueStringDiff.id).toBe('Observation.valueString');
       expect(valueStringDiff.path).toBe('Observation.valueString');
       expect(valueStringDiff.type).toEqual([{ code: 'string' }]);
@@ -314,8 +374,13 @@ describe('StructureDefinition', () => {
       expect(valueStringSnapshot.sliceName).toEqual('valueString');
       expect(valueStringSnapshot.short).toBe('the string choice');
       // then check that differential does NOT have value[x] but has shortcut syntax for valueQuantity and valueString
-      expect(json.differential.element).toHaveLength(3);
-      const valueXDiff = json.differential.element[0];
+      expect(json.differential.element).toHaveLength(4);
+      const rootDiff = json.differential.element[0];
+      expect(rootDiff).toEqual({
+        id: 'Observation',
+        path: 'Observation'
+      });
+      const valueXDiff = json.differential.element[1];
       expect(valueXDiff).toEqual({
         id: 'Observation.value[x]',
         path: 'Observation.value[x]',
@@ -326,13 +391,13 @@ describe('StructureDefinition', () => {
         },
         short: 'a choice of many things'
       });
-      const valueQuantityDiff = json.differential.element[1];
+      const valueQuantityDiff = json.differential.element[2];
       expect(valueQuantityDiff.id).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.path).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.type).toEqual([{ code: 'Quantity' }]);
       expect(valueQuantityDiff.sliceName).toBeUndefined();
       expect(valueQuantitySnapshot.short).toBe('the quantity choice');
-      const valueStringDiff = json.differential.element[2];
+      const valueStringDiff = json.differential.element[3];
       expect(valueStringDiff.id).toBe('Observation.valueString');
       expect(valueStringDiff.path).toBe('Observation.valueString');
       expect(valueStringDiff.type).toEqual([{ code: 'string' }]);
@@ -375,8 +440,8 @@ describe('StructureDefinition', () => {
       expect(catCoding).toEqual(catCodingOriginal);
       expect(cat).toEqual(catOriginal);
 
-      const vsCatCodingDiff = json.differential.element[3];
-      const vsCatDiff = json.differential.element[2];
+      const vsCatCodingDiff = json.differential.element[4];
+      const vsCatDiff = json.differential.element[3];
       expect(vsCatCodingDiff).toEqual({
         id: 'Observation.category:VSCat.coding',
         path: 'Observation.category.coding',
@@ -388,8 +453,8 @@ describe('StructureDefinition', () => {
         sliceName: 'VSCat'
       });
 
-      const catCodingDiff = json.differential.element[1];
-      const catDiff = json.differential.element[0];
+      const catCodingDiff = json.differential.element[2];
+      const catDiff = json.differential.element[1];
       expect(catCodingDiff).toEqual({
         id: 'Observation.category.coding',
         path: 'Observation.category.coding',
@@ -398,6 +463,12 @@ describe('StructureDefinition', () => {
       expect(catDiff).toEqual({
         id: 'Observation.category',
         path: 'Observation.category'
+      });
+
+      const rootDiff = json.differential.element[0];
+      expect(rootDiff).toEqual({
+        id: 'Observation',
+        path: 'Observation'
       });
     });
   });


### PR DESCRIPTION
Although the IG Publisher *should* handle sparse differentials, it doesn't always handle them well.

Since adding in intermediate elements is not harmful, nor is it wrong, just do it to avoid any bugs in the publisher related to sparse differentials.