### PR TITLE
Sanitize ids that are valid names

### DIFF
--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -165,6 +165,39 @@ describe('CodeSystemExporter', () => {
     expect(loggerSpy.getLastMessage('error')).toMatch(/File: Strange\.fsh.*Line: 3 - 8\D*/s);
   });
 
+  it('should sanitize the id and log a message when a valid name is used to make an invalid id', () => {
+    const codeSystem = new FshCodeSystem('Not_good_id')
+      .withFile('Wrong.fsh')
+      .withLocation([2, 8, 5, 18]);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export().codeSystems;
+    expect(exported[0].name).toBe('Not_good_id');
+    expect(exported[0].id).toBe('Not-good-id');
+    expect(loggerSpy.getLastMessage('warn')).toMatch(
+      /The string "Not_good_id" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "Not-good-id"/s
+    );
+    expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
+  });
+
+  it('should sanitize the id and log a message when a long valid name is used to make an invalid id', () => {
+    let longId = 'Toolong';
+    while (longId.length < 65) longId += 'longer';
+    const codeSystem = new FshCodeSystem(longId).withFile('Wrong.fsh').withLocation([2, 8, 5, 18]);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export().codeSystems;
+    expect(exported[0].name).toBe(longId);
+    expect(exported[0].id).toBe(longId.slice(0, 64));
+    const warning = new RegExp(
+      `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${longId.slice(
+        0,
+        64
+      )}"`,
+      's'
+    );
+    expect(loggerSpy.getLastMessage('warn')).toMatch(warning);
+    expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
+  });
+
   // CaretValueRules
   it('should apply a CaretValueRule', () => {
     const codeSystem = new FshCodeSystem('CaretCodeSystem');

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -185,13 +185,11 @@ describe('CodeSystemExporter', () => {
     const codeSystem = new FshCodeSystem(longId).withFile('Wrong.fsh').withLocation([2, 8, 5, 18]);
     doc.codeSystems.set(codeSystem.name, codeSystem);
     const exported = exporter.export().codeSystems;
+    const expectedId = longId.slice(0, 64);
     expect(exported[0].name).toBe(longId);
-    expect(exported[0].id).toBe(longId.slice(0, 64));
+    expect(exported[0].id).toBe(expectedId);
     const warning = new RegExp(
-      `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${longId.slice(
-        0,
-        64
-      )}"`,
+      `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${expectedId}"`,
       's'
     );
     expect(loggerSpy.getLastMessage('warn')).toMatch(warning);

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -260,16 +260,14 @@ describe('InstanceExporter', () => {
       fixedValRule.fixedValue = longId;
       instance.rules.push(fixedValRule);
       const exported = exportInstance(instance);
+      const expectedId = longId.slice(0, 64);
       const expectedInstanceJSON = {
         resourceType: 'Patient',
-        id: longId.slice(0, 64)
+        id: expectedId
       };
       expect(exported.toJSON()).toEqual(expectedInstanceJSON);
       const warning = new RegExp(
-        `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${longId.slice(
-          0,
-          64
-        )}"`,
+        `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${expectedId}"`,
         's'
       );
       expect(loggerSpy.getLastMessage('warn')).toMatch(warning);

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -375,11 +375,11 @@ describe('StructureDefinitionExporter', () => {
 
   it('should log a message when the structure definition has an invalid id', () => {
     const profile = new Profile('Wrong').withFile('Wrong.fsh').withLocation([1, 8, 4, 18]);
-    profile.id = 'will_not_work';
+    profile.id = 'will?not?work';
     doc.profiles.set(profile.name, profile);
     exporter.exportStructDef(profile);
     const exported = pkg.profiles[0];
-    expect(exported.id).toBe('will_not_work');
+    expect(exported.id).toBe('will?not?work');
     expect(loggerSpy.getLastMessage()).toMatch(/does not represent a valid FHIR id/s);
     expect(loggerSpy.getLastMessage()).toMatch(/File: Wrong\.fsh.*Line: 1 - 4\D*/s);
   });
@@ -392,6 +392,39 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.name).toBe('Not-good');
     expect(loggerSpy.getLastMessage()).toMatch(/does not represent a valid FHIR name/s);
     expect(loggerSpy.getLastMessage()).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
+  });
+
+  it('should sanitize the id and log a message when a valid name is used to make an invalid id', () => {
+    const profile = new Profile('Not_good_id').withFile('Wrong.fsh').withLocation([2, 8, 5, 18]);
+    doc.profiles.set(profile.name, profile);
+    exporter.exportStructDef(profile);
+    const exported = pkg.profiles[0];
+    expect(exported.name).toBe('Not_good_id');
+    expect(exported.id).toBe('Not-good-id');
+    expect(loggerSpy.getLastMessage('warn')).toMatch(
+      /The string "Not_good_id" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "Not-good-id"/s
+    );
+    expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
+  });
+
+  it('should sanitize the id and log a message when a long valid name is used to make an invalid id', () => {
+    let longId = 'Toolong';
+    while (longId.length < 65) longId += 'longer';
+    const profile = new Profile(longId).withFile('Wrong.fsh').withLocation([2, 8, 5, 18]);
+    doc.profiles.set(profile.name, profile);
+    exporter.exportStructDef(profile);
+    const exported = pkg.profiles[0];
+    expect(exported.name).toBe(longId);
+    expect(exported.id).toBe(longId.slice(0, 64));
+    const warning = new RegExp(
+      `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${longId.slice(
+        0,
+        64
+      )}"`,
+      's'
+    );
+    expect(loggerSpy.getLastMessage('warn')).toMatch(warning);
+    expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
   });
 
   // Rules

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -414,13 +414,11 @@ describe('StructureDefinitionExporter', () => {
     doc.profiles.set(profile.name, profile);
     exporter.exportStructDef(profile);
     const exported = pkg.profiles[0];
+    const expectedId = longId.slice(0, 64);
     expect(exported.name).toBe(longId);
-    expect(exported.id).toBe(longId.slice(0, 64));
+    expect(exported.id).toBe(expectedId);
     const warning = new RegExp(
-      `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${longId.slice(
-        0,
-        64
-      )}"`,
+      `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${expectedId}"`,
       's'
     );
     expect(loggerSpy.getLastMessage('warn')).toMatch(warning);

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -134,13 +134,11 @@ describe('ValueSetExporter', () => {
     const valueSet = new FshValueSet(longId).withFile('Wrong.fsh').withLocation([2, 8, 5, 18]);
     doc.valueSets.set(valueSet.name, valueSet);
     const exported = exporter.export().valueSets;
+    const expectedId = longId.slice(0, 64);
     expect(exported[0].name).toBe(longId);
-    expect(exported[0].id).toBe(longId.slice(0, 64));
+    expect(exported[0].id).toBe(expectedId);
     const warning = new RegExp(
-      `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${longId.slice(
-        0,
-        64
-      )}"`,
+      `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${expectedId}"`,
       's'
     );
     expect(loggerSpy.getLastMessage('warn')).toMatch(warning);

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -114,6 +114,39 @@ describe('ValueSetExporter', () => {
     expect(loggerSpy.getLastMessage('error')).toMatch(/File: Breakfast\.fsh.*Line: 2 - 8\D*/s);
   });
 
+  it('should sanitize the id and log a message when a valid name is used to make an invalid id', () => {
+    const valueSet = new FshValueSet('Not_good_id')
+      .withFile('Wrong.fsh')
+      .withLocation([2, 8, 5, 18]);
+    doc.valueSets.set(valueSet.name, valueSet);
+    const exported = exporter.export().valueSets;
+    expect(exported[0].name).toBe('Not_good_id');
+    expect(exported[0].id).toBe('Not-good-id');
+    expect(loggerSpy.getLastMessage('warn')).toMatch(
+      /The string "Not_good_id" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "Not-good-id"/s
+    );
+    expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
+  });
+
+  it('should sanitize the id and log a message when a long valid name is used to make an invalid id', () => {
+    let longId = 'Toolong';
+    while (longId.length < 65) longId += 'longer';
+    const valueSet = new FshValueSet(longId).withFile('Wrong.fsh').withLocation([2, 8, 5, 18]);
+    doc.valueSets.set(valueSet.name, valueSet);
+    const exported = exporter.export().valueSets;
+    expect(exported[0].name).toBe(longId);
+    expect(exported[0].id).toBe(longId.slice(0, 64));
+    const warning = new RegExp(
+      `The string "${longId}" represents a valid FHIR name but not a valid FHIR id.*The id will be exported as "${longId.slice(
+        0,
+        64
+      )}"`,
+      's'
+    );
+    expect(loggerSpy.getLastMessage('warn')).toMatch(warning);
+    expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
+  });
+
   it('should export each value set once, even if export is called more than once', () => {
     const breakfast = new FshValueSet('BreakfastVS');
     doc.valueSets.set(breakfast.name, breakfast);


### PR DESCRIPTION
Fixes #441.

Now when a FHIR id is specified that is an invalid id, but a valid name, that name will be turned into an id by replacing `_` with `-` and by truncating to 64 characters. A warning will be emitted, since the users really should just specify the id directly if they are running into this case. If the id is not a valid name, then we can't be sure we can turn it into a valid id, so we do nothing. This will happen even if the id is not being set via a name. Aka even if the user does:
```
CodeSystem: CodeSystem_MaritalStatus
Id: My_Invalid_Id
```

I thought this would be fine, since the old approach would be to log an error and export using `My_Invalid_Id`. In this approach, we would fix `My_Invalid_Id` to be `My-Invalid-Id`, which is not a valid id, and only log a warning. Either way the user will probably want to fix it, but this way the user at least gets a valid id in their output.