### PR TITLE
More carefully validate ig.dependsOn.id

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -171,8 +171,12 @@ export class IGExporter {
           this.ig.dependsOn.push({
             uri: `${depIG.url}`,
             packageId: depId,
-            // packageId should be alphanumeric or '.', id must be alphanumeric or '_' for IG Publisher, so replace '.' with '_'
-            id: depId.replace(/\./g, '_'),
+            // packageId should be "a..z, A..Z, 0..9, and _ and it must start with a..z | A..Z" per
+            // https://chat.fhir.org/#narrow/stream/215610-shorthand/topic/SUSHI.200.2E12.2E7/near/199193333
+            // depId should be [A-Za-z0-9\-\.]{1,64}, so we replace . and - with _ and prepend "id_" if it does not start w/ a-z|A-Z
+            id: /[A-Za-z]/.test(depId[0])
+              ? depId.replace(/\.|-/g, '_')
+              : 'id_' + depId.replace(/\.|-/g, '_'),
             version: depVersion
           });
         } else {

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -172,7 +172,7 @@ describe('IGExporter', () => {
             packageId: 'hl7.fhir.uv.vhdir',
             version: 'current'
           },
-          // test-wonky-id-1 tests that we are correctly turning - in packageId to - in id
+          // test-wonky-id-1 tests that we are correctly turning - in packageId to _ in id
           {
             id: 'test_wonky_id_1',
             packageId: 'test-wonky-id-1',

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -171,6 +171,20 @@ describe('IGExporter', () => {
             uri: 'http://hl7.org/fhir/uv/vhdir/ImplementationGuide/hl7.core.uv.vhdir',
             packageId: 'hl7.fhir.uv.vhdir',
             version: 'current'
+          },
+          // test-wonky-id-1 tests that we are correctly turning - in packageId to - in id
+          {
+            id: 'test_wonky_id_1',
+            packageId: 'test-wonky-id-1',
+            uri: 'http://hl7.org/fhir/ImplementationGuide/test-wonky-id-1',
+            version: 'current'
+          },
+          // 2-test-wonky-id tests that we are correctly prepending id_
+          {
+            id: 'id_2_test_wonky_id',
+            packageId: '2-test-wonky-id',
+            uri: 'http://hl7.org/fhir/ImplementationGuide/2-test-wonky-id',
+            version: 'current'
           }
         ],
         definition: {

--- a/test/ig/fixtures/simple-ig/package.json
+++ b/test/ig/fixtures/simple-ig/package.json
@@ -8,7 +8,9 @@
   "dependencies": {
      "hl7.fhir.r4.core": "4.0.1",
      "hl7.fhir.us.core": "3.1.0",
-     "hl7.fhir.uv.vhdir":"current"
+     "hl7.fhir.uv.vhdir":"current",
+     "test-wonky-id-1": "current",
+     "2-test-wonky-id": "current"
   },
   "language": "en",
   "author": "James Tuna",

--- a/test/testhelpers/testdefs/package/ImplementationGuide-2-test-wonky-id.json
+++ b/test/testhelpers/testdefs/package/ImplementationGuide-2-test-wonky-id.json
@@ -1,0 +1,5 @@
+{
+  "resourceType": "ImplementationGuide",
+  "packageId": "2-test-wonky-id",
+  "url": "http://hl7.org/fhir/ImplementationGuide/2-test-wonky-id"
+}

--- a/test/testhelpers/testdefs/package/ImplementationGuide-test-wonky-id-1.json
+++ b/test/testhelpers/testdefs/package/ImplementationGuide-test-wonky-id-1.json
@@ -1,0 +1,5 @@
+{
+  "resourceType": "ImplementationGuide",
+  "packageId": "test-wonky-id-1",
+  "url": "http://hl7.org/fhir/ImplementationGuide/test-wonky-id-1"
+}


### PR DESCRIPTION
This fixes https://github.com/FHIR/sushi/issues/466. 

Now we will replace both `-` and `.` with `_`, and if the packageId does not start with `[a-zA-z]`, we make it start with `[a-zA-z]` by prepending `id_`. That is kind of arbitrary, but this `id` is just a token that is used interally, so I think it is ok to be a little arbitrary.