### PR TITLE
Menu Configuration Keywords

### DIFF
--- a/src/fshtypes/Configuration.ts
+++ b/src/fshtypes/Configuration.ts
@@ -150,6 +150,8 @@ export type ConfigurationResource = ImplementationGuideDefinitionResource & { om
 export type ConfigurationMenuItem = {
   name: string;
   url?: string;
+  isExternal?: boolean;
+  openInNewTab?: boolean;
   subMenu?: ConfigurationMenuItem[];
 };
 

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -653,15 +653,16 @@ export class IGExporter {
       menuItem += `${prefixSpaces}</li>${EOL}`;
     } else {
       menuItem += `${prefixSpaces}<li>${EOL}${prefixSpaces}${'  '}`;
-      if (item.url || item.openInNewTab) {
+      if (item.url) {
         menuItem += '<a ';
         if (item.openInNewTab) menuItem += 'target="_blank" ';
-        if (item.url) menuItem += `href="${item.url}"`;
-        menuItem += '>';
+        menuItem += `href="${item.url}">`;
       }
       menuItem += item.name;
-      if (item.isExternal) menuItem += '<img src="external.png" style="text-align: baseline"/>';
-      if (item.url || item.openInNewTab) menuItem += '</a>';
+      if (item.url) {
+        if (item.isExternal) menuItem += ' <img src="external.png" style="text-align: baseline"/>';
+        menuItem += '</a>';
+      }
       menuItem += `${EOL}${prefixSpaces}</li>${EOL}`;
     }
     return menuItem;

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -653,9 +653,15 @@ export class IGExporter {
       menuItem += `${prefixSpaces}</li>${EOL}`;
     } else {
       menuItem += `${prefixSpaces}<li>${EOL}${prefixSpaces}${'  '}`;
-      if (item.url) menuItem += `<a href="${item.url}">`;
+      if (item.url || item.openInNewTab) {
+        menuItem += '<a ';
+        if (item.openInNewTab) menuItem += 'target="_blank" ';
+        if (item.url) menuItem += `href="${item.url}"`;
+        menuItem += '>';
+      }
       menuItem += item.name;
-      if (item.url) menuItem += '</a>';
+      if (item.isExternal) menuItem += '<img src="external.png" style="text-align: baseline"/>';
+      if (item.url || item.openInNewTab) menuItem += '</a>';
       menuItem += `${EOL}${prefixSpaces}</li>${EOL}`;
     }
     return menuItem;

--- a/src/import/ensureConfiguration.ts
+++ b/src/import/ensureConfiguration.ts
@@ -402,6 +402,11 @@ function getBoxComment(title: string, comment: string): string {
   return boxComment;
 }
 
+// Helper functions for converting menu XML file
+const itemInNewTab = (item: any) => (item.a._attributes?.target === '_blank' ? 'new-tab ' : '');
+const itemIsExternal = (item: any) =>
+  item.a.img?._attributes?.src === 'external.png' ? 'external ' : '';
+
 /**
  * Convert a menu XML file into the required menu object format for the YAML configuration.
  * This assumes the menu XML format found in the sample-ig.  Other formats won't be parsed
@@ -453,9 +458,7 @@ function getMenuObjectFromMenuXML(menuXML: string): YAMLConfigurationMenuTree {
         if (li.a && !Array.isArray(li.a)) {
           const name = li.a._text;
           const link = li.a._attributes?.href;
-          const inNewTab = li.a._attributes?.target === '_blank' ? 'new-tab ' : '';
-          const isExternal = li.a.img?._attributes?.src === 'external.png' ? 'external ' : '';
-          const menuLinkWithKeywords = `${inNewTab}${isExternal}${link}`;
+          const menuLinkWithKeywords = `${itemInNewTab(li)}${itemIsExternal(li)}${link}`;
           if (li.ul && li.ul.li) {
             const subMenu: YAMLConfigurationMenuTree = {};
             const subItems = Array.isArray(li.ul.li) ? li.ul.li : [li.ul.li];
@@ -463,11 +466,8 @@ function getMenuObjectFromMenuXML(menuXML: string): YAMLConfigurationMenuTree {
               if (subLi.a && !Array.isArray(subLi.a)) {
                 const subName = subLi.a._text;
                 const subLink = subLi.a._attributes?.href;
-                const subInNewTab = subLi.a._attributes?.target === '_blank' ? 'new-tab ' : '';
-                const subIsExternal =
-                  subLi.a.img?._attributes?.src === 'external.png' ? 'external ' : '';
                 if (subLink && subLink !== '#') {
-                  subMenu[subName] = `${subInNewTab}${subIsExternal}${subLink}`;
+                  subMenu[subName] = `${itemInNewTab(subLi)}${itemIsExternal(subLi)}${subLink}`;
                 }
                 // NOTE: if there is another sub-sub-menu, we drop it since publisher doesn't support it
               }

--- a/src/import/ensureConfiguration.ts
+++ b/src/import/ensureConfiguration.ts
@@ -453,6 +453,9 @@ function getMenuObjectFromMenuXML(menuXML: string): YAMLConfigurationMenuTree {
         if (li.a && !Array.isArray(li.a)) {
           const name = li.a._text;
           const link = li.a._attributes?.href;
+          const inNewTab = li.a._attributes?.target === '_blank' ? 'new-tab ' : '';
+          const isExternal = li.a.img?._attributes?.src === 'external.png' ? 'external ' : '';
+          const menuLinkWithKeywords = `${inNewTab}${isExternal}${link}`;
           if (li.ul && li.ul.li) {
             const subMenu: YAMLConfigurationMenuTree = {};
             const subItems = Array.isArray(li.ul.li) ? li.ul.li : [li.ul.li];
@@ -460,8 +463,11 @@ function getMenuObjectFromMenuXML(menuXML: string): YAMLConfigurationMenuTree {
               if (subLi.a && !Array.isArray(subLi.a)) {
                 const subName = subLi.a._text;
                 const subLink = subLi.a._attributes?.href;
+                const subInNewTab = subLi.a._attributes?.target === '_blank' ? 'new-tab ' : '';
+                const subIsExternal =
+                  subLi.a.img?._attributes?.src === 'external.png' ? 'external ' : '';
                 if (subLink && subLink !== '#') {
-                  subMenu[subName] = subLink;
+                  subMenu[subName] = `${subInNewTab}${subIsExternal}${subLink}`;
                 }
                 // NOTE: if there is another sub-sub-menu, we drop it since publisher doesn't support it
               }
@@ -469,10 +475,10 @@ function getMenuObjectFromMenuXML(menuXML: string): YAMLConfigurationMenuTree {
             if (Object.keys(subMenu).length > 0) {
               menu[name] = subMenu;
             } else if (link && link !== '#') {
-              menu[name] = link;
+              menu[name] = menuLinkWithKeywords;
             }
           } else if (link && link !== '#') {
-            menu[name] = link;
+            menu[name] = menuLinkWithKeywords;
           }
         }
       });

--- a/src/import/ensureConfiguration.ts
+++ b/src/import/ensureConfiguration.ts
@@ -609,7 +609,7 @@ const DEFAULT_MENU: YAMLConfigurationMenuTree = {
   'Table of Contents': 'toc.html',
   'Artifact Index': 'artifacts.html',
   Support: {
-    'FHIR Spec': 'http://hl7.org/fhir/R4/index.html'
+    'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html'
   }
 };
 

--- a/src/import/importConfiguration.ts
+++ b/src/import/importConfiguration.ts
@@ -683,7 +683,19 @@ function parseMenu(yamlMenu: YAMLConfigurationMenuTree): ConfigurationMenuItem[]
   return Object.entries(yamlMenu).map(([name, value]) => {
     const item: ConfigurationMenuItem = { name };
     if (typeof value === 'string') {
-      item.url = value;
+      // Set menu item attributes based on keywords
+      if (value.includes('new-tab ')) {
+        item.openInNewTab = true;
+        value = value.replace('new-tab', '');
+      }
+
+      if (value.includes('external ')) {
+        item.isExternal = true;
+        value = value.replace('external', '');
+      }
+
+      // Trim off any white space left after using keywords. URL is remaining value.
+      item.url = value.trim();
     } else {
       item.subMenu = parseMenu(value);
     }

--- a/test/ig/IGExporter.menu-xml.test.ts
+++ b/test/ig/IGExporter.menu-xml.test.ts
@@ -8,6 +8,9 @@ import { loggerSpy } from '../testhelpers/loggerSpy';
 import { minimalConfig } from '../utils/minimalConfig';
 import {
   simpleMenuXMLContent,
+  simpleMenuXMLWithOpenInNewTabContent,
+  simpleMenuXMLWithExternalContent,
+  simpleMenuXMLWithExternalNewTabNoUrlContent,
   subMenuXMLContent,
   subMenuWithWarningXMLContent
 } from './fixtures/menuXMLContent';
@@ -111,6 +114,57 @@ describe('IGExporter', () => {
       expect(loggerSpy.getAllMessages()).toHaveLength(0);
     });
 
+    it('should build menu to open in new tab when provided in config.menu', () => {
+      const config = { ...minimalConfig };
+      config.menu = [
+        { name: 'Animals', url: 'animals.html', openInNewTab: true },
+        { name: 'Plants', url: 'plants.html' },
+        { name: 'Other' }
+      ];
+      const pkg = new Package(config);
+      const exporter = new IGExporter(pkg, null, '');
+      exporter.addMenuXML(tempOut);
+      const menuPath = path.join(tempOut, 'input', 'includes', 'menu.xml');
+      expect(fs.existsSync(menuPath)).toBeTruthy();
+      const content = fs.readFileSync(menuPath, 'utf8');
+      expect(content).toContain(simpleMenuXMLWithOpenInNewTabContent.replace(/\n/g, EOL));
+      expect(loggerSpy.getAllMessages()).toHaveLength(0);
+    });
+
+    it('should build menu with external icon when provided in config.menu', () => {
+      const config = { ...minimalConfig };
+      config.menu = [
+        { name: 'Animals', url: 'animals.html', isExternal: true },
+        { name: 'Plants', url: 'plants.html' },
+        { name: 'Other' }
+      ];
+      const pkg = new Package(config);
+      const exporter = new IGExporter(pkg, null, '');
+      exporter.addMenuXML(tempOut);
+      const menuPath = path.join(tempOut, 'input', 'includes', 'menu.xml');
+      expect(fs.existsSync(menuPath)).toBeTruthy();
+      const content = fs.readFileSync(menuPath, 'utf8');
+      expect(content).toContain(simpleMenuXMLWithExternalContent.replace(/\n/g, EOL));
+      expect(loggerSpy.getAllMessages()).toHaveLength(0);
+    });
+
+    it('should build menu with external icon, new tab, and no url when provided in config.menu', () => {
+      const config = { ...minimalConfig };
+      config.menu = [
+        { name: 'Animals', openInNewTab: true, isExternal: true },
+        { name: 'Plants', url: 'plants.html' },
+        { name: 'Other' }
+      ];
+      const pkg = new Package(config);
+      const exporter = new IGExporter(pkg, null, '');
+      exporter.addMenuXML(tempOut);
+      const menuPath = path.join(tempOut, 'input', 'includes', 'menu.xml');
+      expect(fs.existsSync(menuPath)).toBeTruthy();
+      const content = fs.readFileSync(menuPath, 'utf8');
+      expect(content).toContain(simpleMenuXMLWithExternalNewTabNoUrlContent.replace(/\n/g, EOL));
+      expect(loggerSpy.getAllMessages()).toHaveLength(0);
+    });
+
     it('should build menu with a sub-menu when provided in config.menu', () => {
       const config = { ...minimalConfig };
       config.menu = [
@@ -119,7 +173,8 @@ describe('IGExporter', () => {
           name: 'Plants',
           subMenu: [
             { name: 'Trees', url: 'plants.html#trees' },
-            { name: 'Flowers', url: 'buds.html' }
+            { name: 'Flowers', url: 'buds.html' },
+            { name: 'Cacti', url: 'prickly.com', isExternal: true, openInNewTab: true }
           ]
         }
       ];

--- a/test/ig/IGExporter.menu-xml.test.ts
+++ b/test/ig/IGExporter.menu-xml.test.ts
@@ -10,7 +10,6 @@ import {
   simpleMenuXMLContent,
   simpleMenuXMLWithOpenInNewTabContent,
   simpleMenuXMLWithExternalContent,
-  simpleMenuXMLWithExternalNewTabNoUrlContent,
   subMenuXMLContent,
   subMenuWithWarningXMLContent
 } from './fixtures/menuXMLContent';
@@ -145,23 +144,6 @@ describe('IGExporter', () => {
       expect(fs.existsSync(menuPath)).toBeTruthy();
       const content = fs.readFileSync(menuPath, 'utf8');
       expect(content).toContain(simpleMenuXMLWithExternalContent.replace(/\n/g, EOL));
-      expect(loggerSpy.getAllMessages()).toHaveLength(0);
-    });
-
-    it('should build menu with external icon, new tab, and no url when provided in config.menu', () => {
-      const config = { ...minimalConfig };
-      config.menu = [
-        { name: 'Animals', openInNewTab: true, isExternal: true },
-        { name: 'Plants', url: 'plants.html' },
-        { name: 'Other' }
-      ];
-      const pkg = new Package(config);
-      const exporter = new IGExporter(pkg, null, '');
-      exporter.addMenuXML(tempOut);
-      const menuPath = path.join(tempOut, 'input', 'includes', 'menu.xml');
-      expect(fs.existsSync(menuPath)).toBeTruthy();
-      const content = fs.readFileSync(menuPath, 'utf8');
-      expect(content).toContain(simpleMenuXMLWithExternalNewTabNoUrlContent.replace(/\n/g, EOL));
       expect(loggerSpy.getAllMessages()).toHaveLength(0);
     });
 

--- a/test/ig/fixtures/menuXMLContent.ts
+++ b/test/ig/fixtures/menuXMLContent.ts
@@ -11,6 +11,45 @@ export const simpleMenuXMLContent = `
   </li>
 </ul>`;
 
+export const simpleMenuXMLWithOpenInNewTabContent = `
+<ul xmlns="http://www.w3.org/1999/xhtml" class="nav navbar-nav">
+  <li>
+    <a target="_blank" href="animals.html">Animals</a>
+  </li>
+  <li>
+    <a href="plants.html">Plants</a>
+  </li>
+  <li>
+    Other
+  </li>
+</ul>`;
+
+export const simpleMenuXMLWithExternalContent = `
+<ul xmlns="http://www.w3.org/1999/xhtml" class="nav navbar-nav">
+  <li>
+    <a href="animals.html">Animals<img src="external.png" style="text-align: baseline"/></a>
+  </li>
+  <li>
+    <a href="plants.html">Plants</a>
+  </li>
+  <li>
+    Other
+  </li>
+</ul>`;
+
+export const simpleMenuXMLWithExternalNewTabNoUrlContent = `
+<ul xmlns="http://www.w3.org/1999/xhtml" class="nav navbar-nav">
+  <li>
+    <a target="_blank" >Animals<img src="external.png" style="text-align: baseline"/></a>
+  </li>
+  <li>
+    <a href="plants.html">Plants</a>
+  </li>
+  <li>
+    Other
+  </li>
+</ul>`;
+
 export const subMenuXMLContent = `
 <ul xmlns="http://www.w3.org/1999/xhtml" class="nav navbar-nav">
   <li>
@@ -26,6 +65,9 @@ export const subMenuXMLContent = `
       </li>
       <li>
         <a href="buds.html">Flowers</a>
+      </li>
+      <li>
+        <a target="_blank" href="prickly.com">Cacti<img src="external.png" style="text-align: baseline"/></a>
       </li>
     </ul>
   </li>

--- a/test/ig/fixtures/menuXMLContent.ts
+++ b/test/ig/fixtures/menuXMLContent.ts
@@ -27,20 +27,7 @@ export const simpleMenuXMLWithOpenInNewTabContent = `
 export const simpleMenuXMLWithExternalContent = `
 <ul xmlns="http://www.w3.org/1999/xhtml" class="nav navbar-nav">
   <li>
-    <a href="animals.html">Animals<img src="external.png" style="text-align: baseline"/></a>
-  </li>
-  <li>
-    <a href="plants.html">Plants</a>
-  </li>
-  <li>
-    Other
-  </li>
-</ul>`;
-
-export const simpleMenuXMLWithExternalNewTabNoUrlContent = `
-<ul xmlns="http://www.w3.org/1999/xhtml" class="nav navbar-nav">
-  <li>
-    <a target="_blank" >Animals<img src="external.png" style="text-align: baseline"/></a>
+    <a href="animals.html">Animals <img src="external.png" style="text-align: baseline"/></a>
   </li>
   <li>
     <a href="plants.html">Plants</a>
@@ -67,7 +54,7 @@ export const subMenuXMLContent = `
         <a href="buds.html">Flowers</a>
       </li>
       <li>
-        <a target="_blank" href="prickly.com">Cacti<img src="external.png" style="text-align: baseline"/></a>
+        <a target="_blank" href="prickly.com">Cacti <img src="external.png" style="text-align: baseline"/></a>
       </li>
     </ul>
   </li>

--- a/test/import/YAMLConfiguration.test.ts
+++ b/test/import/YAMLConfiguration.test.ts
@@ -92,7 +92,8 @@ describe('YAMLConfiguration', () => {
           'Value Sets': 'artifacts.html#4'
         },
         Downloads: 'downloads.html',
-        History: 'http://hl7.org/fhir/us/example/history.html'
+        History: 'http://hl7.org/fhir/us/example/history.html',
+        'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html'
       });
       expect(config.parameters).toEqual({
         excludettl: true,

--- a/test/import/ensureConfiguration.test.ts
+++ b/test/import/ensureConfiguration.test.ts
@@ -705,7 +705,7 @@ describe('ensureConfiguration', () => {
       'To control the menu.xml using this config, uncomment and set the "menu" property.'
     );
 
-    // The commented out menu should correspond to the default menu.json
+    // The commented out menu should correspond to the generated menu based on provided menu.xml
     const configTextLines = configText.split('\n');
     const start = configTextLines.findIndex(l => l.startsWith('# menu:'));
     const end = configTextLines.findIndex(l => l.startsWith('# NOTE: The history property'));
@@ -725,7 +725,7 @@ describe('ensureConfiguration', () => {
       },
       'Artifact Index': 'artifacts.html',
       Support: {
-        'FHIR Spec': '{{site.data.fhir.path}}index.html',
+        'FHIR Spec': 'new-tab external {{site.data.fhir.path}}index.html',
         Downloads: 'downloads.html'
       }
     });

--- a/test/import/ensureConfiguration.test.ts
+++ b/test/import/ensureConfiguration.test.ts
@@ -78,7 +78,7 @@ describe('ensureConfiguration', () => {
         'Table of Contents': 'toc.html',
         'Artifact Index': 'artifacts.html',
         Support: {
-          'FHIR Spec': 'http://hl7.org/fhir/R4/index.html'
+          'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html'
         }
       },
       history: {
@@ -148,7 +148,7 @@ describe('ensureConfiguration', () => {
         'IG Home': 'index.html',
         'Table of Contents': 'toc.html',
         'Artifact Index': 'artifacts.html',
-        Support: { 'FHIR Spec': 'http://hl7.org/fhir/R4/index.html' }
+        Support: { 'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html' }
       },
       history: {
         current: 'http://build.fhir.org/ig/example/example-ig',
@@ -223,7 +223,7 @@ describe('ensureConfiguration', () => {
         'IG Home': 'index.html',
         'Table of Contents': 'toc.html',
         'Artifact Index': 'artifacts.html',
-        Support: { 'FHIR Spec': 'http://hl7.org/fhir/R4/index.html' }
+        Support: { 'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html' }
       },
       history: {
         current: 'http://build.fhir.org/ig/example/example-ig',
@@ -321,7 +321,7 @@ describe('ensureConfiguration', () => {
         'IG Home': 'index.html',
         'Table of Contents': 'toc.html',
         'Artifact Index': 'artifacts.html',
-        Support: { 'FHIR Spec': 'http://hl7.org/fhir/R4/index.html' }
+        Support: { 'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html' }
       },
       history: {
         current: 'http://build.fhir.org/ig/example/example-ig',
@@ -379,7 +379,7 @@ describe('ensureConfiguration', () => {
         'IG Home': 'index.html',
         'Table of Contents': 'toc.html',
         'Artifact Index': 'artifacts.html',
-        Support: { 'FHIR Spec': 'http://hl7.org/fhir/R4/index.html' }
+        Support: { 'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html' }
       },
       history: {
         current: 'http://build.fhir.org/ig/example/example-ig',
@@ -452,7 +452,7 @@ describe('ensureConfiguration', () => {
         'IG Home': 'index.html',
         'Table of Contents': 'toc.html',
         'Artifact Index': 'artifacts.html',
-        Support: { 'FHIR Spec': 'http://hl7.org/fhir/R4/index.html' }
+        Support: { 'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html' }
       },
       history: {
         current: 'http://build.fhir.org/ig/example/example-ig',
@@ -510,7 +510,7 @@ describe('ensureConfiguration', () => {
         'IG Home': 'index.html',
         'Table of Contents': 'toc.html',
         'Artifact Index': 'artifacts.html',
-        Support: { 'FHIR Spec': 'http://hl7.org/fhir/R4/index.html' }
+        Support: { 'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html' }
       },
       // history should no longer exist since it will just use the provided package-list.json
       indexPageContent: 'Provides a simple example of how FSH can be used to create an IG'
@@ -612,7 +612,7 @@ describe('ensureConfiguration', () => {
         'IG Home': 'index.html',
         'Table of Contents': 'toc.html',
         'Artifact Index': 'artifacts.html',
-        Support: { 'FHIR Spec': 'http://hl7.org/fhir/R4/index.html' }
+        Support: { 'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html' }
       },
       // history should still not exist since it will just use the provided package-list.json
       indexPageContent: 'Provides a simple example of how FSH can be used to create an IG'
@@ -775,7 +775,7 @@ describe('ensureConfiguration', () => {
         'IG Home': 'index.html',
         'Table of Contents': 'toc.html',
         'Artifact Index': 'artifacts.html',
-        Support: { 'FHIR Spec': 'http://hl7.org/fhir/R4/index.html' }
+        Support: { 'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html' }
       },
       history: {
         current: 'http://build.fhir.org/ig/example/example-ig',

--- a/test/import/fixtures/example-config.yaml
+++ b/test/import/fixtures/example-config.yaml
@@ -164,6 +164,7 @@ menu:
     Value Sets: artifacts.html#4
   Downloads: downloads.html
   History: http://hl7.org/fhir/us/example/history.html
+  FHIR Spec: new-tab external http://hl7.org/fhir/R4/index.html
 
 # The parameters property represents IG.definition.parameter. Rather
 # than a list of code/value pairs (as in the ImplementationGuide

--- a/test/import/importConfiguration.test.ts
+++ b/test/import/importConfiguration.test.ts
@@ -138,7 +138,13 @@ describe('importConfiguration', () => {
           ]
         },
         { name: 'Downloads', url: 'downloads.html' },
-        { name: 'History', url: 'http://hl7.org/fhir/us/example/history.html' }
+        { name: 'History', url: 'http://hl7.org/fhir/us/example/history.html' },
+        {
+          name: 'FHIR Spec',
+          url: 'http://hl7.org/fhir/R4/index.html',
+          isExternal: true,
+          openInNewTab: true
+        }
       ],
       parameters: [
         { code: 'copyrightyear', value: '2019+' },
@@ -1792,7 +1798,8 @@ describe('importConfiguration', () => {
           'Value Sets': 'artifacts.html#4'
         },
         Downloads: 'downloads.html',
-        History: 'http://hl7.org/fhir/us/example/history.html'
+        History: 'http://hl7.org/fhir/us/example/history.html',
+        'FHIR Spec': 'new-tab external http://hl7.org/fhir/R4/index.html'
       };
       const config = importConfiguration(minYAML, 'test-config.yaml');
       expect(config.menu).toEqual([
@@ -1806,7 +1813,13 @@ describe('importConfiguration', () => {
           ]
         },
         { name: 'Downloads', url: 'downloads.html' },
-        { name: 'History', url: 'http://hl7.org/fhir/us/example/history.html' }
+        { name: 'History', url: 'http://hl7.org/fhir/us/example/history.html' },
+        {
+          name: 'FHIR Spec',
+          url: 'http://hl7.org/fhir/R4/index.html',
+          isExternal: true,
+          openInNewTab: true
+        }
       ]);
     });
   });


### PR DESCRIPTION
This PR fixes #440 and addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-393.

It adds support for two keywords in menu configuration. `new-tab` allows a user to configure that the menu item will open in a new tab (using `target="_blank"`) and `external` allows a user to add the external link icon in the menu item.

I also updated the default menu configuration that we add to include these two keywords on the FHIR Spec menu link to more closely reflect what the current `menu.xml` looks like. Any provided `menu.xml` that we try to translate into a configuration object will now look to use these keywords where applicable.