### PR TITLE
Bring back sparse differentials

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -1,6 +1,11 @@
 import upperFirst from 'lodash/upperFirst';
 import cloneDeep from 'lodash/cloneDeep';
-import { ElementDefinition, ElementDefinitionType, LooseElementDefJSON } from './ElementDefinition';
+import {
+  ElementDefinition,
+  ElementDefinitionType,
+  LooseElementDefJSON,
+  ElementDefinitionSlicing
+} from './ElementDefinition';
 import { Meta } from './specialTypes';
 import { Identifier, CodeableConcept, Coding, Narrative, Resource, Extension } from './dataTypes';
 import { ContactDetail, UsageContext } from './metaDataTypes';
@@ -337,59 +342,37 @@ export class StructureDefinition {
       j.snapshot = { element: this.elements.map(e => e.toJSON()) };
     }
 
-    // Create a cached hasDiff function since hasDiff can be expensive and may be called multiple times
-    // per element when generating the differential.
-    const hasDiffCache: Map<string, boolean> = new Map();
-    const cachedHasDiff = (element: ElementDefinition): boolean => {
-      if (!hasDiffCache.has(element.id)) {
-        hasDiffCache.set(element.id, element.hasDiff());
-      }
-      return hasDiffCache.get(element.id);
+    const differentialElements = this.elements
+      .filter(e => e.hasDiff())
+      .map(e => e.calculateDiff().toJSON());
+    const defaultDifferentialElements = [{ id: this.elements[0].id, path: this.elements[0].path }];
+
+    j.differential = {
+      element: differentialElements.length > 0 ? differentialElements : defaultDifferentialElements
     };
 
-    // Populate the differential (including intermediate elements to avoid a "sparse differential")
-    j.differential = { element: [] };
-    this.elements.forEach(e => {
-      if (cachedHasDiff(e)) {
-        const diff = e.calculateDiff().toJSON();
-        const isTypeSlicingChoiceDiff =
-          diff.id.endsWith('[x]') &&
-          Object.keys(diff).length === 3 &&
-          diff.id &&
-          diff.path &&
-          diff.slicing?.discriminator?.length === 1 &&
-          diff.slicing.discriminator[0].type === 'type' &&
-          diff.slicing.discriminator[0].path === '$this' &&
-          diff.slicing.rules === 'open' &&
-          (diff.slicing.ordered == null || diff.slicing.ordered === false);
-
-        // choice[x] elements that differ only by the standard type slicing definition don't need to go in the
-        // differential, as they are inferred. See: https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/
-        if (!isTypeSlicingChoiceDiff) {
-          j.differential.element.push(diff);
-        } else if (e.children().some(c => cachedHasDiff(c))) {
-          // Even for a type-slicing choice diff, we want at least a simple diff when it has children with a diff
-          j.differential.element.push({
-            id: e.id,
-            path: e.path
-          });
-        }
-      } else if (e.children().some(c => cachedHasDiff(c))) {
-        // Since it has children with a diff, at least add a simple diff element to avoid "sparse differentials"
-        j.differential.element.push({
-          id: e.id,
-          path: e.path
-        });
+    // Post-process the differential to remove any choice[x] elements if the only thing they do is establish the type
+    // slicing.  In this case, the type slicing can be inferred and does not need to be explicitly added.
+    // See: https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/
+    j.differential.element = j.differential.element.filter(
+      (e: { id: string; path: string; slicing: ElementDefinitionSlicing }) => {
+        return (
+          // not a choice, or
+          !e.id.endsWith('[x]') ||
+          // is a choice but not one whose only diff is the standard type slicing
+          !(
+            Object.keys(e).length === 3 &&
+            e.id &&
+            e.path &&
+            e.slicing?.discriminator?.length === 1 &&
+            e.slicing.discriminator[0].type === 'type' &&
+            e.slicing.discriminator[0].path === '$this' &&
+            e.slicing.rules === 'open' &&
+            (e.slicing.ordered == null || e.slicing.ordered === false)
+          )
+        );
       }
-    });
-
-    // Never have an empty differential. It makes the IG Publisher mad.
-    if (j.differential.element.length === 0) {
-      j.differential.element.push({
-        id: this.elements[0].id,
-        path: this.elements[0].path
-      });
-    }
+    );
 
     // If the StructureDefinition is in progress, we want to persist that in the JSON so that when
     // the Fisher retrieves it from a package and converts to JSON, the inProgress state will be

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -1,11 +1,6 @@
 import upperFirst from 'lodash/upperFirst';
 import cloneDeep from 'lodash/cloneDeep';
-import {
-  ElementDefinition,
-  ElementDefinitionType,
-  LooseElementDefJSON,
-  ElementDefinitionSlicing
-} from './ElementDefinition';
+import { ElementDefinition, ElementDefinitionType, LooseElementDefJSON } from './ElementDefinition';
 import { Meta } from './specialTypes';
 import { Identifier, CodeableConcept, Coding, Narrative, Resource, Extension } from './dataTypes';
 import { ContactDetail, UsageContext } from './metaDataTypes';
@@ -342,37 +337,37 @@ export class StructureDefinition {
       j.snapshot = { element: this.elements.map(e => e.toJSON()) };
     }
 
-    const differentialElements = this.elements
-      .filter(e => e.hasDiff())
-      .map(e => e.calculateDiff().toJSON());
-    const defaultDifferentialElements = [{ id: this.elements[0].id, path: this.elements[0].path }];
+    // Populate the differential
+    j.differential = { element: [] };
+    this.elements.forEach(e => {
+      if (e.hasDiff()) {
+        const diff = e.calculateDiff().toJSON();
+        const isTypeSlicingChoiceDiff =
+          diff.id.endsWith('[x]') &&
+          Object.keys(diff).length === 3 &&
+          diff.id &&
+          diff.path &&
+          diff.slicing?.discriminator?.length === 1 &&
+          diff.slicing.discriminator[0].type === 'type' &&
+          diff.slicing.discriminator[0].path === '$this' &&
+          diff.slicing.rules === 'open' &&
+          (diff.slicing.ordered == null || diff.slicing.ordered === false);
 
-    j.differential = {
-      element: differentialElements.length > 0 ? differentialElements : defaultDifferentialElements
-    };
-
-    // Post-process the differential to remove any choice[x] elements if the only thing they do is establish the type
-    // slicing.  In this case, the type slicing can be inferred and does not need to be explicitly added.
-    // See: https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/
-    j.differential.element = j.differential.element.filter(
-      (e: { id: string; path: string; slicing: ElementDefinitionSlicing }) => {
-        return (
-          // not a choice, or
-          !e.id.endsWith('[x]') ||
-          // is a choice but not one whose only diff is the standard type slicing
-          !(
-            Object.keys(e).length === 3 &&
-            e.id &&
-            e.path &&
-            e.slicing?.discriminator?.length === 1 &&
-            e.slicing.discriminator[0].type === 'type' &&
-            e.slicing.discriminator[0].path === '$this' &&
-            e.slicing.rules === 'open' &&
-            (e.slicing.ordered == null || e.slicing.ordered === false)
-          )
-        );
+        // choice[x] elements that differ only by the standard type slicing definition don't need to go in the
+        // differential, as they are inferred. See: https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/
+        if (!isTypeSlicingChoiceDiff) {
+          j.differential.element.push(diff);
+        }
       }
-    );
+    });
+
+    // Never have an empty differential. It makes the IG Publisher mad.
+    if (j.differential.element.length === 0) {
+      j.differential.element.push({
+        id: this.elements[0].id,
+        path: this.elements[0].path
+      });
+    }
 
     // If the StructureDefinition is in progress, we want to persist that in the JSON so that when
     // the Fisher retrieves it from a package and converts to JSON, the inProgress state will be

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -3691,9 +3691,8 @@ describe('StructureDefinitionExporter', () => {
     const sd = pkg.profiles[0];
     const json = sd.toJSON();
 
-    expect(json.differential.element).toHaveLength(2);
+    expect(json.differential.element).toHaveLength(1);
     expect(json.differential.element).toEqual([
-      { id: 'Observation', path: 'Observation' },
       { id: 'Observation.subject', path: 'Observation.subject', min: 1 }
     ]);
   });
@@ -3720,16 +3719,8 @@ describe('StructureDefinitionExporter', () => {
     const sd = pkg.profiles[0];
     const json = sd.toJSON();
 
-    expect(json.differential.element).toHaveLength(4);
+    expect(json.differential.element).toHaveLength(2);
     expect(json.differential.element).toEqual([
-      {
-        id: 'Observation',
-        path: 'Observation'
-      },
-      {
-        id: 'Observation.code',
-        path: 'Observation.code'
-      },
       {
         id: 'Observation.code.coding',
         path: 'Observation.code.coding',
@@ -3792,12 +3783,8 @@ describe('StructureDefinitionExporter', () => {
     const sd = pkg.profiles[0];
     const json = sd.toJSON();
 
-    expect(json.differential.element).toHaveLength(8);
+    expect(json.differential.element).toHaveLength(7);
     expect(json.differential.element).toEqual([
-      {
-        id: 'Observation',
-        path: 'Observation'
-      },
       {
         id: 'Observation.component',
         path: 'Observation.component',
@@ -3857,16 +3844,8 @@ describe('StructureDefinitionExporter', () => {
     exporter.exportStructDef(profile);
     const sd = pkg.profiles[0];
     const json = sd.toJSON();
-    expect(json.differential.element).toHaveLength(3);
+    expect(json.differential.element).toHaveLength(1);
     expect(json.differential.element).toEqual([
-      {
-        id: 'Observation',
-        path: 'Observation'
-      },
-      {
-        id: 'Observation.code',
-        path: 'Observation.code'
-      },
       {
         id: 'Observation.code.coding:RespRateCode',
         path: 'Observation.code.coding',

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -122,17 +122,13 @@ describe('StructureDefinition', () => {
       valueX.min = 1;
 
       const json = observation.toJSON();
-      expect(json.differential.element).toHaveLength(3);
+      expect(json.differential.element).toHaveLength(2);
       expect(json.differential.element[0]).toEqual({
-        id: 'Observation',
-        path: 'Observation'
-      });
-      expect(json.differential.element[1]).toEqual({
         id: 'Observation.code',
         path: 'Observation.code',
         short: 'Special observation code'
       });
-      expect(json.differential.element[2]).toEqual({
+      expect(json.differential.element[1]).toEqual({
         id: 'Observation.value[x]',
         path: 'Observation.value[x]',
         min: 1
@@ -146,17 +142,13 @@ describe('StructureDefinition', () => {
       valueX.min = 1;
 
       const json = observation.toJSON(false);
-      expect(json.differential.element).toHaveLength(3);
+      expect(json.differential.element).toHaveLength(2);
       expect(json.differential.element[0]).toEqual({
-        id: 'Observation',
-        path: 'Observation'
-      });
-      expect(json.differential.element[1]).toEqual({
         id: 'Observation.code',
         path: 'Observation.code',
         short: 'Special observation code'
       });
-      expect(json.differential.element[2]).toEqual({
+      expect(json.differential.element[1]).toEqual({
         id: 'Observation.value[x]',
         path: 'Observation.value[x]',
         min: 1
@@ -164,88 +156,16 @@ describe('StructureDefinition', () => {
       expect(json.snapshot).toBeUndefined();
     });
 
-    it('should contain intermediate elements in differential to avoid sparse differentials', () => {
+    it('should generate sparse differentials', () => {
       const componentCode = observation.elements.find(e => e.id === 'Observation.component.code');
       componentCode.short = 'Special component code';
 
       const json = observation.toJSON();
-      expect(json.differential.element).toHaveLength(3);
+      expect(json.differential.element).toHaveLength(1);
       expect(json.differential.element[0]).toEqual({
-        id: 'Observation',
-        path: 'Observation'
-      });
-      expect(json.differential.element[1]).toEqual({
-        id: 'Observation.component',
-        path: 'Observation.component'
-      });
-      expect(json.differential.element[2]).toEqual({
         id: 'Observation.component.code',
         path: 'Observation.component.code',
         short: 'Special component code'
-      });
-    });
-
-    it('should contain intermediate elements in differential to avoid sparse differentials without generating snapshot', () => {
-      const componentCode = observation.elements.find(e => e.id === 'Observation.component.code');
-      componentCode.short = 'Special component code';
-
-      const json = observation.toJSON(false);
-      expect(json.differential.element).toHaveLength(3);
-      expect(json.differential.element[0]).toEqual({
-        id: 'Observation',
-        path: 'Observation'
-      });
-      expect(json.differential.element[1]).toEqual({
-        id: 'Observation.component',
-        path: 'Observation.component'
-      });
-      expect(json.differential.element[2]).toEqual({
-        id: 'Observation.component.code',
-        path: 'Observation.component.code',
-        short: 'Special component code'
-      });
-    });
-
-    it('should contain intermediate elements in differential for children of choices', () => {
-      // If we have this:
-      //   * valueQuantity ^short = "value[x] Quantity choice"
-      // then value[x] should not appear because IG Publisher infers it.
-      // But if we have this:
-      //   * value[x].extension ^short = "Extension on value[x]"
-      //   * valueQuantity ^short = "the quantity choice"
-      // then it should appear since it has a direct child.
-      const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
-      valueX.sliceIt('type', '$this', false, 'open');
-      valueX.unfoldChoiceElementTypes(fisher);
-      const valueXExtension = observation.elements.find(
-        e => e.id === 'Observation.value[x].extension'
-      );
-      valueXExtension.short = 'Extension on value[x]';
-      const valueQuantity = valueX.addSlice('valueQuantity', new ElementDefinitionType('Quantity'));
-      valueQuantity.short = 'the quantity choice';
-
-      const json = observation.toJSON();
-      expect(json.differential.element).toHaveLength(4);
-      expect(json.differential.element[0]).toEqual({
-        id: 'Observation',
-        path: 'Observation'
-      });
-      expect(json.differential.element[1]).toEqual({
-        id: 'Observation.value[x]',
-        path: 'Observation.value[x]'
-      });
-      expect(json.differential.element[2]).toEqual({
-        id: 'Observation.value[x].extension',
-        path: 'Observation.value[x].extension',
-        short: 'Extension on value[x]'
-      });
-      expect(json.differential.element[3]).toEqual({
-        id: 'Observation.valueQuantity',
-        path: 'Observation.valueQuantity',
-        short: 'the quantity choice',
-        type: [{ code: 'Quantity' }],
-        min: 0,
-        max: '1'
       });
     });
 
@@ -296,13 +216,8 @@ describe('StructureDefinition', () => {
       expect(valueStringSnapshot.sliceName).toEqual('valueString');
       expect(valueStringSnapshot.short).toBe('the string choice');
       // then check that differential has value[x] and shortcut syntax valueQuantity and valueString
-      expect(json.differential.element).toHaveLength(4);
-      const rootDiff = json.differential.element[0];
-      expect(rootDiff).toEqual({
-        id: 'Observation',
-        path: 'Observation'
-      });
-      const valueXDiff = json.differential.element[1];
+      expect(json.differential.element).toHaveLength(3);
+      const valueXDiff = json.differential.element[0];
       expect(valueXDiff).toEqual({
         id: 'Observation.value[x]',
         path: 'Observation.value[x]',
@@ -313,13 +228,13 @@ describe('StructureDefinition', () => {
           rules: 'open'
         }
       });
-      const valueQuantityDiff = json.differential.element[2];
+      const valueQuantityDiff = json.differential.element[1];
       expect(valueQuantityDiff.id).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.path).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.type).toEqual([{ code: 'Quantity' }]);
       expect(valueQuantityDiff.sliceName).toBeUndefined();
       expect(valueQuantitySnapshot.short).toBe('the quantity choice');
-      const valueStringDiff = json.differential.element[3];
+      const valueStringDiff = json.differential.element[2];
       expect(valueStringDiff.id).toBe('Observation.valueString');
       expect(valueStringDiff.path).toBe('Observation.valueString');
       expect(valueStringDiff.type).toEqual([{ code: 'string' }]);
@@ -360,19 +275,14 @@ describe('StructureDefinition', () => {
       expect(valueStringSnapshot.sliceName).toEqual('valueString');
       expect(valueStringSnapshot.short).toBe('the string choice');
       // then check that differential does NOT have value[x] but has shortcut syntax for valueQuantity and valueString
-      expect(json.differential.element).toHaveLength(3);
-      const rootDiff = json.differential.element[0];
-      expect(rootDiff).toEqual({
-        id: 'Observation',
-        path: 'Observation'
-      });
-      const valueQuantityDiff = json.differential.element[1];
+      expect(json.differential.element).toHaveLength(2);
+      const valueQuantityDiff = json.differential.element[0];
       expect(valueQuantityDiff.id).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.path).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.type).toEqual([{ code: 'Quantity' }]);
       expect(valueQuantityDiff.sliceName).toBeUndefined();
       expect(valueQuantitySnapshot.short).toBe('the quantity choice');
-      const valueStringDiff = json.differential.element[2];
+      const valueStringDiff = json.differential.element[1];
       expect(valueStringDiff.id).toBe('Observation.valueString');
       expect(valueStringDiff.path).toBe('Observation.valueString');
       expect(valueStringDiff.type).toEqual([{ code: 'string' }]);
@@ -417,13 +327,8 @@ describe('StructureDefinition', () => {
       expect(valueStringSnapshot.sliceName).toEqual('valueString');
       expect(valueStringSnapshot.short).toBe('the string choice');
       // then check that differential does NOT have value[x] but has shortcut syntax for valueQuantity and valueString
-      expect(json.differential.element).toHaveLength(4);
-      const rootDiff = json.differential.element[0];
-      expect(rootDiff).toEqual({
-        id: 'Observation',
-        path: 'Observation'
-      });
-      const valueXDiff = json.differential.element[1];
+      expect(json.differential.element).toHaveLength(3);
+      const valueXDiff = json.differential.element[0];
       expect(valueXDiff).toEqual({
         id: 'Observation.value[x]',
         path: 'Observation.value[x]',
@@ -434,13 +339,13 @@ describe('StructureDefinition', () => {
         },
         short: 'a choice of many things'
       });
-      const valueQuantityDiff = json.differential.element[2];
+      const valueQuantityDiff = json.differential.element[1];
       expect(valueQuantityDiff.id).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.path).toBe('Observation.valueQuantity');
       expect(valueQuantityDiff.type).toEqual([{ code: 'Quantity' }]);
       expect(valueQuantityDiff.sliceName).toBeUndefined();
       expect(valueQuantitySnapshot.short).toBe('the quantity choice');
-      const valueStringDiff = json.differential.element[3];
+      const valueStringDiff = json.differential.element[2];
       expect(valueStringDiff.id).toBe('Observation.valueString');
       expect(valueStringDiff.path).toBe('Observation.valueString');
       expect(valueStringDiff.type).toEqual([{ code: 'string' }]);
@@ -483,8 +388,8 @@ describe('StructureDefinition', () => {
       expect(catCoding).toEqual(catCodingOriginal);
       expect(cat).toEqual(catOriginal);
 
-      const vsCatCodingDiff = json.differential.element[4];
-      const vsCatDiff = json.differential.element[3];
+      const vsCatCodingDiff = json.differential.element[3];
+      const vsCatDiff = json.differential.element[2];
       expect(vsCatCodingDiff).toEqual({
         id: 'Observation.category:VSCat.coding',
         path: 'Observation.category.coding',
@@ -496,8 +401,8 @@ describe('StructureDefinition', () => {
         sliceName: 'VSCat'
       });
 
-      const catCodingDiff = json.differential.element[2];
-      const catDiff = json.differential.element[1];
+      const catCodingDiff = json.differential.element[1];
+      const catDiff = json.differential.element[0];
       expect(catCodingDiff).toEqual({
         id: 'Observation.category.coding',
         path: 'Observation.category.coding',
@@ -506,12 +411,6 @@ describe('StructureDefinition', () => {
       expect(catDiff).toEqual({
         id: 'Observation.category',
         path: 'Observation.category'
-      });
-
-      const rootDiff = json.differential.element[0];
-      expect(rootDiff).toEqual({
-        id: 'Observation',
-        path: 'Observation'
       });
     });
   });


### PR DESCRIPTION
Fixes https://github.com/FHIR/sushi/issues/463.

In https://github.com/FHIR/sushi/pull/453 we got rid of sparse differentials. Now sparse differentials are back! I mostly just removed the code and tests that were added in #453. So if you compare the contents of StructureDefinition.ts on this branch to the contents on the commit before #453 (https://github.com/FHIR/sushi/commit/b9bd6c78f377a83ff69833ed334b95022ea3e589), things should look very similar.