### PR TITLE
Restructure invalid packages to have correct format

### DIFF
--- a/test/fhirdefs/fixtures/sushi-test-no-package#current/StructureDefinition-MyPatient.json
+++ b/test/fhirdefs/fixtures/sushi-test-no-package#current/StructureDefinition-MyPatient.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "MyPatient",
+  "url": "http://hl7.org/fhir/sushi-test/StructureDefinition/MyPatient",
+  "name": "MyPatient",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient.deceased[x]",
+        "path": "Patient.deceased[x]",
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fhirdefs/fixtures/sushi-test-no-package#current/other/filler.txt
+++ b/test/fhirdefs/fixtures/sushi-test-no-package#current/other/filler.txt
@@ -1,0 +1,1 @@
+Hello I'm filler

--- a/test/fhirdefs/fixtures/sushi-test-wrong-format#current/StructureDefinition-MyPatient.json
+++ b/test/fhirdefs/fixtures/sushi-test-wrong-format#current/StructureDefinition-MyPatient.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "MyPatient",
+  "url": "http://hl7.org/fhir/sushi-test/StructureDefinition/MyPatient",
+  "name": "MyPatient",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient.deceased[x]",
+        "path": "Patient.deceased[x]",
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fhirdefs/fixtures/sushi-test-wrong-format#current/other/filler.txt
+++ b/test/fhirdefs/fixtures/sushi-test-wrong-format#current/other/filler.txt
@@ -1,0 +1,1 @@
+Hi I'm filler

--- a/test/fhirdefs/fixtures/sushi-test-wrong-format#current/package/package.json
+++ b/test/fhirdefs/fixtures/sushi-test-wrong-format#current/package/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "sushi-test",
+  "version" : "0.1.0",
+  "canonical" : "http://hl7.org/fhir/sushi-test",
+  "url" : "http://hl7.org/fhir/sushi-test",
+  "title" : "FSH Test IG",
+  "description": "Provides a simple example of how FSH can be used to create an IG",
+  "dependencies": {
+     "hl7.fhir.r4.core": "4.0.1",
+     "hl7.fhir.us.core": "3.1.0",
+     "hl7.fhir.uv.vhdir":"current"
+  },
+  "date": "20200413230227",
+  "language": "en",
+  "author": "James Tuna",
+  "maintainers": [
+    {
+      "name": "Bill Cod",
+      "email": "cod@reef.gov",
+      "url": "https://capecodfishermen.org/"
+    }
+  ],
+  "license": "CC0-1.0"
+ }


### PR DESCRIPTION
This addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-402. 

When reviewing #470, @cmoesel noticed a weird discrepancy between loading US Core 3.1.0 and loading the current version of US Core. The details on that are here https://github.com/FHIR/sushi/pull/470#pullrequestreview-422137685.

A package is supposed to have a certain format in which all of contents are nested within a `package` subfolder, according to https://chat.fhir.org/#narrow/stream/215610-shorthand/topic/dev.20dependencies. However, many older packages did not actually follow this rule, so a package like US Core 3.1.0 may have folders as peers of `package` which should actually be subfolders of package. This PR adds a function to nest all peers that are not within the `package` folder into the `package` folder when downloading a package, so that these incorrectly formatted packages will be fixed by SUSHI to have the correct format.

The FSH implementation of mCODE depends on FHIR Core 4.0.1 and US Core 3.1.0, both of which use the old incorrect format. If you clear your cache, and then run SUSHI on fsh-mcode on master, you will see that those packages are downloaded and saved with certain folders as peers of `package`. If you then clear the cache and run SUSHI on fsh-mcode on this branch, those folders will be nested within `package`, but the output of mCODE will be the same.