### PR TITLE
Fix type overwrite error

### DIFF
--- a/src/errors/InvalidAccessError.ts
+++ b/src/errors/InvalidAccessError.ts
@@ -1,0 +1,5 @@
+export class InvalidAccessError extends Error {
+  constructor() {
+    super('Cannot directly change type. Elements will naturally inherit their Parent type.');
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -42,3 +42,4 @@ export * from './ParentDeclaredAsProfileNameError';
 export * from './ParentDeclaredAsProfileIdError';
 export * from './InvalidResourceTypeError';
 export * from './InvalidExtensionParentError';
+export * from './InvalidAccessError';

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -8,7 +8,8 @@ import {
   CannotResolvePathError,
   InvalidElementAccessError,
   MissingSnapshotError,
-  InvalidResourceTypeError
+  InvalidResourceTypeError,
+  InvalidAccessError
 } from '../errors';
 import {
   getArrayIndex,
@@ -285,6 +286,10 @@ export class StructureDefinition {
   setInstancePropertyByPath(path: string, value: any, fisher: Fishable): void {
     if (path.startsWith('snapshot') || path.startsWith('differential')) {
       throw new InvalidElementAccessError(path);
+    }
+    const parentName = this.type || 'Resource';
+    if (path == 'type' && value != parentName) {
+      throw new InvalidAccessError();
     }
     setPropertyOnDefinitionInstance(this, path, value, fisher);
   }

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -925,6 +925,12 @@ describe('StructureDefinition', () => {
         'Cannot directly access differential or snapshot with path: differential.element[0]'
       );
     });
+
+    it('should throw an InvalidAccessError when trying to override the Parent type with a caret value', () => {
+      expect(() => {
+        observation.setInstancePropertyByPath('type', 'foo', fisher);
+      }).toThrow('Cannot directly change type. Elements will naturally inherit their Parent type.');
+    });
   });
 
   describe('#validateValueAtPath', () => {


### PR DESCRIPTION
Fixed bug where user is able to overwrite Parent's type with caret syntax. This fixes #462 an example for testing could be found in that issue. 