### PR TITLE
No duplicate filenames

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -493,6 +493,20 @@ export class IGExporter {
    * @returns {PageMetadata []} - sorted list of file information objects
    */
   private organizePageContent(pages: string[]): PageMetadata[] {
+    // Remove any preexisting duplicate file names, and log an error
+    pages = pages.filter(page => {
+      if (
+        pages.find(p => p.slice(0, p.lastIndexOf('.')) === page.slice(0, page.lastIndexOf('.'))) !==
+        page
+      ) {
+        logger.error(`Duplicate file ${page} will be ignored. Please rename to avoid collisions.`, {
+          file: page
+        });
+        return false;
+      }
+      return true;
+    });
+
     const pageData = pages.map(page => {
       const nameParts = page.match(/^(\d+)_(.*)/);
       let prefix: number = null;

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -1234,7 +1234,7 @@ describe('IGExporter', () => {
         {
           nameUrl: 'index.html',
           title: 'Home',
-          generation: 'html'
+          generation: 'markdown'
         },
         {
           nameUrl: '1_rocks.html',
@@ -1257,6 +1257,9 @@ describe('IGExporter', () => {
           generation: 'markdown'
         }
       ]);
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Duplicate file index.xml will be ignored. Please rename to avoid collisions/
+      );
     });
 
     it('should not remove numeric prefixes from files when doing so would cause name collisions', () => {
@@ -1264,7 +1267,7 @@ describe('IGExporter', () => {
       expect(fs.existsSync(pageContentPath)).toBeTruthy();
       const pageContentFiles = fs.readdirSync(pageContentPath);
       expect(pageContentFiles).toHaveLength(5);
-      expect(pageContentFiles).toContain('index.xml');
+      expect(pageContentFiles).toContain('index.md');
       expect(pageContentFiles).toContain('1_rocks.md');
       expect(pageContentFiles).toContain('2_rocks.md');
       expect(pageContentFiles).toContain('3_index.md');

--- a/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/index.md
+++ b/test/ig/fixtures/name-collision-ig/ig-data/input/pagecontent/index.md
@@ -1,0 +1,1 @@
+This is yet another index file, which is definitely a bad idea.


### PR DESCRIPTION
Fixes #477 by adding a check for duplicate file names. SUSHI used to hang when duplicate file names were encountered, now an error is logged and the second file name is ignored.