### PR TITLE
Use expected ig-data path even when it doesn't exist on the filesystem

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,8 +19,7 @@ import {
   loadExternalDependencies,
   fillTank,
   writeFHIRResources,
-  getRawFSHes,
-  getIgDataPath
+  getRawFSHes
 } from './utils/Processing';
 
 app().catch(e => {
@@ -107,7 +106,7 @@ async function app() {
   if (config.FSHOnly) {
     logger.info('Exporting FSH definitions only. No IG related content will be exported.');
   } else {
-    const igDataPath = getIgDataPath(input);
+    const igDataPath = path.resolve(input, 'ig-data');
     logger.info('Assembling Implementation Guide sources...');
     const igExporter = new IGExporter(outPackage, defs, igDataPath, isIgPubContext);
     igExporter.export(outDir);

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -154,15 +154,6 @@ export function writeFHIRResources(outDir: string, outPackage: Package, snapshot
   logger.info(`Exported ${count} FHIR resources as JSON.`);
 }
 
-export function getIgDataPath(input: string): string {
-  const igDataPath = path.resolve(input, 'ig-data');
-  if (fs.existsSync(igDataPath)) {
-    return igDataPath;
-  } else {
-    return null;
-  }
-}
-
 function getFilesRecursive(dir: string): string[] {
   if (fs.statSync(dir).isDirectory()) {
     const ancestors = fs.readdirSync(dir, 'utf8').map(f => getFilesRecursive(path.join(dir, f)));

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -9,8 +9,7 @@ import {
   readConfig,
   loadExternalDependencies,
   getRawFSHes,
-  writeFHIRResources,
-  getIgDataPath
+  writeFHIRResources
 } from '../../src/utils/Processing';
 import * as loadModule from '../../src/fhirdefs/load';
 import { FHIRDefinitions } from '../../src/fhirdefs';
@@ -369,33 +368,6 @@ describe('Processing', () => {
 
     it('should write an info message with the number of instances exported', () => {
       expect(loggerSpy.getLastMessage('info')).toMatch(/Exported 12 FHIR resources/s);
-    });
-  });
-
-  describe('#getIgDataPath()', () => {
-    let tempRoot: string;
-
-    beforeAll(() => {
-      tempRoot = temp.mkdirSync('sushi-test');
-      fs.mkdirSync(path.join(tempRoot, 'yes-please'));
-      fs.mkdirSync(path.join(tempRoot, 'yes-please', 'ig-data'));
-      fs.mkdirSync(path.join(tempRoot, 'not-this-time'));
-    });
-
-    afterAll(() => {
-      temp.cleanupSync();
-    });
-
-    it('should return the path to the ig-data directory when it exists', () => {
-      const input = path.join(tempRoot, 'yes-please');
-      const igDataPath = getIgDataPath(input);
-      expect(igDataPath).toBe(path.join(input, 'ig-data'));
-    });
-
-    it('should return null when the path to the ig-data directory does not exist', () => {
-      const input = path.join(tempRoot, 'not-this-time');
-      const igDataPath = getIgDataPath(input);
-      expect(igDataPath).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Fixes #488 

The IGExporter expects a path to be passed in, even if the path does not exist on the file system. If it receives null, it throws.  Fix app.ts to never pass in a null path to the IGExporter.

Since we only get the path in one place, and since it is now a single line of code, we no longer have need for a separate getIgDataPath function.