### PR TITLE
0.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Sushi Unshortens Short Hand Inputs (FSH Compiler)",
   "scripts": {
     "build": "rm -rf dist && tsc && cp -r src/ig/files dist/ig/files",


### PR DESCRIPTION
Bump to 0.13.1, needed to include #489 which fixes a bug that would cause SUSHI to have an unexpected error when the user did not have an `ig-data` folder.