### PR TITLE
Contained resources in StructureDefinitions, export primitives with children

### DIFF
--- a/src/export/FHIRExporter.ts
+++ b/src/export/FHIRExporter.ts
@@ -40,6 +40,7 @@ export class FHIRExporter {
     this.valueSetExporter.export();
     this.codeSystemExporter.export();
     this.instanceExporter.export();
+    this.structureDefinitionExporter.applyDeferredRules();
     this.mappingExporter.export();
 
     return this.pkg;

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -335,6 +335,12 @@ export class StructureDefinition {
         // @ts-ignore
         j[prop] = cloneDeep(this[prop]);
       }
+      // children of primitive properties are located by an underscore-prefixed property name
+      // @ts-ignore
+      if (this[`_${prop}`] !== undefined) {
+        // @ts-ignore
+        j[`_${prop}`] = cloneDeep(this[`_${prop}`]);
+      }
     }
 
     // Now handle snapshot and differential

--- a/src/fshtypes/rules/CaretValueRule.ts
+++ b/src/fshtypes/rules/CaretValueRule.ts
@@ -4,6 +4,7 @@ import { FixedValueType } from './FixedValueRule';
 export class CaretValueRule extends Rule {
   caretPath: string;
   value: FixedValueType;
+  isInstance: boolean;
 
   constructor(path: string) {
     super(path);

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1232,6 +1232,8 @@ export class FSHImporter extends FSHVisitor {
     // Get the caret path, but slice off the starting ^
     caretValueRule.caretPath = this.visitCaretPath(ctx.caretPath()).slice(1);
     caretValueRule.value = this.visitValue(ctx.value());
+    caretValueRule.isInstance =
+      ctx.value().SEQUENCE() != null && !this.allAliases.has(ctx.value().SEQUENCE().getText());
     return caretValueRule;
   }
 

--- a/test/export/FHIRExporter.test.ts
+++ b/test/export/FHIRExporter.test.ts
@@ -1,7 +1,11 @@
-import { exportFHIR, Package } from '../../src/export';
-import { FSHTank } from '../../src/import';
-import { FHIRDefinitions } from '../../src/fhirdefs';
+import path from 'path';
+import { exportFHIR, Package, FHIRExporter } from '../../src/export';
+import { FSHTank, FSHDocument } from '../../src/import';
+import { FHIRDefinitions, loadFromPath } from '../../src/fhirdefs';
 import { minimalConfig } from '../utils/minimalConfig';
+import { Instance, Profile } from '../../src/fshtypes';
+import { CaretValueRule } from '../../src/fshtypes/rules';
+import { TestFisher } from '../testhelpers';
 
 describe('FHIRExporter', () => {
   it('should output empty results with empty input', () => {
@@ -19,5 +23,40 @@ describe('FHIRExporter', () => {
         template: 'hl7.fhir.template#0.0.5'
       })
     );
+  });
+
+  it('should allow a profile to contain an inline resource', () => {
+    const defs = new FHIRDefinitions();
+    loadFromPath(
+      path.join(__dirname, '..', 'testhelpers', 'testdefs', 'package'),
+      'testPackage',
+      defs
+    );
+
+    const doc = new FSHDocument('fileName');
+    const input = new FSHTank([doc], minimalConfig);
+    const pkg = new Package(input.config);
+    const fisher = new TestFisher(input, defs, pkg);
+    const exporter = new FHIRExporter(input, pkg, fisher);
+
+    const instance = new Instance('myResource');
+    instance.instanceOf = 'Observation';
+    doc.instances.set(instance.name, instance);
+
+    const profile = new Profile('ContainingProfile');
+    const caretValueRule = new CaretValueRule('');
+    caretValueRule.caretPath = 'contained';
+    caretValueRule.value = 'myResource';
+    profile.rules.push(caretValueRule);
+    doc.profiles.set(profile.name, profile);
+
+    const result = exporter.export();
+
+    expect(result.profiles.length).toBe(1);
+    expect(result.profiles[0].contained.length).toBe(1);
+    expect(result.profiles[0].contained[0]).toEqual({
+      resourceType: 'Observation',
+      id: 'myResource'
+    });
   });
 });

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -1793,8 +1793,8 @@ describe('InstanceExporter', () => {
         // * entry ^slicing.discriminator.type = #value
         // * entry contains Patient 0..1
         // * entry[PatientsOnly].resource only Patient
-        // * contained contains PatientOrOrganization 0..1
-        // * contained[PatientOrOrganization] only Patient or Organization
+        // * entry contains PatientOrOrganization 0..1
+        // * entry[PatientOrOrganization] only Patient or Organization
         bundle.rules.push(
           caretRule,
           containsRule,

--- a/test/export/StructureDefinition.ProfileExporter.test.ts
+++ b/test/export/StructureDefinition.ProfileExporter.test.ts
@@ -146,6 +146,7 @@ describe('ProfileExporter', () => {
     const caretValueRule = new CaretValueRule('');
     caretValueRule.caretPath = 'contained';
     caretValueRule.value = 'myResource';
+    caretValueRule.isInstance = true;
     profile.rules.push(caretValueRule);
     doc.profiles.set(profile.name, profile);
 

--- a/test/export/StructureDefinition.ProfileExporter.test.ts
+++ b/test/export/StructureDefinition.ProfileExporter.test.ts
@@ -1,11 +1,12 @@
+import path from 'path';
 import { StructureDefinitionExporter, Package } from '../../src/export';
 import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, loadFromPath } from '../../src/fhirdefs';
-import { Profile } from '../../src/fshtypes';
+import { Profile, Instance } from '../../src/fshtypes';
 import { loggerSpy } from '../testhelpers/loggerSpy';
 import { TestFisher } from '../testhelpers';
-import path from 'path';
 import { minimalConfig } from '../utils/minimalConfig';
+import { CaretValueRule } from '../../src/fshtypes/rules';
 
 describe('ProfileExporter', () => {
   let defs: FHIRDefinitions;
@@ -134,5 +135,25 @@ describe('ProfileExporter', () => {
     expect(exported[2].name).toBe('Foo');
     expect(exported[1].baseDefinition === exported[0].url);
     expect(exported[2].baseDefinition === exported[1].url);
+  });
+
+  it('should defer adding an instance to a profile as a contained resource', () => {
+    const instance = new Instance('myResource');
+    instance.instanceOf = 'Observation';
+    doc.instances.set(instance.name, instance);
+
+    const profile = new Profile('ContainingProfile');
+    const caretValueRule = new CaretValueRule('');
+    caretValueRule.caretPath = 'contained';
+    caretValueRule.value = 'myResource';
+    profile.rules.push(caretValueRule);
+    doc.profiles.set(profile.name, profile);
+
+    const exported = exporter.export().profiles;
+    expect(exported.length).toBe(1);
+    expect(exported[0].contained).toBeUndefined();
+    expect(exporter.deferredRules.size).toBe(1);
+    expect(exporter.deferredRules.get(exported[0]).length).toBe(1);
+    expect(exporter.deferredRules.get(exported[0])).toContain(caretValueRule);
   });
 });

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -3854,6 +3854,21 @@ describe('StructureDefinitionExporter', () => {
     ]);
   });
 
+  it('should include the children of primitive elements when serializing to JSON', () => {
+    const profile = new Profile('SpecialUrlId');
+    profile.parent = 'Observation';
+
+    const rule = new CaretValueRule('');
+    rule.caretPath = 'url.id';
+    rule.value = 'my-id';
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+    const json = sd.toJSON();
+    expect(json).toHaveProperty('_url', { id: 'my-id' });
+  });
+
   it.skip('should not change sliceName based on a CaretValueRule', () => {
     const profile = new Profile('NameChange');
     profile.parent = 'resprate';

--- a/test/import/FSHImporter.CodeSystem.test.ts
+++ b/test/import/FSHImporter.CodeSystem.test.ts
@@ -328,7 +328,7 @@ describe('FSHImporter', () => {
           `;
         const result = importSingleText(input);
         const codeSystem = result.codeSystems.get('ZOO');
-        assertCaretValueRule(codeSystem.rules[0], '', 'publisher', 'Matt');
+        assertCaretValueRule(codeSystem.rules[0], '', 'publisher', 'Matt', false);
       });
 
       it('should parse a code system that uses CaretValueRules alongside concepts', () => {
@@ -341,7 +341,7 @@ describe('FSHImporter', () => {
         const codeSystem = result.codeSystems.get('ZOO');
         expect(codeSystem.concepts[0].code).toBe('lion');
         expect(codeSystem.concepts[0].sourceInfo.file).toBe('Zoo.fsh');
-        assertCaretValueRule(codeSystem.rules[0], '', 'publisher', 'Damon');
+        assertCaretValueRule(codeSystem.rules[0], '', 'publisher', 'Damon', false);
       });
 
       it('should log an error when a CaretValueRule contains a path before ^', () => {

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -318,7 +318,7 @@ describe('FSHImporter', () => {
         const result = importSingleText(input);
         const extension = result.extensions.get('SomeExtension');
         expect(extension.rules).toHaveLength(1);
-        assertCaretValueRule(extension.rules[0], 'id', 'short', 'foo');
+        assertCaretValueRule(extension.rules[0], 'id', 'short', 'foo', false);
       });
     });
 

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -1443,13 +1443,14 @@ describe('FSHImporter', () => {
         `;
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
-        assertCaretValueRule(profile.rules[0], '', 'description', 'foo');
-        assertCaretValueRule(profile.rules[1], '', 'experimental', false);
+        assertCaretValueRule(profile.rules[0], '', 'description', 'foo', false);
+        assertCaretValueRule(profile.rules[1], '', 'experimental', false, false);
         assertCaretValueRule(
           profile.rules[2],
           '',
           'keyword[0]',
-          new FshCode('bar', 'foo', 'baz').withLocation([6, 25, 6, 37]).withFile('')
+          new FshCode('bar', 'foo', 'baz').withLocation([6, 25, 6, 37]).withFile(''),
+          false
         );
       });
 
@@ -1463,13 +1464,14 @@ describe('FSHImporter', () => {
         `;
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
-        assertCaretValueRule(profile.rules[0], 'status', 'short', 'foo');
-        assertCaretValueRule(profile.rules[1], 'status', 'sliceIsConstraining', false);
+        assertCaretValueRule(profile.rules[0], 'status', 'short', 'foo', false);
+        assertCaretValueRule(profile.rules[1], 'status', 'sliceIsConstraining', false, false);
         assertCaretValueRule(
           profile.rules[2],
           'status',
           'code[0]',
-          new FshCode('bar', 'foo', 'baz').withLocation([6, 29, 6, 41]).withFile('')
+          new FshCode('bar', 'foo', 'baz').withLocation([6, 29, 6, 41]).withFile(''),
+          false
         );
       });
 
@@ -1481,7 +1483,7 @@ describe('FSHImporter', () => {
         `;
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
-        assertCaretValueRule(profile.rules[0], 'status', 'short', 'Non-breaking');
+        assertCaretValueRule(profile.rules[0], 'status', 'short', 'Non-breaking', false);
       });
 
       it('should add resources to the contained array using a CaretValueRule', () => {
@@ -1492,7 +1494,7 @@ describe('FSHImporter', () => {
         `;
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
-        assertCaretValueRule(profile.rules[0], '', 'contained', 'myResource');
+        assertCaretValueRule(profile.rules[0], '', 'contained', 'myResource', true);
       });
     });
 

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -1483,6 +1483,17 @@ describe('FSHImporter', () => {
         const profile = result.profiles.get('ObservationProfile');
         assertCaretValueRule(profile.rules[0], 'status', 'short', 'Non-breaking');
       });
+
+      it('should add resources to the contained array using a CaretValueRule', () => {
+        const input = `
+        Profile: ObservationProfile
+        Parent: Observation
+        * ^contained = myResource
+        `;
+        const result = importSingleText(input);
+        const profile = result.profiles.get('ObservationProfile');
+        assertCaretValueRule(profile.rules[0], '', 'contained', 'myResource');
+      });
     });
 
     describe('#obeysRule', () => {

--- a/test/import/FSHImporter.ValueSet.test.ts
+++ b/test/import/FSHImporter.ValueSet.test.ts
@@ -805,7 +805,7 @@ describe('FSHImporter', () => {
           `;
         const result = importSingleText(input);
         const valueSet = result.valueSets.get('ZooVS');
-        assertCaretValueRule(valueSet.rules[0], '', 'publisher', 'foo');
+        assertCaretValueRule(valueSet.rules[0], '', 'publisher', 'foo', false);
       });
 
       it('should parse a value set that uses CaretValueRules alongside components', () => {
@@ -819,7 +819,7 @@ describe('FSHImporter', () => {
         assertValueSetConceptComponent(valueSet.components[0], 'ZOO', undefined, [
           new FshCode('bear', 'ZOO').withLocation([3, 11, 3, 18]).withFile('Simple.fsh')
         ]);
-        assertCaretValueRule(valueSet.rules[0], '', 'publisher', 'foo');
+        assertCaretValueRule(valueSet.rules[0], '', 'publisher', 'foo', false);
       });
 
       it('should log an error when a CaretValueRule contains a path before ^', () => {

--- a/test/testhelpers/asserts.ts
+++ b/test/testhelpers/asserts.ts
@@ -106,13 +106,15 @@ export function assertCaretValueRule(
   rule: Rule,
   path: string,
   caretPath: string,
-  value: FixedValueType
+  value: FixedValueType,
+  isInstance: boolean
 ): void {
   expect(rule).toBeInstanceOf(CaretValueRule);
   const caretValueRule = rule as CaretValueRule;
   expect(caretValueRule.path).toBe(path);
   expect(caretValueRule.caretPath).toBe(caretPath);
   expect(caretValueRule.value).toEqual(value);
+  expect(caretValueRule.isInstance).toBe(isInstance);
 }
 
 export function assertObeysRule(rule: Rule, path: string, invariant: string) {


### PR DESCRIPTION
Completes task [CIMPL-397](https://standardhealthrecord.atlassian.net/browse/CIMPL-397). See also #457 

Primitive elements can have child elements. They were already being added during import, but were getting lost during export in the `toJSON` method.

StructureDefinitions can contain resources on their `contained` element. This element can be accessed using a CaretValueRule. The current implementation checks to see if the element's type is `Resource`, but this may be too restrictive in cases that I haven't thought of yet. Because the resource to add may be an inline Instance, these rules are deferred until after the InstanceExporter finishes.