### PR TITLE
Allow profiles/extensions to inherit *some* extensions

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -34,6 +34,14 @@ import {
 } from '../fhirtypes/common';
 import { Package } from './Package';
 
+// Extensions that should not be inherited by derived profiles
+// See: https://jira.hl7.org/browse/FHIR-27535
+const DISINHERITED_EXTENSIONS = [
+  'http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status',
+  'http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version',
+  'http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name'
+];
+
 /**
  * The StructureDefinitionExporter is the class for exporting Profiles and Extensions.
  * The operations and structure of both exporters are very similar, so they currently share an exporter.
@@ -67,8 +75,12 @@ export class StructureDefinitionExporter implements Fishable {
     delete structDef.language;
     delete structDef.text;
     delete structDef.contained;
-    delete structDef.extension; // see https://github.com/FHIR/sushi/issues/116
-    delete structDef.modifierExtension;
+    structDef.extension = structDef.extension?.filter(
+      e => !DISINHERITED_EXTENSIONS.includes(e.url)
+    );
+    structDef.modifierExtension = structDef.modifierExtension?.filter(
+      e => !DISINHERITED_EXTENSIONS.includes(e.url)
+    );
     structDef.url = `${this.tank.config.canonical}/StructureDefinition/${structDef.id}`;
     delete structDef.identifier;
     structDef.version = this.tank.config.version; // can be overridden using a rule

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -88,7 +88,27 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.language).toBeUndefined();
     expect(exported.text).toBeUndefined();
     expect(exported.contained).toBeUndefined(); // inherited from Observation
-    expect(exported.extension).toBeUndefined();
+    // NOTE: The following extensions are stripped out as disinherited extensions:
+    // {
+    //   url: "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+    //   valueCode: "normative"
+    // },
+    // {
+    //   url: "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
+    //   valueCode: "4.0.0"
+    // }
+    expect(exported.extension).toEqual([
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-category',
+        valueString: 'Clinical.Diagnostics'
+      },
+      { url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm', valueInteger: 5 },
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-security-category',
+        valueCode: 'patient'
+      },
+      { url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-wg', valueCode: 'oo' }
+    ]);
     expect(exported.modifierExtension).toBeUndefined();
     expect(exported.url).toBe('http://hl7.org/fhir/us/minimal/StructureDefinition/Foo'); // constructed from canonical and id
     expect(exported.identifier).toBeUndefined();
@@ -257,7 +277,10 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.language).toBeUndefined();
     expect(exported.text).toBeUndefined();
     expect(exported.contained).toBeUndefined(); // inherited from patient-mothersMaidenName
-    expect(exported.extension).toBeUndefined();
+    expect(exported.extension).toEqual([
+      { url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-wg', valueCode: 'pa' },
+      { url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm', valueInteger: 1 }
+    ]);
     expect(exported.modifierExtension).toBeUndefined();
     expect(exported.url).toBe('http://hl7.org/fhir/us/minimal/StructureDefinition/Foo'); // constructed from canonical and id
     expect(exported.identifier).toBeUndefined();
@@ -2338,7 +2361,9 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = pkg.profiles[0];
-    const extensionElement = sd.extension[0];
+    const extensionElement = sd.extension.find(
+      e => e.url === 'http://hl7.org/fhir/us/minimal/StructureDefinition/SpecialExtension'
+    );
     expect(extensionElement).toBeDefined();
     expect(extensionElement).toEqual({
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/SpecialExtension',


### PR DESCRIPTION
Instead of removing ALL extensions from the parent SD, allow some to be inherited.  This is implemented by keeping track of extensions NOT to inherit.
See: https://jira.hl7.org/browse/FHIR-27535

This is submitted as a DRAFT PR until I get confirmation if the [list of uninheritable extensions](https://jira.hl7.org/browse/FHIR-27535) is complete as-is or if others (like fmm and wg) should also be disallowed.