### PR TITLE
Local CodeSystem in CaretRules

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -35,7 +35,7 @@ export class InstanceExporter implements Fishable {
     rules.forEach(r => {
       r.path = r.path.replace(/\[0+\]/g, '');
     });
-    rules = rules.map(r => replaceReferences(r, this.tank, this.fisher));
+    rules = rules.map(r => replaceReferences(r, this.tank, this.fisher) as FixedValueRule);
     // Convert strings in fixedValueRules to instances
     rules = rules.filter(r => {
       if (r.isInstance) {

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -35,7 +35,7 @@ export class InstanceExporter implements Fishable {
     rules.forEach(r => {
       r.path = r.path.replace(/\[0+\]/g, '');
     });
-    rules = rules.map(r => replaceReferences(r, this.tank, this.fisher) as FixedValueRule);
+    rules = rules.map(r => replaceReferences(r, this.tank, this.fisher));
     // Convert strings in fixedValueRules to instances
     rules = rules.filter(r => {
       if (r.isInstance) {

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -155,7 +155,7 @@ export class StructureDefinitionExporter implements Fishable {
           if (rule instanceof CardRule) {
             element.constrainCardinality(rule.min, rule.max);
           } else if (rule instanceof FixedValueRule) {
-            const replacedRule = replaceReferences(rule, this.tank, this) as FixedValueRule;
+            const replacedRule = replaceReferences(rule, this.tank, this);
             element.fixValue(replacedRule.fixedValue, replacedRule.exactly, this);
           } else if (rule instanceof FlagRule) {
             element.applyFlags(
@@ -189,7 +189,7 @@ export class StructureDefinitionExporter implements Fishable {
               });
             }
           } else if (rule instanceof CaretValueRule) {
-            const replacedRule = replaceReferences(rule, this.tank, this) as CaretValueRule;
+            const replacedRule = replaceReferences(rule, this.tank, this);
             if (replacedRule.path !== '') {
               element.setInstancePropertyByPath(replacedRule.caretPath, replacedRule.value, this);
             } else {

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -155,7 +155,7 @@ export class StructureDefinitionExporter implements Fishable {
           if (rule instanceof CardRule) {
             element.constrainCardinality(rule.min, rule.max);
           } else if (rule instanceof FixedValueRule) {
-            const replacedRule = replaceReferences(rule, this.tank, this);
+            const replacedRule = replaceReferences(rule, this.tank, this) as FixedValueRule;
             element.fixValue(replacedRule.fixedValue, replacedRule.exactly, this);
           } else if (rule instanceof FlagRule) {
             element.applyFlags(
@@ -189,17 +189,22 @@ export class StructureDefinitionExporter implements Fishable {
               });
             }
           } else if (rule instanceof CaretValueRule) {
-            if (rule.path !== '') {
-              element.setInstancePropertyByPath(rule.caretPath, rule.value, this);
+            const replacedRule = replaceReferences(rule, this.tank, this) as CaretValueRule;
+            if (replacedRule.path !== '') {
+              element.setInstancePropertyByPath(replacedRule.caretPath, replacedRule.value, this);
             } else {
-              if (rule.isInstance) {
+              if (replacedRule.isInstance) {
                 if (this.deferredRules.has(structDef)) {
-                  this.deferredRules.get(structDef).push(rule);
+                  this.deferredRules.get(structDef).push(replacedRule);
                 } else {
-                  this.deferredRules.set(structDef, [rule]);
+                  this.deferredRules.set(structDef, [replacedRule]);
                 }
               } else {
-                structDef.setInstancePropertyByPath(rule.caretPath, rule.value, this);
+                structDef.setInstancePropertyByPath(
+                  replacedRule.caretPath,
+                  replacedRule.value,
+                  this
+                );
               }
             }
           } else if (rule instanceof ObeysRule) {

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -226,12 +226,8 @@ export function getArrayIndex(pathPart: PathPart): number {
  * @param {Fishable} fisher - A fishable implementation for finding definitions and metadata
  * @returns {FixedValueRule} a clone of the rule if replacing is done, otherwise the original rule
  */
-export function replaceReferences(
-  rule: FixedValueRule | CaretValueRule,
-  tank: FSHTank,
-  fisher: Fishable
-): FixedValueRule | CaretValueRule {
-  let clone: FixedValueRule | CaretValueRule;
+export function replaceReferences<T>(rule: T, tank: FSHTank, fisher: Fishable): T {
+  let clone: T;
   const value = getRuleValue(rule);
   if (value instanceof FshReference) {
     const instance = tank.fish(value.reference, Type.Instance) as Instance;
@@ -271,7 +267,7 @@ export function replaceReferences(
  * @param rule - The rule to get a value from
  * @returns - The value on the rule
  */
-function getRuleValue(rule: FixedValueRule | CaretValueRule): FixedValueType {
+function getRuleValue(rule: any): FixedValueType {
   if (rule instanceof FixedValueRule) {
     return rule.fixedValue;
   } else if (rule instanceof CaretValueRule) {

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -226,7 +226,11 @@ export function getArrayIndex(pathPart: PathPart): number {
  * @param {Fishable} fisher - A fishable implementation for finding definitions and metadata
  * @returns {FixedValueRule} a clone of the rule if replacing is done, otherwise the original rule
  */
-export function replaceReferences<T>(rule: T, tank: FSHTank, fisher: Fishable): T {
+export function replaceReferences<T extends FixedValueRule | CaretValueRule>(
+  rule: T,
+  tank: FSHTank,
+  fisher: Fishable
+): T {
   let clone: T;
   const value = getRuleValue(rule);
   if (value instanceof FshReference) {
@@ -267,7 +271,7 @@ export function replaceReferences<T>(rule: T, tank: FSHTank, fisher: Fishable): 
  * @param rule - The rule to get a value from
  * @returns - The value on the rule
  */
-function getRuleValue(rule: any): FixedValueType {
+function getRuleValue(rule: FixedValueRule | CaretValueRule): FixedValueType {
   if (rule instanceof FixedValueRule) {
     return rule.fixedValue;
   } else if (rule instanceof CaretValueRule) {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -2423,6 +2423,98 @@ describe('StructureDefinitionExporter', () => {
     });
   });
 
+  it('should apply a Reference CaretValueRule on an SD and replace the Reference', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    const instance = new Instance('Bar');
+    instance.id = 'bar-id';
+    instance.instanceOf = 'Organization';
+    doc.instances.set(instance.name, instance);
+
+    const rule = new CaretValueRule('');
+    rule.caretPath = 'identifier[0].assigner';
+    rule.value = new FshReference('Bar');
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+
+    expect(sd.identifier[0].assigner).toEqual({
+      reference: 'Organization/bar-id'
+    });
+  });
+
+  it('should apply a Reference CaretValueRule on an ED and replace the Reference', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    const instance = new Instance('Bar');
+    instance.id = 'bar-id';
+    instance.instanceOf = 'Organization';
+    doc.instances.set(instance.name, instance);
+
+    const rule = new CaretValueRule('subject');
+    rule.caretPath = 'patternReference';
+    rule.value = new FshReference('Bar');
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+
+    const ed = sd.elements.find(e => e.id === 'Observation.subject');
+
+    expect(ed.patternReference).toEqual({
+      reference: 'Organization/bar-id'
+    });
+  });
+
+  it('should apply a CodeSystem CaretValueRule on an SD and replace the CodeSystem', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    const cs = new FshCodeSystem('Bar');
+    cs.id = 'bar-id';
+    doc.codeSystems.set(cs.name, cs);
+
+    const rule = new CaretValueRule('');
+    rule.caretPath = 'jurisdiction';
+    rule.value = new FshCode('foo', 'Bar');
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+
+    expect(sd.jurisdiction[0].coding[0]).toEqual({
+      code: 'foo',
+      system: 'http://hl7.org/fhir/us/minimal/CodeSystem/bar-id'
+    });
+  });
+
+  it('should apply a CodeSystem CaretValueRule on an ED and replace the Reference', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    const cs = new FshCodeSystem('Bar');
+    cs.id = 'bar-id';
+    doc.codeSystems.set(cs.name, cs);
+
+    const rule = new CaretValueRule('subject');
+    rule.caretPath = 'code';
+    rule.value = new FshCode('foo', 'Bar');
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+
+    const ed = sd.elements.find(e => e.id === 'Observation.subject');
+
+    expect(ed.code[0]).toEqual({
+      code: 'foo',
+      system: 'http://hl7.org/fhir/us/minimal/CodeSystem/bar-id'
+    });
+  });
+
   // ObeysRule
   it('should apply an ObeysRule at the specified path', () => {
     const profile = new Profile('Foo');


### PR DESCRIPTION
This fixes #516.

CodeSystems defined in FSH were not being replaced with their canonical URLs when they were used in a CaretValueRule. It would work on a FixedValueRule, but not a CaretValueRule. So if the user did:
```
CodeSystem: MyCS
Id: my-cs
* #mycode "My Display" "My Definition"

Profile: MyProfile
Parent: Patient
* active ^code[0] = MyCS#mycode
```
The `MyCS` would not be converted to the URL for `MyCS`, resulting in an error. This was also actually an issue for References too. References to locally defined resources would not be resolved into the form `<resource.resourceType>/<resource.id>`. The code for replacing References and CodeSystems is in the same spot, so this PR fixes resolution for both of them.

To test this, you can use the example given above. On `master`, that will result in a `Resolved value "MyCS" is not a valid URI.` error. On this branch, it should build without error, and the value will be correctly replaced. Additionally, the tests on https://github.com/FHIR/sushi/commit/ffbe61805345e1ce141b2da4e88afb0cfc55fe3d fail on that commit, but then the next commit fixes them by adding the bug fix.