### PR TITLE
Fix conflicting extension names

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -419,7 +419,7 @@ export class ElementDefinition {
 
   getSlices() {
     return this.structDef.elements.filter(
-      e => e.id !== this.id && e.path === this.path && e.id.startsWith(this.id)
+      e => e.id !== this.id && e.path === this.path && e.id.startsWith(`${this.id}:`)
     );
   }
 

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -343,7 +343,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.derivation).toBe('constraint');
   });
 
-  it.skip('should export sub-extensions, with similar starting names and different types', () => {
+  it('should export sub-extensions, with similar starting names and different types', () => {
     const ruleString = new OnlyRule('extension[Foo].value[x]');
     ruleString.types = [{ type: 'string' }];
     const ruleDecimal = new OnlyRule('extension[FooBar].value[x]');


### PR DESCRIPTION
Fixes #531, and adds code that fixes the skipped test introduced by https://github.com/FHIR/sushi/pull/537.

To test, you can unskip that test on master, and see that it fails, and then see that on this branch, that test passes. You can also test with the example given in the issue description.