### PR TITLE
Support whitespace in Reference()

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1248,11 +1248,17 @@ export class FSHImporter extends FSHVisitor {
   }
 
   private parseOrReference(reference: string): string[] {
-    return reference.slice(reference.indexOf('(') + 1, reference.length - 1).split(/\s+or\s+/);
+    return reference
+      .slice(reference.indexOf('(') + 1, reference.length - 1)
+      .split(/\s+or\s+/)
+      .map(r => r.trim());
   }
 
   private parsePipeReference(reference: string): string[] {
-    return reference.slice(reference.indexOf('(') + 1, reference.length - 1).split(/\s*\|\s*/);
+    return reference
+      .slice(reference.indexOf('(') + 1, reference.length - 1)
+      .split(/\s*\|\s*/)
+      .map(r => r.trim());
   }
 
   visitCanonical(ctx: pc.CanonicalContext): FshCanonical {


### PR DESCRIPTION
This PR fixes #535. Spaces inside the `()` of `Reference` is properly supported now. The issue and tests show the cases this could occur in, but below are simplified examples:

Fixed Value Rule: Previously did not find and resolve the reference correctly, but will now resolve properly.

```
* subject = Reference(   mCODEPatientExample01  )
```

Only Rule: Previously logged an error that "    CancerStageParent " could not be found, but now sets the rule properly.

```
* stage.assessment only Reference(   CancerStageParent )
```