### PR TITLE
Allow quantities to be fixed to specializations

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -183,6 +183,8 @@ export class ElementDefinition {
   patternCoding: Coding;
   fixedQuantity: Quantity;
   patternQuantity: Quantity;
+  fixedAge: Quantity;
+  patternAge: Quantity;
   fixedRatio: Ratio;
   patternRatio: Ratio;
   fixedReference: Reference;
@@ -1158,7 +1160,7 @@ export class ElementDefinition {
       case 'Quantity':
         value = value as FshQuantity;
         // Special case quantity to support compatible specializations (like Age), but try to do it
-        // in a flexible way (without hard-coding every specializations here).
+        // in a flexible way (without hard-coding every specialization here).
         let providedType = 'Quantity';
         const actualType = this.type[0].code;
         if (actualType !== 'Quantity') {

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -9,7 +9,8 @@ import {
   FshReference,
   Extension,
   FshCodeSystem,
-  RuleSet
+  RuleSet,
+  FshQuantity
 } from '../../src/fshtypes';
 import {
   FixedValueRule,
@@ -1277,6 +1278,26 @@ describe('InstanceExporter', () => {
           system: 'http://hl7.org/fhir/us/minimal/CodeSystem/Visible'
         }
       ]);
+    });
+
+    // Fixing Quantities to Quantity specializations (e.g., Age)
+    it('should fix a Quantity to a Quantity specialization', () => {
+      const conditionInstance = new Instance('SomeCondition');
+      conditionInstance.instanceOf = 'Condition';
+      const fixedAgeRule = new FixedValueRule('onsetAge');
+      fixedAgeRule.fixedValue = new FshQuantity(
+        42.0,
+        new FshCode('a', 'http://unitsofmeasure.org', 'years')
+      );
+      conditionInstance.rules.push(fixedAgeRule);
+      doc.instances.set(conditionInstance.name, conditionInstance);
+      const exported = exportInstance(conditionInstance);
+      expect(exported.onsetAge).toEqual({
+        value: 42.0,
+        code: 'a',
+        system: 'http://unitsofmeasure.org',
+        unit: 'years'
+      });
     });
 
     // Sliced elements

--- a/test/fhirtypes/ElementDefinition.fixFshQuantity.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixFshQuantity.test.ts
@@ -64,13 +64,11 @@ describe('ElementDefinition', () => {
       const onsetX = condition.elements.find(e => e.id === 'Condition.onset[x]');
       onsetX.type = [new ElementDefinitionType('Age')];
       onsetX.fixValue(fshQuantityAge, false, fisher);
-      // @ts-ignore we don't elaborate over all possible pattern[x] in ElementDefinition
       expect(onsetX.patternAge).toEqual({
         value: 42.0,
         code: 'a',
         system: 'http://unitsofmeasure.org'
       });
-      // @ts-ignore we don't elaborate over all possible pattern[x] in ElementDefinition
       expect(onsetX.fixedAge).toBeUndefined();
     });
 
@@ -78,13 +76,11 @@ describe('ElementDefinition', () => {
       const onsetX = condition.elements.find(e => e.id === 'Condition.onset[x]');
       onsetX.type = [new ElementDefinitionType('Age')];
       onsetX.fixValue(fshQuantityAge, true, fisher);
-      // @ts-ignore we don't elaborate over all possible pattern[x] in ElementDefinition
       expect(onsetX.fixedAge).toEqual({
         value: 42.0,
         code: 'a',
         system: 'http://unitsofmeasure.org'
       });
-      // @ts-ignore we don't elaborate over all possible pattern[x] in ElementDefinition
       expect(onsetX.patternAge).toBeUndefined();
     });
 

--- a/test/fhirtypes/ElementDefinition.setInstancePropertyByPath.test.ts
+++ b/test/fhirtypes/ElementDefinition.setInstancePropertyByPath.test.ts
@@ -3,7 +3,7 @@ import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
 import { ElementDefinition, ElementDefinitionType } from '../../src/fhirtypes/ElementDefinition';
 import { StructureDefinition } from '../../src/fhirtypes/StructureDefinition';
 import { TestFisher } from '../testhelpers';
-import { FshCode } from '../../src/fshtypes';
+import { FshCode, FshQuantity } from '../../src/fshtypes';
 import path from 'path';
 
 describe('ElementDefinition', () => {
@@ -45,8 +45,26 @@ describe('ElementDefinition', () => {
     });
 
     it('should set a nested instance property which must be created', () => {
-      status.setInstancePropertyByPath('patternQuantity.value', 1.2, fisher);
-      expect(status.patternQuantity.value).toBe(1.2);
+      // This isn't how you would normally do this, but it's useful for testing this part of the logic
+      const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
+      valueX.setInstancePropertyByPath('patternQuantity.value', 1.2, fisher);
+      expect(valueX.patternQuantity.value).toBe(1.2);
+    });
+
+    it('should set a Quantity on a Quantity specialization instance property (e.g., Age)', () => {
+      // This isn't how you would normally do this, but it's useful for testing this part of the logic
+      const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
+      valueX.setInstancePropertyByPath(
+        'patternAge',
+        new FshQuantity(42.0, new FshCode('a', 'http://unitsofmeasure.org')),
+        fisher
+      );
+      // @ts-ignore we don't elaborate over all possible pattern[x] in ElementDefinition
+      expect(valueX.patternAge).toEqual({
+        value: 42.0,
+        code: 'a',
+        system: 'http://unitsofmeasure.org'
+      });
     });
 
     it('should not set an instance property which is being fixed incorrectly', () => {

--- a/test/fhirtypes/ElementDefinition.setInstancePropertyByPath.test.ts
+++ b/test/fhirtypes/ElementDefinition.setInstancePropertyByPath.test.ts
@@ -59,7 +59,6 @@ describe('ElementDefinition', () => {
         new FshQuantity(42.0, new FshCode('a', 'http://unitsofmeasure.org')),
         fisher
       );
-      // @ts-ignore we don't elaborate over all possible pattern[x] in ElementDefinition
       expect(valueX.patternAge).toEqual({
         value: 42.0,
         code: 'a',


### PR DESCRIPTION
Allow quantities to be fixed to specializations like Age and Duration. Note that we do not do any extra validation (e.g., we don't ensure that Age uses valid units for Age, or that a Count uses the '1' unit) -- we leave that for the IG Publisher to validate.

To test this, you can first run the tests at commit 16a827e without the fix.  Four tests will fail.  Then run them again at commit ed136db (the fix) and they will succeed.

You can also test them via a profile like this:

```
Profile: ConditionWithFixedOnsetAge
Parent: Condition
* onset[x] only Age
* onset[x] = 42 'a'
```

Or an instance like this:
```
Instance: ConditionAcquiredAt42
InstanceOf: Condition
* subject = Reference(Patient/abc)
* onsetAge = 42 'a'
```

Fixes #515 