### PR TITLE
Fix custom extension urls

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -30,7 +30,8 @@ import {
   splitOnPathPeriods,
   applyMixinRules,
   cleanResource,
-  applyInsertRules
+  applyInsertRules,
+  getUrlFromFshDefinition
 } from '../fhirtypes/common';
 import { Package } from './Package';
 
@@ -89,7 +90,7 @@ export class StructureDefinitionExporter implements Fishable {
       // for consistency, delete rather than leaving null-valued
       delete structDef.modifierExtension;
     }
-    structDef.url = `${this.tank.config.canonical}/StructureDefinition/${structDef.id}`;
+    structDef.url = getUrlFromFshDefinition(fshDefinition, this.tank.config.canonical);
     delete structDef.identifier;
     structDef.version = this.tank.config.version; // can be overridden using a rule
     structDef.setName(fshDefinition.name, fshDefinition.sourceInfo);

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -552,6 +552,36 @@ export function isInheritedResource(
   }
 }
 
+/**
+ * Determines the formal FHIR URL to use to refer to this entity (for example when fishing).
+ * If a caret value rule has been applied to the entity's url, use the value specified in that
+ * rule. Otherwise, use the default url based on the configured canonical url.
+ *
+ * @param fshDefinition - The FSH definition that the returned URL refers to
+ * @param canonical - The canonical URL for the FSH project
+ * @returns {string} - The URL to use to refer to the FHIR entity
+ */
+export function getUrlFromFshDefinition(
+  fshDefinition: Profile | Extension | FshValueSet | FshCodeSystem,
+  canonical: string
+): string {
+  for (const rule of fshDefinition.rules) {
+    if (rule instanceof CaretValueRule && rule.path === '' && rule.caretPath === 'url') {
+      // this value should only be a string, but that might change at some point
+      return rule.value.toString();
+    }
+  }
+  let fhirType: string;
+  if (fshDefinition instanceof FshValueSet) {
+    fhirType = 'ValueSet';
+  } else if (fshDefinition instanceof FshCodeSystem) {
+    fhirType = 'CodeSystem';
+  } else {
+    fhirType = 'StructureDefinition';
+  }
+  return `${canonical}/${fhirType}/${fshDefinition.id}`;
+}
+
 const nameRegex = /^[A-Z]([A-Za-z0-9_]){0,254}$/;
 
 export class HasName {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1993,6 +1993,92 @@ describe('StructureDefinitionExporter', () => {
     expect(extensionSliceValueX.type).toEqual([new ElementDefinitionType('Quantity')]);
   });
 
+  it('should apply a ContainsRule of an extension with an overridden URL', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+    doc.profiles.set('Foo', profile);
+
+    const extBar = new Extension('Bar');
+    const caretValueRule = new CaretValueRule('');
+    caretValueRule.caretPath = 'url';
+    caretValueRule.value = 'http://different-url.com/StructureDefinition/Bar';
+    extBar.rules.push(caretValueRule);
+    doc.extensions.set('Bar', extBar);
+
+    const constainsRule = new ContainsRule('extension');
+    constainsRule.items = [{ name: 'bar', type: 'Bar' }];
+    profile.rules.push(constainsRule);
+
+    const onlyRule = new OnlyRule('extension[bar].value[x]');
+    onlyRule.types = [{ type: 'Quantity' }];
+    profile.rules.push(onlyRule);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
+
+    const extension = sd.elements.find(e => e.id === 'Observation.extension');
+    const extensionSlice = sd.elements.find(e => e.id === 'Observation.extension:bar');
+    const extensionSliceUrl = sd.elements.find(e => e.id === 'Observation.extension:bar.url');
+    const extensionSliceValueX = sd.elements.find(
+      e => e.id === 'Observation.extension:bar.value[x]'
+    );
+
+    expect(extension.slicing).toBeDefined();
+    expect(extension.slicing.discriminator.length).toBe(1);
+    expect(extension.slicing.discriminator[0]).toEqual({ type: 'value', path: 'url' });
+    expect(extensionSlice).toBeDefined();
+    expect(extensionSliceUrl).toBeDefined();
+    expect(extensionSliceUrl.fixedUri).toBe('http://different-url.com/StructureDefinition/Bar');
+    expect(extensionSliceValueX).toBeDefined();
+    expect(extensionSliceValueX.type).toEqual([new ElementDefinitionType('Quantity')]);
+  });
+
+  it('should apply a ContainsRule of an extension with an overridden URL by URL', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+    doc.profiles.set('Foo', profile);
+
+    const extBar = new Extension('Bar');
+    const caretValueRule = new CaretValueRule('');
+    caretValueRule.caretPath = 'url';
+    caretValueRule.value = 'http://different-url.com/StructureDefinition/Bar';
+    extBar.rules.push(caretValueRule);
+    doc.extensions.set('Bar', extBar);
+
+    const constainsRule = new ContainsRule('extension');
+    constainsRule.items = [{ name: 'bar', type: 'Bar' }];
+    profile.rules.push(constainsRule);
+
+    const onlyRule = new OnlyRule(
+      'extension[http://different-url.com/StructureDefinition/Bar].value[x]'
+    );
+    onlyRule.types = [{ type: 'Quantity' }];
+    profile.rules.push(onlyRule);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
+
+    const extension = sd.elements.find(e => e.id === 'Observation.extension');
+    const extensionSlice = sd.elements.find(e => e.id === 'Observation.extension:bar');
+    const extensionSliceUrl = sd.elements.find(e => e.id === 'Observation.extension:bar.url');
+    const extensionSliceValueX = sd.elements.find(
+      e => e.id === 'Observation.extension:bar.value[x]'
+    );
+
+    expect(extension.slicing).toBeDefined();
+    expect(extension.slicing.discriminator.length).toBe(1);
+    expect(extension.slicing.discriminator[0]).toEqual({ type: 'value', path: 'url' });
+    expect(extensionSlice).toBeDefined();
+    expect(extensionSliceUrl).toBeDefined();
+    expect(extensionSliceUrl.fixedUri).toBe('http://different-url.com/StructureDefinition/Bar');
+    expect(extensionSliceValueX).toBeDefined();
+    expect(extensionSliceValueX.type).toEqual([new ElementDefinitionType('Quantity')]);
+  });
+
   it('should apply multiple ContainsRule on an element with defined slicing', () => {
     const profile = new Profile('Foo');
     profile.parent = 'resprate';


### PR DESCRIPTION
If you override an extension's URL with a caret rule, the extension definition should fix the 'Extension.url' element value to the overridden URL. Prior to this fix, it fixed it to the canonical-based URL instead.  This caused problems if you tried to access and use that extension in a profile.

To test, you can run the test from commit f635fff without the fix.  It should fail.  If you run it with the fix (commit 43671f8) it should succeed.

You can also test it using the example FSH for #532:
```
Extension: TestExtension
* ^url = "http://foo.bar.baz"

Profile: TestProfile
Parent: Communication
* payload.extension contains TestExtension named ContentConcept 1..
// * payload.extension contains http://foo.bar.baz named ContentConcept 1..
* payload.extension[ContentConcept].value[x] only CodeableConcept
```

Fixs #532 