### PR TITLE
Support fixing inline instances on profiles

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -5,7 +5,7 @@ import {
   idRegex,
   InstanceDefinition
 } from '../fhirtypes';
-import { Profile, Extension, Instance, Invariant } from '../fshtypes';
+import { Profile, Extension, Invariant } from '../fshtypes';
 import { FSHTank } from '../import';
 import { InstanceExporter } from '../export';
 import {
@@ -158,25 +158,8 @@ export class StructureDefinitionExporter implements Fishable {
             element.constrainCardinality(rule.min, rule.max);
           } else if (rule instanceof FixedValueRule) {
             if (rule.isInstance) {
-              let instance = this.pkg.fish(
-                rule.fixedValue as string,
-                Type.Instance
-              ) as InstanceDefinition;
-              if (instance == null) {
-                // If we find a FSH definition, then we can export and fish for it again
-                const fshDefinition = this.tank.fish(
-                  rule.fixedValue as string,
-                  Type.Instance
-                ) as Instance;
-                if (fshDefinition) {
-                  const instanceExporter = new InstanceExporter(this.tank, this.pkg, this.fisher);
-                  instanceExporter.exportInstance(fshDefinition as Instance);
-                  instance = this.pkg.fish(
-                    rule.fixedValue as string,
-                    Type.Instance
-                  ) as InstanceDefinition;
-                }
-              }
+              const instanceExporter = new InstanceExporter(this.tank, this.pkg, this.fisher);
+              const instance = instanceExporter.fishForFHIR(rule.fixedValue as string);
               if (instance == null) {
                 logger.error(
                   `Cannot find definition for Instance: ${rule.fixedValue}. Skipping rule.`

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1127,8 +1127,8 @@ export class ElementDefinition {
       type = 'Reference';
     } else if (value instanceof FshCanonical) {
       type = 'Canonical';
-    } else if (typeof value === 'object') {
-      type = value.constructor?.name;
+    } else if (value instanceof InstanceDefinition) {
+      type = 'InstanceDefinition';
     } else {
       type = typeof value;
     }
@@ -1234,6 +1234,7 @@ export class ElementDefinition {
         );
         break;
       default:
+        type = (typeof value === 'object' && value.constructor?.name) ?? type;
         throw new MismatchedTypeError(type, value, this.type[0].code);
     }
 

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -185,6 +185,10 @@ export class ElementDefinition {
   patternQuantity: Quantity;
   fixedAge: Quantity;
   patternAge: Quantity;
+  fixedAddress: InstanceDefinition;
+  patternAddress: InstanceDefinition;
+  fixedPeriod: InstanceDefinition;
+  patternPeriod: InstanceDefinition;
   fixedRatio: Ratio;
   patternRatio: Ratio;
   fixedReference: Reference;
@@ -1218,6 +1222,16 @@ export class ElementDefinition {
           canonicalUrl += `|${value.version}`;
         }
         this.fixString(canonicalUrl, exactly);
+        break;
+      case 'InstanceDefinition':
+        value = value as InstanceDefinition;
+        const stringVal = JSON.stringify(value);
+        this.fixFHIRValue(
+          stringVal,
+          value.toJSON(),
+          exactly,
+          value._instanceMeta.sdType ?? value.resourceType
+        );
         break;
       default:
         throw new MismatchedTypeError(type, value, this.type[0].code);

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -852,16 +852,7 @@ export class FSHImporter extends FSHVisitor {
       return [this.visitValueSetRule(ctx.valueSetRule())];
     } else if (ctx.fixedValueRule()) {
       const rule = this.visitFixedValueRule(ctx.fixedValueRule());
-      if (rule.isInstance) {
-        const sourceInfo = { location: this.extractStartStop(ctx), file: this.currentFile };
-        logger.error(
-          'Resources cannot be added inline to a Profile or Extension, skipping rule.',
-          sourceInfo
-        );
-        return [];
-      } else {
-        return [rule];
-      }
+      return [rule];
     } else if (ctx.onlyRule()) {
       return [this.visitOnlyRule(ctx.onlyRule())];
     } else if (ctx.containsRule()) {

--- a/src/utils/Mixin.ts
+++ b/src/utils/Mixin.ts
@@ -6,7 +6,6 @@
 export function applyMixins(derivedCtor: any, baseCtors: any[]) {
   baseCtors.forEach(baseCtor => {
     Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {
-      if (name === 'constructor') return;
       Object.defineProperty(
         derivedCtor.prototype,
         name,

--- a/src/utils/Mixin.ts
+++ b/src/utils/Mixin.ts
@@ -6,6 +6,7 @@
 export function applyMixins(derivedCtor: any, baseCtors: any[]) {
   baseCtors.forEach(baseCtor => {
     Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {
+      if (name === 'constructor') return;
       Object.defineProperty(
         derivedCtor.prototype,
         name,

--- a/test/fhirtypes/ElementDefinition.fixInstanceDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixInstanceDefinition.test.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { cloneDeep } from 'lodash';
 import { loadFromPath } from '../../src/fhirdefs/load';
 import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
 import { StructureDefinition, InstanceDefinition } from '../../src/fhirtypes';
@@ -9,7 +8,6 @@ describe('ElementDefinition', () => {
   let defs: FHIRDefinitions;
   let patient: StructureDefinition;
   let observation: StructureDefinition;
-  let location: StructureDefinition;
   let fisher: TestFisher;
 
   beforeAll(() => {
@@ -24,7 +22,6 @@ describe('ElementDefinition', () => {
   beforeEach(() => {
     patient = fisher.fishForStructureDefinition('Patient');
     observation = fisher.fishForStructureDefinition('Observation');
-    // location = fisher.fishForStructureDefinition('Location');
   });
 
   describe('#fixInstance', () => {

--- a/test/fhirtypes/ElementDefinition.fixInstanceDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixInstanceDefinition.test.ts
@@ -1,0 +1,172 @@
+import path from 'path';
+import { cloneDeep } from 'lodash';
+import { loadFromPath } from '../../src/fhirdefs/load';
+import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
+import { StructureDefinition, InstanceDefinition } from '../../src/fhirtypes';
+import { TestFisher } from '../testhelpers';
+
+describe('ElementDefinition', () => {
+  let defs: FHIRDefinitions;
+  let patient: StructureDefinition;
+  let observation: StructureDefinition;
+  let location: StructureDefinition;
+  let fisher: TestFisher;
+
+  beforeAll(() => {
+    defs = new FHIRDefinitions();
+    loadFromPath(
+      path.join(__dirname, '..', 'testhelpers', 'testdefs', 'package'),
+      'testPackage',
+      defs
+    );
+    fisher = new TestFisher().withFHIR(defs);
+  });
+  beforeEach(() => {
+    patient = fisher.fishForStructureDefinition('Patient');
+    observation = fisher.fishForStructureDefinition('Observation');
+    // location = fisher.fishForStructureDefinition('Location');
+  });
+
+  describe('#fixInstance', () => {
+    it('should fix an allowed type of an instance', () => {
+      const addressInstance = new InstanceDefinition();
+      addressInstance._instanceMeta.name = 'USPostalAddress';
+      addressInstance._instanceMeta.sdType = 'Address';
+      addressInstance._instanceMeta.usage = 'Inline';
+      addressInstance.country = 'US';
+      addressInstance.type = 'postal';
+
+      const address = patient.elements.find(e => e.id === 'Patient.address');
+      address.fixValue(addressInstance);
+      expect(address.patternAddress).toEqual({ country: 'US', type: 'postal' });
+      expect(address.fixedAddress).toBeUndefined();
+    });
+
+    it('should fix an allowed type of an instance (exactly)', () => {
+      const addressInstance = new InstanceDefinition();
+      addressInstance._instanceMeta.name = 'USPostalAddress';
+      addressInstance._instanceMeta.sdType = 'Address';
+      addressInstance._instanceMeta.usage = 'Inline';
+      addressInstance.country = 'US';
+      addressInstance.type = 'postal';
+
+      const address = patient.elements.find(e => e.id === 'Patient.address');
+      address.fixValue(addressInstance, true);
+      expect(address.fixedAddress).toEqual({ country: 'US', type: 'postal' });
+      expect(address.patternAddress).toBeUndefined();
+    });
+
+    it('should throw NoSingleTypeError when element has multiple types', () => {
+      const periodInstance = new InstanceDefinition();
+      periodInstance._instanceMeta.name = 'LastYear';
+      periodInstance._instanceMeta.sdType = 'Period';
+      periodInstance._instanceMeta.usage = 'Inline';
+      periodInstance.start = '2019-08-01';
+      periodInstance.end = '2020-08-01';
+
+      const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
+      expect(() => {
+        valueX.fixValue(periodInstance);
+      }).toThrow(
+        'Cannot fix InstanceDefinition value on this element since this element does not have a single type'
+      );
+      expect(() => {
+        valueX.fixValue(periodInstance, true);
+      }).toThrow(
+        'Cannot fix InstanceDefinition value on this element since this element does not have a single type'
+      );
+      expect(valueX.patternPeriod).toBeUndefined();
+      expect(valueX.fixedPeriod).toBeUndefined();
+    });
+
+    it('should throw ValueAlreadyFixedError when the value is fixed to a different value by pattern[x]', () => {
+      const workAddress = new InstanceDefinition();
+      workAddress._instanceMeta.name = 'USPostalAddress';
+      workAddress._instanceMeta.sdType = 'Address';
+      workAddress._instanceMeta.usage = 'Inline';
+      workAddress.country = 'US';
+      workAddress.type = 'postal';
+      workAddress.use = 'work';
+      const homeAddress = new InstanceDefinition();
+      homeAddress._instanceMeta.name = 'USPostalAddress';
+      homeAddress._instanceMeta.sdType = 'Address';
+      homeAddress._instanceMeta.usage = 'Inline';
+      homeAddress.country = 'US';
+      homeAddress.type = 'postal';
+      homeAddress.use = 'home';
+
+      const address = patient.elements.find(e => e.id === 'Patient.address');
+      address.fixValue(workAddress);
+      expect(address.patternAddress).toEqual({ country: 'US', type: 'postal', use: 'work' });
+      address.fixValue(workAddress);
+      expect(address.patternAddress).toEqual({ country: 'US', type: 'postal', use: 'work' });
+      expect(() => {
+        address.fixValue(homeAddress);
+      }).toThrow(
+        'Cannot fix {"country":"US","type":"postal","use":"home"} to this element; a different Address is already fixed: {"country":"US","type":"postal","use":"work"}'
+      );
+    });
+
+    it('should throw ValueAlreadyFixedError when the value is fixed to a different value by fixed[x]', () => {
+      const workAddress = new InstanceDefinition();
+      workAddress._instanceMeta.name = 'USPostalAddress';
+      workAddress._instanceMeta.sdType = 'Address';
+      workAddress._instanceMeta.usage = 'Inline';
+      workAddress.country = 'US';
+      workAddress.type = 'postal';
+      workAddress.use = 'work';
+      const homeAddress = new InstanceDefinition();
+      homeAddress._instanceMeta.name = 'USPostalAddress';
+      homeAddress._instanceMeta.sdType = 'Address';
+      homeAddress._instanceMeta.usage = 'Inline';
+      homeAddress.country = 'US';
+      homeAddress.type = 'postal';
+      homeAddress.use = 'home';
+
+      const address = patient.elements.find(e => e.id === 'Patient.address');
+      address.fixValue(workAddress, true);
+      expect(address.fixedAddress).toEqual({ country: 'US', type: 'postal', use: 'work' });
+      address.fixValue(workAddress, true);
+      expect(address.fixedAddress).toEqual({ country: 'US', type: 'postal', use: 'work' });
+      expect(() => {
+        address.fixValue(homeAddress, true);
+      }).toThrow(
+        'Cannot fix {"country":"US","type":"postal","use":"home"} to this element; a different Address is already fixed: {"country":"US","type":"postal","use":"work"}'
+      );
+    });
+
+    it('should throw FixedToPatternError when trying to change fixed[x] to patternp[x]', () => {
+      const addressInstance = new InstanceDefinition();
+      addressInstance._instanceMeta.name = 'USPostalAddress';
+      addressInstance._instanceMeta.sdType = 'Address';
+      addressInstance._instanceMeta.usage = 'Inline';
+      addressInstance.country = 'US';
+      addressInstance.type = 'postal';
+
+      const address = patient.elements.find(e => e.id === 'Patient.address');
+      address.fixValue(addressInstance, true);
+      expect(address.fixedAddress).toEqual({ country: 'US', type: 'postal' });
+      expect(() => {
+        address.fixValue(addressInstance);
+      }).toThrow(
+        'Cannot fix this element using a pattern; as it is already fixed in the StructureDefinition using fixedAddress'
+      );
+    });
+
+    it('should throw MismatchedTypeError when the value is fixed to an unsupported type', () => {
+      const periodInstance = new InstanceDefinition();
+      periodInstance._instanceMeta.name = 'LastYear';
+      periodInstance._instanceMeta.sdType = 'Period';
+      periodInstance._instanceMeta.usage = 'Inline';
+      periodInstance.start = '2019-08-01';
+      periodInstance.end = '2020-08-01';
+
+      const address = patient.elements.find(e => e.id === 'Patient.address');
+      expect(() => {
+        address.fixValue(periodInstance);
+      }).toThrow(
+        'Cannot fix Period value: {"start":"2019-08-01","end":"2020-08-01"}. Value does not match element type: Address'
+      );
+    });
+  });
+});

--- a/test/fhirtypes/ElementDefinition.fixInstanceDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixInstanceDefinition.test.ts
@@ -132,7 +132,7 @@ describe('ElementDefinition', () => {
       );
     });
 
-    it('should throw FixedToPatternError when trying to change fixed[x] to patternp[x]', () => {
+    it('should throw FixedToPatternError when trying to change fixed[x] to pattern[x]', () => {
       const addressInstance = new InstanceDefinition();
       addressInstance._instanceMeta.name = 'USPostalAddress';
       addressInstance._instanceMeta.sdType = 'Address';

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -1352,7 +1352,7 @@ describe('FSHImporter', () => {
         assertFixedValueRule(profile.rules[0], 'identifier.system', 'http://example.org');
       });
 
-      it('should log an error and skip the rule when parsing fixed value Resource rule', () => {
+      it('should parsing fixed value Resource rule', () => {
         const input = `
 
         Profile: ObservationProfile
@@ -1362,10 +1362,8 @@ describe('FSHImporter', () => {
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
-        expect(profile.rules).toHaveLength(0);
-        expect(loggerSpy.getLastMessage('error')).toMatch(
-          /Resources cannot be added inline to a Profile or Extension, skipping rule\..*Line: 5\D*/s
-        );
+        expect(profile.rules).toHaveLength(1);
+        assertFixedValueRule(profile.rules[0], 'contained[0]', 'SomeInstance', false, true);
       });
     });
 

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -1352,7 +1352,7 @@ describe('FSHImporter', () => {
         assertFixedValueRule(profile.rules[0], 'identifier.system', 'http://example.org');
       });
 
-      it('should parsing fixed value Resource rule', () => {
+      it('should parse a fixed value Resource rule', () => {
         const input = `
 
         Profile: ObservationProfile


### PR DESCRIPTION
This PR fixes #511 and supports fixing inline instances on profiles. The example in the issue is now supported, and the tests show a few other examples of what is not allowed.

I do have a couple questions about the implementation:
- In order to reach the `InstanceDefinition` case in `ElementDefinition.fixValue`, I had to make the change to the `applyMixins` function to not set the constructor name. I'm not entirely sure if this is the right approach, because it looks like the original implementation is the way that the [TypeScript documentation]( https://www.typescriptlang.org/docs/handbook/mixins.html#mixin-sample) describes. However, without this change, instances will be an instance of the `InstanceDefinition` class, but their constructor name is `HasId` because the `applyMixins` overwrites this. If others don't think this change is correct, I can always have `ElementDefinition.fixValue` go into the `InstanceDefinition` case whenever we see a `HasId` constructor name.
- I got rid of the error in the importer that we cannot fix instances to profiles since we are now allowing that. However, I'm not sure if there were other cases that we had in mind when writing that error that we still don't want to support. If so, I can add an error back in for those cases.