### PR TITLE
Fix FSHOnly warning bug

### DIFF
--- a/src/import/importConfiguration.ts
+++ b/src/import/importConfiguration.ts
@@ -59,7 +59,11 @@ const IG_ONLY_PROPERTIES = [
   'parameters',
   'template',
   'templates',
-  'menu'
+  'menu',
+  'copyrightyear',
+  'copyrightYear',
+  'releaseLabel',
+  'releaselabel'
 ];
 
 /**
@@ -166,7 +170,7 @@ export function importConfiguration(yaml: YAMLConfiguration | string, file: stri
 
   if (yaml.FSHOnly) {
     // If no IG is being generated, emit warning when IG specific properties are used in config
-    const unusedProperties = Object.keys(config).filter((p: keyof Configuration) =>
+    const unusedProperties = Object.keys(yaml).filter((p: keyof YAMLConfiguration) =>
       IG_ONLY_PROPERTIES.includes(p)
     );
     if (unusedProperties.length > 0) {

--- a/test/import/importConfiguration.test.ts
+++ b/test/import/importConfiguration.test.ts
@@ -2261,7 +2261,7 @@ describe('importConfiguration', () => {
       minYAML.FSHOnly = true;
       const config = importConfiguration(minYAML, 'test-config.yaml');
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /The following properties are unused and only relevant for IG creation: contained, parameters, template, menu.*File: test-config.yaml/s
+        /The following properties are unused and only relevant for IG creation: copyrightYear, releaseLabel, template, menu, contained.*File: test-config.yaml/s
       );
       expect(config.FSHOnly).toBe(true);
     });


### PR DESCRIPTION
This fixes #553.

As the issue description notes, we were emitting a warning incorrectly when `releaseLabel` and/or `copyrightYear` were present in the config. Since these fields get includes into `parameters`, the warning would not `parameters`, but this is confusing, because the user is not necessarily aware that `releaseLabel` and `copyrightYear` go into `parameters`. This PR fixes that bug by changing the warning to directly use the fields in the yaml file.