### PR TITLE
Don't change type code for id and url

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -952,7 +952,10 @@ export class ElementDefinition {
     }
     for (const [typeCode, currentMatches] of currentTypeMatches) {
       const newType = cloneDeep(type);
-      newType.code = typeCode;
+      // never change the code of an id or url element
+      if (!(this.path.endsWith('.id') || this.path.endsWith('.url'))) {
+        newType.code = typeCode;
+      }
       this.applyProfiles(newType, targetType, currentMatches);
       intersection.push(newType);
     }

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1392,6 +1392,45 @@ describe('StructureDefinitionExporter', () => {
     expect(lastMessage).toMatch(/File: FooQuantity\.fsh.*Line: 6 - 11\D*/s);
   });
 
+  it('should apply an OnlyRule to constrain an id element', () => {
+    const specialString = new Profile('SpecialString');
+    specialString.parent = 'string';
+    doc.profiles.set(specialString.name, specialString);
+    const profile = new Profile('MyObservation');
+    profile.parent = 'Observation';
+    const onlyRule = new OnlyRule('code.id');
+    onlyRule.types = [{ type: 'SpecialString' }];
+    profile.rules.push(onlyRule);
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+    const codeId = sd.findElement('Observation.code.id');
+    expect(codeId.type.length).toBe(1);
+    expect(codeId.type[0].getActualCode()).toBe('http://hl7.org/fhirpath/System.String');
+    expect(codeId.type[0].profile.length).toBe(1);
+    expect(codeId.type[0].profile[0]).toBe(
+      'http://hl7.org/fhir/us/minimal/StructureDefinition/SpecialString'
+    );
+  });
+
+  it('should apply an OnlyRule to constrain a url element', () => {
+    const specialUri = new Profile('SpecialUri');
+    specialUri.parent = 'uri';
+    doc.profiles.set(specialUri.name, specialUri);
+    const extension = new Extension('SpecialExtension');
+    const onlyRule = new OnlyRule('url');
+    onlyRule.types = [{ type: 'SpecialUri' }];
+    extension.rules.push(onlyRule);
+    exporter.exportStructDef(extension);
+    const sd = pkg.extensions[0];
+    const url = sd.findElement('Extension.url');
+    expect(url.type.length).toBe(1);
+    expect(url.type[0].getActualCode()).toBe('http://hl7.org/fhirpath/System.String');
+    expect(url.type[0].profile.length).toBe(1);
+    expect(url.type[0].profile[0]).toBe(
+      'http://hl7.org/fhir/us/minimal/StructureDefinition/SpecialUri'
+    );
+  });
+
   it('should not apply an incorrect OnlyRule', () => {
     const profile = new Profile('Foo');
     profile.parent = 'Observation';


### PR DESCRIPTION
Fixes #543 and completes task [CIMPL-467](https://standardhealthrecord.atlassian.net/browse/CIMPL-467)

The id and url elements need to always have a type code of http://hl7.org/fhirpath/System.String. Do not let this code change when applying type constraints to these elements.