### PR TITLE
Add Reslicing

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -186,7 +186,10 @@ export class StructureDefinitionExporter implements Fishable {
             const vsURI = this.fishForMetadata(rule.valueSet, Type.ValueSet)?.url ?? rule.valueSet;
             element.bindToVS(vsURI, rule.strength as ElementDefinitionBindingStrength);
           } else if (rule instanceof ContainsRule) {
-            const isExtension = element.type?.length === 1 && element.type[0].code === 'Extension';
+            const isExtension =
+              element.type?.length === 1 &&
+              element.type[0].code === 'Extension' &&
+              !element.sliceName;
             if (isExtension) {
               this.handleExtensionContainsRule(fshDefinition, rule, structDef, element);
             } else {

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1799,7 +1799,7 @@ export class ElementDefinition {
 
     const slice = this.clone(true);
     delete slice.slicing;
-    slice.id = `${this.id}:${name}`;
+    slice.id = this.sliceName ? `${this.id}/${name}` : `${this.id}:${name}`;
 
     // if a slice with the same id already exists, don't add it again
     const existingSlice = this.structDef.findElement(slice.id);
@@ -1816,7 +1816,7 @@ export class ElementDefinition {
     // Capture the original so that the differential only contains changes from this point on.
     slice.captureOriginal();
 
-    slice.sliceName = name;
+    slice.sliceName = this.sliceName ? `${this.sliceName}/${name}` : name;
     // When we slice, we do not inherit min cardinality, but rather make it 0
     // Allows multiple slices to be defined without violating cardinality of sliced element
     // Cardinality can be later narrowed by card constraints, which check validity of narrowing

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -1,5 +1,6 @@
 import upperFirst from 'lodash/upperFirst';
 import cloneDeep from 'lodash/cloneDeep';
+import escapeRegExp from 'lodash/escapeRegExp';
 import { ElementDefinition, ElementDefinitionType, LooseElementDefJSON } from './ElementDefinition';
 import { Meta } from './specialTypes';
 import { Identifier, CodeableConcept, Coding, Narrative, Resource, Extension } from './dataTypes';
@@ -133,12 +134,13 @@ export class StructureDefinition {
     let lastMatchId = '';
     for (; i < this.elements.length; i++) {
       const currentId = this.elements[i].id;
-      if (element.id.startsWith(`${currentId}.`) || element.id.startsWith(`${currentId}:`)) {
+      if (new RegExp(`${escapeRegExp(currentId)}[.:/]`).test(element.id)) {
         lastMatchId = currentId;
       } else if (
-        (!currentId.startsWith(`${lastMatchId}.`) && !currentId.startsWith(`${lastMatchId}:`)) ||
+        !new RegExp(`${escapeRegExp(lastMatchId)}[./:]`).test(currentId) ||
         // If element is not a slice at this level, and the currentId is a slice, break to add children before slices
-        (element.id.startsWith(`${lastMatchId}.`) && currentId.startsWith(`${lastMatchId}:`))
+        (new RegExp(`${escapeRegExp(lastMatchId)}[.]`).test(element.id) &&
+          new RegExp(`${escapeRegExp(lastMatchId)}[:/]`).test(currentId))
       ) {
         break;
       }

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -464,6 +464,24 @@ describe('StructureDefinition', () => {
       expect(resprate.elements).toHaveLength(originalLength + 1);
       expect(resprate.elements[14].id).toBe('Observation.category.coding');
     });
+
+    it('should add resliced elements in the right place', () => {
+      const originalLength = resprate.elements.length;
+      resprate.addElement(new ElementDefinition('Observation.category:VSCat/foo'));
+      expect(resprate.elements).toHaveLength(originalLength + 1);
+      expect(resprate.elements[26].id).toBe('Observation.category:VSCat/foo');
+    });
+
+    it('should add children of resliced elements in the right place', () => {
+      const originalLength = resprate.elements.length;
+      resprate.addElement(new ElementDefinition('Observation.category:VSCat/foo'));
+      resprate.addElement(new ElementDefinition('Observation.category:VSCat/foo/bar'));
+      resprate.addElement(new ElementDefinition('Observation.category:VSCat/foo.extension'));
+      expect(resprate.elements).toHaveLength(originalLength + 3);
+      expect(resprate.elements[26].id).toBe('Observation.category:VSCat/foo');
+      expect(resprate.elements[27].id).toBe('Observation.category:VSCat/foo.extension');
+      expect(resprate.elements[28].id).toBe('Observation.category:VSCat/foo/bar');
+    });
   });
 
   describe('#findElement', () => {


### PR DESCRIPTION
Fixes #542 by adding support for reslicing in `ContainsRule`s.

I tested this using the example given in #542, and it appears to work for me. As far as I can gather from the spec, there isn't really anything special about reslicing outside of the `sliceName` (and as a result the `id`) having the format `initialSlice/reslice1/reslice2`. As a result, this updates the `addSlice` function to handle the case in which the element we are adding to is itself a slice, in which case we have to reslice.