### PR TITLE
Fixing complex objects checks for fixed children

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1328,7 +1328,7 @@ export class ElementDefinition {
       // find the element on fhirValue that would get assigned to the child.
       // sometimes, there may be arrays inside complex object types, such as CodeableConcept.
       // therefore, flatten those arrays as the path is traversed so that all possible new values are found.
-      const childPath = child.id.replace(`${this.id}.`, '').split('.');
+      const childPath = child.path.replace(`${this.path}.`, '').split('.');
       let newChildValue = [fhirValue];
       for (const pathPart of childPath) {
         newChildValue = flatten(


### PR DESCRIPTION
Fixes #560 and completes task [CIMPL-496](https://standardhealthrecord.atlassian.net/browse/CIMPL-496).

When fixing a complex object to an element, children of that element or of that element's slicedElement may already have fixed values. When this happens, make sure that the two values do not conflict with one another.

The case of "an instance is assigned to a slice (such as `address[RecentAddress]`), and a later fixed value on a non-slice (such as `address.period.start`) would violate that slice" is out of scope for this task.