### PR TITLE
Fix bug with slicing rules on value[x]

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -670,7 +670,12 @@ export class StructureDefinition {
         // NOTE: The spec is somewhat inconsistent on handling choice slicing, we decided on this
         // approach per consistency with 4.0.1 observation-vitalsigns profiles and per this post
         // https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/.
-        matchingXElement.sliceIt('type', '$this', false, 'open');
+        matchingXElement.sliceIt(
+          'type',
+          '$this',
+          matchingXElement.slicing?.ordered,
+          matchingXElement.slicing?.rules
+        );
         // Get the sliceName for the new element
         const newSlice = matchingXElement.addSlice(sliceName, matchingType);
         return newSlice;

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -666,6 +666,21 @@ describe('StructureDefinition', () => {
       expect(valueQuantity.min).toBe(0);
       expect(valueX.slicing).toBeDefined();
       expect(valueX.slicing.discriminator[0]).toEqual({ type: 'type', path: '$this' });
+      expect(valueX.slicing.ordered).toBe(false);
+      expect(valueX.slicing.rules).toBe('open');
+      expect(observation.elements.length).toBe(originalLength + 1);
+    });
+
+    it('should preserve existing slicing when making a non-existent choice element explicit', () => {
+      const originalLength = observation.elements.length;
+      const valueX = observation.findElementByPath('value[x]', fisher);
+      expect(valueX.slicing).toBeUndefined();
+      valueX.slicing = { ordered: true, rules: 'closed' };
+      observation.findElementByPath('valueQuantity', fisher);
+      expect(valueX.slicing).toBeDefined();
+      expect(valueX.slicing.discriminator[0]).toEqual({ type: 'type', path: '$this' });
+      expect(valueX.slicing.ordered).toBe(true);
+      expect(valueX.slicing.rules).toBe('closed');
       expect(observation.elements.length).toBe(originalLength + 1);
     });
 


### PR DESCRIPTION
This fixes #564 by preserving any existing slicing information (`ordered` or `rules`) on a value[x] element when that value[x] element is implicitly sliced by the creation of something like a `valueQuantity` element.