### PR TITLE
Add logic to skip hidden files when including non-FSH IG resources

### DIFF
--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -197,8 +197,7 @@ export function loadCustomResources(input: string, defs: FHIRDefinitions): void 
           if (file.startsWith('.')) {
             // Ignore hidden files on *nix, like `.DS_Store` on macOS
             continue;
-          }
-          else if (file.endsWith('.json')) {
+          } else if (file.endsWith('.json')) {
             resourceJSON = fs.readJSONSync(path.join(dirPath, file));
           } else if (file.endsWith('xml')) {
             resourceJSON = converter.xmlToObj(fs.readFileSync(path.join(dirPath, file)).toString());

--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import os from 'os';
 import tar from 'tar';
 import axios from 'axios';
+import junk from 'junk';
 import temp from 'temp';
 import { logger } from '../utils';
 import { Fhir as FHIRConverter } from 'fhir/fhir';
@@ -194,8 +195,8 @@ export function loadCustomResources(input: string, defs: FHIRDefinitions): void 
       for (const file of files) {
         let resourceJSON: any;
         try {
-          if (file.startsWith('.')) {
-            // Ignore hidden files on *nix, like `.DS_Store` on macOS
+          if (junk.is(file)) {
+            // Ignore "junk" files created by the OS, like .DS_Store on macOS and Thumbs.db on Windows
             continue;
           } else if (file.endsWith('.json')) {
             resourceJSON = fs.readJSONSync(path.join(dirPath, file));

--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -194,7 +194,11 @@ export function loadCustomResources(input: string, defs: FHIRDefinitions): void 
       for (const file of files) {
         let resourceJSON: any;
         try {
-          if (file.endsWith('.json')) {
+          if (file.startsWith('.')) {
+            // Ignore hidden files on *nix, like `.DS_Store` on macOS
+            continue;
+          }
+          else if (file.endsWith('.json')) {
             resourceJSON = fs.readJSONSync(path.join(dirPath, file));
           } else if (file.endsWith('xml')) {
             resourceJSON = converter.xmlToObj(fs.readFileSync(path.join(dirPath, file)).toString());


### PR DESCRIPTION
This prevents an error when macOS silently adds a `.DS_Store` file to one of the folders in `ig-data/input/{supported-resource-input-directory}/`.

I ran into this when trying to include some `.json` format instances in an IG under `ig-data/input/examples/`. When modifying the .json files in the `examples/` folder, macOS will sometimes silently add a `.DS_Store` file into `examples/`.

When this happens, the `sushi` command will fail with a generic "Invalid file detected in directory /path/to/examples/" message. Because the `.DS_Store` file is hidden by the OS in Finder, this issue is hard to debug.

This change will ignore any files that begin with `.` to avoid this problem.