### PR TITLE
Allow BYO resources to be in IG folder

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -83,7 +83,10 @@ async function app() {
   const dependencyDefs = loadExternalDependencies(defs, config);
 
   // Load custom resources specified in ig-data folder
-  loadCustomResources(input, defs);
+  loadCustomResources(path.join(input, 'ig-data', 'input'), defs);
+  if (isIgPubContext) {
+    loadCustomResources(path.join(input, '..', 'input'), defs);
+  }
 
   let tank: FSHTank;
   try {

--- a/src/app.ts
+++ b/src/app.ts
@@ -84,7 +84,7 @@ async function app() {
 
   // Load custom resources specified in ig-data folder
   loadCustomResources(path.join(input, 'ig-data', 'input'), defs);
-  if (isIgPubContext) {
+  if (isIgPubContext && !fs.existsSync(path.join(input, 'ig-data'))) {
     loadCustomResources(path.join(input, '..', 'input'), defs);
   }
 

--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -170,10 +170,10 @@ export function cleanCachedPackage(packageDirectory: string): void {
 
 /**
  * Loads custom resources defined in ig-data into FHIRDefs
- * @param {string} input - The input path to the cli
+ * @param {string} resourceDir - The path to the directory containing the resource subdirs
  * @param {FHIRDefinitions} defs - The FHIRDefinitions object to load definitions into
  */
-export function loadCustomResources(input: string, defs: FHIRDefinitions): void {
+export function loadCustomResources(resourceDir: string, defs: FHIRDefinitions): void {
   // Similar code for loading custom resources exists in IGExporter.ts addPredefinedResources()
   const pathEnds = [
     'capabilities',
@@ -188,7 +188,7 @@ export function loadCustomResources(input: string, defs: FHIRDefinitions): void 
   const converter = new FHIRConverter();
   for (const pathEnd of pathEnds) {
     let invalidFile = false;
-    const dirPath = path.join(input, 'ig-data', 'input', pathEnd);
+    const dirPath = path.join(resourceDir, pathEnd);
     if (fs.existsSync(dirPath)) {
       const files = fs.readdirSync(dirPath);
       for (const file of files) {

--- a/test/fhirdefs/load.test.ts
+++ b/test/fhirdefs/load.test.ts
@@ -317,7 +317,13 @@ describe('#loadCustomResources', () => {
   let defs: FHIRDefinitions;
   beforeAll(() => {
     defs = new FHIRDefinitions();
-    const fixtures = path.join(__dirname, 'fixtures', 'customized-ig-with-resources');
+    const fixtures = path.join(
+      __dirname,
+      'fixtures',
+      'customized-ig-with-resources',
+      'ig-data',
+      'input'
+    );
     loadCustomResources(fixtures, defs);
   });
 

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -817,7 +817,7 @@ describe('IGExporter', () => {
         defs
       );
       fixtures = path.join(__dirname, 'fixtures', 'customized-ig-with-resources');
-      loadCustomResources(fixtures, defs);
+      loadCustomResources(path.join(fixtures, 'ig-data', 'input'), defs);
     });
 
     beforeEach(() => {


### PR DESCRIPTION
This makes it so SUSHI will also search the IG folders for BYO-JSON/XML. This content only gets loaded in so that it can be used in the FSH definitions, it does not get copied over.

Since this is a part of the larger new IG Publisher integration, we can merge this into a feature branch that can then be merged into master at once.

I actually think that some of the concerns I had about loading definitions from the output folders of SUSHI weren't really a problem. If you run SUSHI and generate files into the IG Publisher folders, then on the next run of SUSHI you will load those in, since we don't have a `generated` folder yet, but this doesn't actually seem to be an issue. SUSHI prefers stuff defined in FSH to BYO-JSON/XML, and it doesn't do checks for duplicate definitions with BYO-JSON/XML content, so the generated definitions are just loaded in and then never used.