### PR TITLE
Do not inherit summary extension

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -43,7 +43,8 @@ const UNINHERITED_EXTENSIONS = [
   'http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version',
   'http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name',
   'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
-  'http://hl7.org/fhir/StructureDefinition/structuredefinition-wg'
+  'http://hl7.org/fhir/StructureDefinition/structuredefinition-wg',
+  'http://hl7.org/fhir/StructureDefinition/structuredefinition-summary'
 ];
 
 /**


### PR DESCRIPTION
Fixes https://github.com/FHIR/sushi/issues/582 by adding the summary extension to the list of extensions to not inherit.