### PR TITLE
Improve 'IG Publisher mode' messages

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -31,7 +31,7 @@ export function findInputDir(input: string): string {
   const fshSubdirectoryPath = path.join(input, 'fsh');
   if (fs.existsSync(fshSubdirectoryPath)) {
     input = path.join(input, 'fsh');
-    logger.info('fsh/ subdirectory detected and add to input path');
+    logger.info('fsh/ subdirectory detected and added to input path');
   }
   return input;
 }
@@ -39,7 +39,10 @@ export function findInputDir(input: string): string {
 export function ensureOutputDir(input: string, output: string, isIgPubContext: boolean): string {
   if (isIgPubContext) {
     logger.info(
-      'Current FSH tank conforms to an IG Publisher context. Output will be adjusted accordingly.'
+      'SUSHI detected a "fsh" directory in the input path. As a result, SUSHI will operate in "IG Publisher integration" mode. This means:\n' +
+        '  - the "fsh" directory will be used as the input path\n' +
+        '  - the parent of the "fsh" directory (e.g., "../fsh") will be used as the output path unless otherwise specified with --out option\n' +
+        '  - generation of publisher-related scripts will be suppressed (i.e., assumed to be managed by you)'
     );
   }
   let outDir = output;

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -31,7 +31,6 @@ export function findInputDir(input: string): string {
   const fshSubdirectoryPath = path.join(input, 'fsh');
   if (fs.existsSync(fshSubdirectoryPath)) {
     input = path.join(input, 'fsh');
-    logger.info('fsh/ subdirectory detected and added to input path');
   }
   return input;
 }


### PR DESCRIPTION
This PR fixes #555 by improving the generic message that is logged when SUSHI encounters a `fsh/` directory and is in "IG Publisher mode."

I used the message that @cmoesel suggested on the issue, but made a small adjustment to include that the output folder can also be specified by the `--out` option.

One additional question I have that I wanted a second opinion on before changing is around the additional messages that are logged when we adjust the input and output paths. Right now, when the input path needs to be adjusted and we don't specify an output path, the following messages are logged in this order:

```
info  fsh/ subdirectory detected and added to input path
info  SUSHI detected a "fsh" directory in the input path. As a result, SUSHI will operate in "IG Publisher integration" mode. This means:
  - the "fsh" directory will be used as the input path
  - the parent of the "fsh" directory (e.g., "../fsh") will be used as the output path unless otherwise specified with --out option
  - generation of publisher-related scripts will be suppressed (i.e., assumed to be managed by you)
info  No output path specified. Output to ../sample-fsh-tanks/publisher-test
```
Do you think the first and third message are now unnecessary with the improved second message? Or do they seem helpful still? If so, it might make more sense to have the second, detailed message come first, and then have the first and third message come after if they are applicable. Before switching that around though, I wanted to know what other people thought.