### PR TITLE
Support FSH definitions in input/fsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Options:
 Additional information:
   [path-to-fsh-defs]
     Default: "."
-    If fsh/ subdirectory present, it is included in [path-to-fsh-defs]
+    If input/fsh/ subdirectory present, it is included in [path-to-fsh-defs]
   -o, --out <out>
     Default: "build"
-    If fsh/ subdirectory present, default output is one directory above fsh/
+    If input/fsh/ subdirectory present, default output is one directory above fsh/
 ```
 
 # IG Generation

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,10 +46,12 @@ async function app() {
       console.log('Additional information:');
       console.log('  [path-to-fsh-defs]');
       console.log('    Default: "."');
-      console.log('    If fsh/ subdirectory present, it is included in [path-to-fsh-defs]');
+      console.log('    If input/fsh/ subdirectory present, it is included in [path-to-fsh-defs]');
       console.log('  -o, --out <out>');
       console.log('    Default: "build"');
-      console.log('    If fsh/ subdirectory present, default output is one directory above fsh/');
+      console.log(
+        '    If input/fsh/ subdirectory present, default output is one directory above fsh/'
+      );
     })
     .arguments('[path-to-fsh-defs]')
     .action(function (pathToFshDefs) {
@@ -67,8 +69,11 @@ async function app() {
 
   input = findInputDir(input);
 
-  // If a fsh subdirectory is used, we are in an IG Publisher context
-  const isIgPubContext = path.parse(input).base === 'fsh';
+  // If an input/fsh subdirectory is used, we are in an IG Publisher context
+  const fshFolder = path.parse(input).base === 'fsh';
+  const inputFshFolder = fshFolder && path.parse(input).dir.endsWith(`${path.sep}input`);
+  // TODO: Legacy support for top level fsh/ subdirectory. When no longer supporting, update to const isIgPubContext = inputFshFolder;
+  const isIgPubContext = fshFolder || inputFshFolder;
   const outDir = ensureOutputDir(input, program.out, isIgPubContext);
 
   let config: Configuration;

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -39,8 +39,8 @@ export function findInputDir(input: string): string {
   if (!fs.existsSync(inputFshSubdirectoryPath) && fs.existsSync(fshSubdirectoryPath)) {
     input = path.join(input, 'fsh');
     logger.warn(
-      'SUSHI detected a "fsh" directory that will be used in the input path. \n' +
-        'The top level "fsh" directory is being deprecated. FSH definitions in \n' +
+      'SUSHI detected a "fsh" directory that will be used in the input path. ' +
+        'The top level "fsh" directory is being deprecated. FSH definitions in ' +
         '"fsh" should be moved to "input/fsh".'
     );
   }

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -56,20 +56,38 @@ export function findInputDir(input: string): string {
   return input;
 }
 
-export function ensureOutputDir(input: string, output: string, isIgPubContext: boolean): string {
-  if (isIgPubContext) {
+export function ensureOutputDir(
+  input: string,
+  output: string,
+  isIgPubContext: boolean,
+  isLegacyIgPubContext: boolean
+): string {
+  if (isIgPubContext || isLegacyIgPubContext) {
     // TODO: Message includes information about legacy support for top level fsh folder. Remove when not supported.
+    let directory = 'fsh';
+    let article = 'a';
+    let parentDirectory = 'fsh';
+    if (isIgPubContext) {
+      directory = 'input/fsh';
+      article = 'an';
+      parentDirectory = 'input';
+    }
     logger.info(
-      'SUSHI detected an "input/fsh" or "fsh" directory in the input path. As a result, SUSHI will operate in "IG Publisher integration" mode. This means:\n' +
-        '  - the "input/fsh" or "fsh" directory will be used as the input path\n' +
-        '  - the parent of the "fsh" directory (e.g., "../fsh") will be used as the output path unless otherwise specified with --out option\n' +
+      `SUSHI detected ${article} "${directory}" directory in the input path. As a result, SUSHI will operate in "IG Publisher integration" mode. This means:\n` +
+        `  - the "${directory}" directory will be used as the input path\n` +
+        `  - the parent of the "${parentDirectory}" directory will be used as the output path unless otherwise specified with --out option\n` +
         '  - generation of publisher-related scripts will be suppressed (i.e., assumed to be managed by you)'
     );
   }
   let outDir = output;
-  if (isIgPubContext && !output) {
-    // When running in an IG Publisher context, default output is the parent folder of the tank
+  if (isLegacyIgPubContext && !output) {
+    // TODO: Legacy support for top level "fsh" directory. Remove when no longer supported.
+    // When running in a legacy IG Publisher context, default output is the parent folder of the tank
     outDir = path.join(input, '..');
+    logger.info(`No output path specified. Output to ${outDir}`);
+  } else if (isIgPubContext && !output) {
+    // When running in an IG Publisher context, default output is the parent folder of the input/fsh folder
+    outDir = path.join(input, '..', '..');
     logger.info(`No output path specified. Output to ${outDir}`);
   } else if (!output) {
     // Any other time, default output is just to 'build'
@@ -160,13 +178,19 @@ export function fillTank(rawFSHes: RawFSH[], config: Configuration): FSHTank {
   return new FSHTank(docs, config);
 }
 
-export function writeFHIRResources(outDir: string, outPackage: Package, snapshot: boolean) {
+export function writeFHIRResources(
+  outDir: string,
+  outPackage: Package,
+  snapshot: boolean,
+  useGeneratedFolder: boolean
+) {
   logger.info('Exporting FHIR resources as JSON...');
   let count = 0;
   const writeResources = (
     folder: string,
     resources: { getFileName: () => string; toJSON: (snapshot: boolean) => any }[]
   ) => {
+    folder = useGeneratedFolder ? 'generated' : folder;
     const exportDir = path.join(outDir, 'input', folder);
     resources.forEach(resource => {
       fs.outputJSONSync(path.join(exportDir, resource.getFileName()), resource.toJSON(snapshot), {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -27,19 +27,30 @@ export function findInputDir(input: string): string {
     logger.info('path-to-fsh-defs defaulted to current working directory');
   }
 
+  // TODO: Legacy support. Remove when no longer supported.
   // Use fsh/ subdirectory if not already specified and present
   const fshSubdirectoryPath = path.join(input, 'fsh');
   if (fs.existsSync(fshSubdirectoryPath)) {
     input = path.join(input, 'fsh');
-    logger.info('fsh/ subdirectory detected and add to input path');
+    return input;
+  }
+
+  // Use input/fsh/ subdirectory if not already specified and present
+  const inputFshSubdirectoryPath = path.join(input, 'input', 'fsh');
+  if (fs.existsSync(inputFshSubdirectoryPath)) {
+    input = path.join(input, 'input', 'fsh');
   }
   return input;
 }
 
 export function ensureOutputDir(input: string, output: string, isIgPubContext: boolean): string {
   if (isIgPubContext) {
+    // TODO: Message includes information about legacy support for top level fsh folder. Remove when not supported.
     logger.info(
-      'Current FSH tank conforms to an IG Publisher context. Output will be adjusted accordingly.'
+      'SUSHI detected an "input/fsh" or "fsh" directory in the input path. As a result, SUSHI will operate in "IG Publisher integration" mode. This means:\n' +
+        '  - the "input/fsh" or "fsh" directory will be used as the input path\n' +
+        '  - the parent of the "fsh" directory (e.g., "../fsh") will be used as the output path unless otherwise specified with --out option\n' +
+        '  - generation of publisher-related scripts will be suppressed (i.e., assumed to be managed by you)'
     );
   }
   let outDir = output;

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -40,8 +40,17 @@ export function findInputDir(input: string): string {
     input = path.join(input, 'fsh');
     logger.warn(
       'SUSHI detected a "fsh" directory that will be used in the input path. ' +
-        'The top level "fsh" directory is being deprecated. FSH definitions in ' +
-        '"fsh" should be moved to "input/fsh".'
+        'Use of this folder is deprecated and will be removed in a future release. ' +
+        'To migrate to the new folder structure the following changes are needed:\n' +
+        `  - sushi-config.yaml moves to ${path.resolve(
+          input,
+          '..',
+          'input',
+          'fsh',
+          'sushi-config.yaml'
+        )}\n` +
+        `  - ig-data/* files move to ${path.resolve(input, '..')}${path.sep}*\n` +
+        `  - .fsh files move to ${path.resolve(input, 'input', 'fsh')}${path.sep}*`
     );
   }
   return input;

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -28,17 +28,21 @@ export function findInputDir(input: string): string {
   }
 
   // TODO: Legacy support. Remove when no longer supported.
-  // Use fsh/ subdirectory if not already specified and present
-  const fshSubdirectoryPath = path.join(input, 'fsh');
-  if (fs.existsSync(fshSubdirectoryPath)) {
-    input = path.join(input, 'fsh');
-    return input;
-  }
-
   // Use input/fsh/ subdirectory if not already specified and present
   const inputFshSubdirectoryPath = path.join(input, 'input', 'fsh');
   if (fs.existsSync(inputFshSubdirectoryPath)) {
     input = path.join(input, 'input', 'fsh');
+  }
+
+  // Use fsh/ subdirectory if not already specified and present
+  const fshSubdirectoryPath = path.join(input, 'fsh');
+  if (!fs.existsSync(inputFshSubdirectoryPath) && fs.existsSync(fshSubdirectoryPath)) {
+    input = path.join(input, 'fsh');
+    logger.warn(
+      'SUSHI detected a "fsh" directory that will be used in the input path. \n' +
+        'The top level "fsh" directory is being deprecated. FSH definitions in \n' +
+        '"fsh" should be moved to "input/fsh".'
+    );
   }
   return input;
 }

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -88,23 +88,32 @@ describe('Processing', () => {
     it('should use and create the output directory when it is provided', () => {
       const input = path.join(tempRoot, 'my-input');
       const output = path.join(tempRoot, 'my-output');
-      const igContextOutputDir = ensureOutputDir(input, output, true);
-      const nonIgContextOutputDir = ensureOutputDir(input, output, false);
+      const legacyIgContextOutputDir = ensureOutputDir(input, output, false, true);
+      const igContextOutputDir = ensureOutputDir(input, output, true, false);
+      const nonIgContextOutputDir = ensureOutputDir(input, output, false, false);
       expect(igContextOutputDir).toBe(output);
       expect(nonIgContextOutputDir).toBe(output);
+      expect(legacyIgContextOutputDir).toBe(output);
       expect(fs.existsSync(output)).toBeTruthy();
     });
 
     it('should default the output directory to "build" when not running in IG Publisher context', () => {
       const input = path.join(tempRoot, 'my-input');
-      const outputDir = ensureOutputDir(input, undefined, false);
+      const outputDir = ensureOutputDir(input, undefined, false, false);
       expect(outputDir).toBe('build');
       expect(fs.existsSync(outputDir)).toBeTruthy();
     });
 
-    it('should default the output directory to the parent of the input when running in IG Publisher context', () => {
+    it('should default the output directory to the parent of the input when running in legacy IG Publisher context', () => {
       const input = path.join(tempRoot, 'my-input');
-      const outputDir = ensureOutputDir(input, undefined, true);
+      const outputDir = ensureOutputDir(input, undefined, false, true);
+      expect(outputDir).toBe(tempRoot);
+      expect(fs.existsSync(outputDir)).toBeTruthy();
+    });
+
+    it('should default the output directory to the grandparent of the input when running in IG Publisher context', () => {
+      const input = path.join(tempRoot, 'my-input', 'my-fsh');
+      const outputDir = ensureOutputDir(input, undefined, true, false);
       expect(outputDir).toBe(tempRoot);
       expect(fs.existsSync(outputDir)).toBeTruthy();
     });
@@ -270,10 +279,12 @@ describe('Processing', () => {
 
   describe('#writeFHIRResources()', () => {
     let tempRoot: string;
+    let tempIGPubRoot: string;
     let outPackage: Package;
 
     beforeAll(() => {
       tempRoot = temp.mkdirSync('output-dir');
+      tempIGPubRoot = temp.mkdirSync('output-ig-dir');
       const input = path.join(__dirname, 'fixtures', 'valid-yaml');
       const config = readConfig(input);
       outPackage = new Package(config);
@@ -336,83 +347,121 @@ describe('Processing', () => {
         myProfileInstance,
         myOtherInstance
       );
-      writeFHIRResources(tempRoot, outPackage, false);
     });
 
     afterAll(() => {
       temp.cleanupSync();
     });
 
-    it('should write profiles and profile instances to the "profiles" directory', () => {
-      const profilesPath = path.join(tempRoot, 'input', 'profiles');
-      expect(fs.existsSync(profilesPath)).toBeTruthy();
-      const profilesFiles = fs.readdirSync(profilesPath);
-      expect(profilesFiles.length).toBe(2);
-      expect(profilesFiles).toContain('StructureDefinition-my-profile.json');
-      expect(profilesFiles).toContain('StructureDefinition-my-profile-instance.json');
+    describe('IG Publisher mode and flat tank', () => {
+      beforeAll(() => {
+        writeFHIRResources(tempIGPubRoot, outPackage, false, true);
+      });
+
+      afterAll(() => {
+        temp.cleanupSync();
+      });
+
+      it('should write all resources to the "generated" directory', () => {
+        const generatedPath = path.join(tempIGPubRoot, 'input', 'generated');
+        expect(fs.existsSync(generatedPath)).toBeTruthy();
+        const allGeneratedFiles = fs.readdirSync(generatedPath);
+        expect(allGeneratedFiles.length).toBe(12);
+        expect(allGeneratedFiles).toContain('StructureDefinition-my-profile.json');
+        expect(allGeneratedFiles).toContain('StructureDefinition-my-profile-instance.json');
+        expect(allGeneratedFiles).toContain('StructureDefinition-my-extension.json');
+        expect(allGeneratedFiles).toContain('StructureDefinition-my-extension-instance.json');
+        expect(allGeneratedFiles).toContain('ValueSet-my-value-set.json');
+        expect(allGeneratedFiles).toContain('CodeSystem-my-code-system.json');
+        expect(allGeneratedFiles).toContain('ConceptMap-my-concept-map.json');
+        expect(allGeneratedFiles).toContain('Observation-my-example.json');
+        expect(allGeneratedFiles).toContain('CapabilityStatement-my-capabilities.json');
+        expect(allGeneratedFiles).toContain('StructureDefinition-my-model.json');
+        expect(allGeneratedFiles).toContain('OperationDefinition-my-operation.json');
+        expect(allGeneratedFiles).toContain('Observation-my-other-instance.json');
+      });
     });
 
-    it('should write extensions and extension instances to the "extensions" directory', () => {
-      const extensionsPath = path.join(tempRoot, 'input', 'extensions');
-      expect(fs.existsSync(extensionsPath)).toBeTruthy();
-      const extensionsFiles = fs.readdirSync(extensionsPath);
-      expect(extensionsFiles.length).toBe(2);
-      expect(extensionsFiles).toContain('StructureDefinition-my-extension.json');
-      expect(extensionsFiles).toContain('StructureDefinition-my-extension-instance.json');
-    });
+    describe('legacy IG Publisher mode', () => {
+      beforeAll(() => {
+        writeFHIRResources(tempRoot, outPackage, false, false);
+      });
 
-    it('should write value sets, code systems, and vocabulary instances to the "vocabulary" directory', () => {
-      const vocabularyPath = path.join(tempRoot, 'input', 'vocabulary');
-      expect(fs.existsSync(vocabularyPath)).toBeTruthy();
-      const vocabularyFiles = fs.readdirSync(vocabularyPath);
-      expect(vocabularyFiles.length).toBe(3);
-      expect(vocabularyFiles).toContain('ValueSet-my-value-set.json');
-      expect(vocabularyFiles).toContain('CodeSystem-my-code-system.json');
-      expect(vocabularyFiles).toContain('ConceptMap-my-concept-map.json');
-    });
+      afterAll(() => {
+        temp.cleanupSync();
+      });
 
-    it('should write example instances to the "examples" directory', () => {
-      const examplesPath = path.join(tempRoot, 'input', 'examples');
-      expect(fs.existsSync(examplesPath)).toBeTruthy();
-      const examplesFiles = fs.readdirSync(examplesPath);
-      expect(examplesFiles.length).toBe(1);
-      expect(examplesFiles).toContain('Observation-my-example.json');
-    });
+      it('should write profiles and profile instances to the "profiles" directory', () => {
+        const profilesPath = path.join(tempRoot, 'input', 'profiles');
+        expect(fs.existsSync(profilesPath)).toBeTruthy();
+        const profilesFiles = fs.readdirSync(profilesPath);
+        expect(profilesFiles.length).toBe(2);
+        expect(profilesFiles).toContain('StructureDefinition-my-profile.json');
+        expect(profilesFiles).toContain('StructureDefinition-my-profile-instance.json');
+      });
 
-    it('should write capability instances to the "capabilities" directory', () => {
-      const capabilitiesPath = path.join(tempRoot, 'input', 'capabilities');
-      expect(fs.existsSync(capabilitiesPath)).toBeTruthy();
-      const capabilitiesFiles = fs.readdirSync(capabilitiesPath);
-      expect(capabilitiesFiles.length).toBe(1);
-      expect(capabilitiesFiles).toContain('CapabilityStatement-my-capabilities.json');
-    });
+      it('should write extensions and extension instances to the "extensions" directory', () => {
+        const extensionsPath = path.join(tempRoot, 'input', 'extensions');
+        expect(fs.existsSync(extensionsPath)).toBeTruthy();
+        const extensionsFiles = fs.readdirSync(extensionsPath);
+        expect(extensionsFiles.length).toBe(2);
+        expect(extensionsFiles).toContain('StructureDefinition-my-extension.json');
+        expect(extensionsFiles).toContain('StructureDefinition-my-extension-instance.json');
+      });
 
-    it('should write model instances to the "models" directory', () => {
-      const modelsPath = path.join(tempRoot, 'input', 'models');
-      expect(fs.existsSync(modelsPath)).toBeTruthy();
-      const modelsFiles = fs.readdirSync(modelsPath);
-      expect(modelsFiles.length).toBe(1);
-      expect(modelsFiles).toContain('StructureDefinition-my-model.json');
-    });
+      it('should write value sets, code systems, and vocabulary instances to the "vocabulary" directory', () => {
+        const vocabularyPath = path.join(tempRoot, 'input', 'vocabulary');
+        expect(fs.existsSync(vocabularyPath)).toBeTruthy();
+        const vocabularyFiles = fs.readdirSync(vocabularyPath);
+        expect(vocabularyFiles.length).toBe(3);
+        expect(vocabularyFiles).toContain('ValueSet-my-value-set.json');
+        expect(vocabularyFiles).toContain('CodeSystem-my-code-system.json');
+        expect(vocabularyFiles).toContain('ConceptMap-my-concept-map.json');
+      });
 
-    it('should write operation instances to the "operations" directory', () => {
-      const operationsPath = path.join(tempRoot, 'input', 'operations');
-      expect(fs.existsSync(operationsPath)).toBeTruthy();
-      const operationsFiles = fs.readdirSync(operationsPath);
-      expect(operationsFiles.length).toBe(1);
-      expect(operationsFiles).toContain('OperationDefinition-my-operation.json');
-    });
+      it('should write example instances to the "examples" directory', () => {
+        const examplesPath = path.join(tempRoot, 'input', 'examples');
+        expect(fs.existsSync(examplesPath)).toBeTruthy();
+        const examplesFiles = fs.readdirSync(examplesPath);
+        expect(examplesFiles.length).toBe(1);
+        expect(examplesFiles).toContain('Observation-my-example.json');
+      });
 
-    it('should write all other non-inline instances to the "resources" directory', () => {
-      const resourcesPath = path.join(tempRoot, 'input', 'resources');
-      expect(fs.existsSync(resourcesPath)).toBeTruthy();
-      const resourcesFiles = fs.readdirSync(resourcesPath);
-      expect(resourcesFiles.length).toBe(1);
-      expect(resourcesFiles).toContain('Observation-my-other-instance.json');
-    });
+      it('should write capability instances to the "capabilities" directory', () => {
+        const capabilitiesPath = path.join(tempRoot, 'input', 'capabilities');
+        expect(fs.existsSync(capabilitiesPath)).toBeTruthy();
+        const capabilitiesFiles = fs.readdirSync(capabilitiesPath);
+        expect(capabilitiesFiles.length).toBe(1);
+        expect(capabilitiesFiles).toContain('CapabilityStatement-my-capabilities.json');
+      });
 
-    it('should write an info message with the number of instances exported', () => {
-      expect(loggerSpy.getLastMessage('info')).toMatch(/Exported 12 FHIR resources/s);
+      it('should write model instances to the "models" directory', () => {
+        const modelsPath = path.join(tempRoot, 'input', 'models');
+        expect(fs.existsSync(modelsPath)).toBeTruthy();
+        const modelsFiles = fs.readdirSync(modelsPath);
+        expect(modelsFiles.length).toBe(1);
+        expect(modelsFiles).toContain('StructureDefinition-my-model.json');
+      });
+
+      it('should write operation instances to the "operations" directory', () => {
+        const operationsPath = path.join(tempRoot, 'input', 'operations');
+        expect(fs.existsSync(operationsPath)).toBeTruthy();
+        const operationsFiles = fs.readdirSync(operationsPath);
+        expect(operationsFiles.length).toBe(1);
+        expect(operationsFiles).toContain('OperationDefinition-my-operation.json');
+      });
+
+      it('should write all other non-inline instances to the "resources" directory', () => {
+        const resourcesPath = path.join(tempRoot, 'input', 'resources');
+        expect(fs.existsSync(resourcesPath)).toBeTruthy();
+        const resourcesFiles = fs.readdirSync(resourcesPath);
+        expect(resourcesFiles.length).toBe(1);
+        expect(resourcesFiles).toContain('Observation-my-other-instance.json');
+      });
+
+      it('should write an info message with the number of instances exported', () => {
+        expect(loggerSpy.getLastMessage('info')).toMatch(/Exported 12 FHIR resources/s);
+      });
     });
   });
 

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -49,7 +49,7 @@ describe('Processing', () => {
       const foundInput = findInputDir(input);
       expect(foundInput).toBe(path.join(tempRoot, 'has-fsh', 'fsh'));
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /top level "fsh" directory is being deprecated/s
+        /Use of this folder is deprecated and will be removed in a future release/s
       );
     });
 

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -27,8 +27,10 @@ describe('Processing', () => {
 
     beforeAll(() => {
       tempRoot = temp.mkdirSync('sushi-test');
-      fs.mkdirpSync(path.join(tempRoot, 'has-fsh', 'fsh')); // TODO: Legacy support. Remove when no longer supported.
+      fs.mkdirpSync(path.join(tempRoot, 'has-fsh', 'fsh')); // TODO: Tests legacy support. Remove when no longer supported.
       fs.mkdirpSync(path.join(tempRoot, 'has-input-fsh', 'input', 'fsh'));
+      fs.mkdirpSync(path.join(tempRoot, 'has-fsh-and-input-fsh', 'fsh')); // TODO: Tests legacy support. Remove when no longer supported.
+      fs.mkdirpSync(path.join(tempRoot, 'has-fsh-and-input-fsh', 'input', 'fsh'));
       fs.mkdirSync(path.join(tempRoot, 'no-fsh'));
     });
 
@@ -41,17 +43,27 @@ describe('Processing', () => {
       expect(foundInput).toBe('.');
     });
 
-    // TODO: Legacy support. Remove when no longer supported.
+    // TODO: Tests legacy support. Remove when no longer supported.
     it('should find a path to the fsh subdirectory if present', () => {
       const input = path.join(tempRoot, 'has-fsh');
       const foundInput = findInputDir(input);
       expect(foundInput).toBe(path.join(tempRoot, 'has-fsh', 'fsh'));
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /top level "fsh" directory is being deprecated/s
+      );
     });
 
     it('should find a path to the input/fsh subdirectory if present', () => {
       const input = path.join(tempRoot, 'has-input-fsh');
       const foundInput = findInputDir(input);
       expect(foundInput).toBe(path.join(tempRoot, 'has-input-fsh', 'input', 'fsh'));
+    });
+
+    // TODO: Tests legacy support. Remove when no longer supported.
+    it('should prefer path to input/fsh over fsh/ if both present', () => {
+      const input = path.join(tempRoot, 'has-fsh-and-input-fsh');
+      const foundInput = findInputDir(input);
+      expect(foundInput).toBe(path.join(tempRoot, 'has-fsh-and-input-fsh', 'input', 'fsh'));
     });
 
     it('should find a path to the provided directory if the fsh subdirectory is not present', () => {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -27,7 +27,8 @@ describe('Processing', () => {
 
     beforeAll(() => {
       tempRoot = temp.mkdirSync('sushi-test');
-      fs.mkdirpSync(path.join(tempRoot, 'has-fsh', 'fsh'));
+      fs.mkdirpSync(path.join(tempRoot, 'has-fsh', 'fsh')); // TODO: Legacy support. Remove when no longer supported.
+      fs.mkdirpSync(path.join(tempRoot, 'has-input-fsh', 'input', 'fsh'));
       fs.mkdirSync(path.join(tempRoot, 'no-fsh'));
     });
 
@@ -40,10 +41,17 @@ describe('Processing', () => {
       expect(foundInput).toBe('.');
     });
 
+    // TODO: Legacy support. Remove when no longer supported.
     it('should find a path to the fsh subdirectory if present', () => {
       const input = path.join(tempRoot, 'has-fsh');
       const foundInput = findInputDir(input);
       expect(foundInput).toBe(path.join(tempRoot, 'has-fsh', 'fsh'));
+    });
+
+    it('should find a path to the input/fsh subdirectory if present', () => {
+      const input = path.join(tempRoot, 'has-input-fsh');
+      const foundInput = findInputDir(input);
+      expect(foundInput).toBe(path.join(tempRoot, 'has-input-fsh', 'input', 'fsh'));
     });
 
     it('should find a path to the provided directory if the fsh subdirectory is not present', () => {


### PR DESCRIPTION
This PR completes [CIMPL-508](https://standardhealthrecord.atlassian.net/browse/CIMPL-508). It adds support for reading FSH definitions from an `input/fsh` folder even if the subdirectory is not specified in the input path.

This also still maintains support for automatically reading in FSH definitions found in a `fsh/` subdirectory. I added comments to the places where we will need to remove the handling when we no longer want to support this folder. If we imagine that we just will continue to support it, I can either update or remove those comments.

There is one unintended side effect of maintaining support for both folders. Now, if we were to have a `myTank/input/fsh` folder with FSH definitions, you can run SUSHI pointing to `myTank` and we will automatically look in `myTank/input/fsh`, which is the intention of this task. However, you can also run SUSHI pointing to `myTank/input` and SUSHI will find the `fsh` folder now, but if we remove the support for that top level `fsh/` folder, that same SUSHI command will not work. I think this is okay because we aren't expecting someone with an `myTank/input/fsh` folder to be running SUSHI pointing at `input`, but I just wanted to raise it in case it was concerning to anyone else.