### PR TITLE
Include id property in user-defined groupings

### DIFF
--- a/src/fhirtypes/ImplementationGuide.ts
+++ b/src/fhirtypes/ImplementationGuide.ts
@@ -47,6 +47,7 @@ export type ImplementationGuideDefinition = {
 };
 
 export type ImplementationGuideDefinitionGrouping = {
+  id: string;
   name: string;
   description?: string;
 };

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -1024,6 +1024,7 @@ export class IGExporter {
       }
     } else {
       this.ig.definition.grouping.push({
+        id: name,
         name: name,
         ...(description && { description })
       });

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -460,8 +460,14 @@ describe('IGExporter', () => {
       expect(fs.existsSync(igPath)).toBeTruthy();
       const content = fs.readJSONSync(igPath);
       expect(content.definition.grouping).toHaveLength(2);
-      expect(content.definition.grouping).toContainEqual({ name: 'MyPatientGroup' });
-      expect(content.definition.grouping).toContainEqual({ name: 'MyObservationGroup' });
+      expect(content.definition.grouping).toContainEqual({
+        id: 'MyPatientGroup',
+        name: 'MyPatientGroup'
+      });
+      expect(content.definition.grouping).toContainEqual({
+        id: 'MyObservationGroup',
+        name: 'MyObservationGroup'
+      });
     });
 
     it('should create groups for each configured group', () => {
@@ -482,10 +488,12 @@ describe('IGExporter', () => {
       expect(fs.existsSync(igPath)).toBeTruthy();
       const content = fs.readJSONSync(igPath);
       expect(content.definition.grouping).toContainEqual({
+        id: 'MyPatientGroup',
         name: 'MyPatientGroup',
         description: 'Group for some patient-related things.'
       });
       expect(content.definition.grouping).toContainEqual({
+        id: 'MyObservationGroup',
         name: 'MyObservationGroup',
         description: 'Group for some observation-related things.'
       });


### PR DESCRIPTION
Currently SUSHI sets only `name` and (optionally) `description` for user-defined groups when generating `ImplementationGuide-*.json`.

The IG publisher expects there to also be an `id` property, like so:

```js
...
  "definition": {
    "grouping": [
      {
        "id": "Group name goes here", // <----- this is what this PR adds in
        "name": "Group name goes here",
        "description": "Some description.."
      }
    ],
...
```

Without this `id` property, the user-defined group will not show up in the `artifacts.html` file built by the IG. When this property is defined, the group and associated resources appear in `artifacts.html` as expected.

A few things that are known to be wrong/broken with this PR:

- There's not a way to actually set the `id` property separately from `name`. This would require monkeying around with `config.yaml`. It may make sense to make the following change:

    ```yaml
    # Current format
    groups:
      GroupA:
        description: The Alpha Group
        resources:
        - StructureDefinition/animal-patient
        - StructureDefinition/arm-procedure

    # Proposed change
    groups:
      GroupIdGoesHere:
        name: Group name goes here
        description: The Alpha Group
        resources:
        - StructureDefinition/animal-patient
        - StructureDefinition/arm-procedure
    ```

- There are two failing tests (at least locally).

I'm not experienced enough with the SUSHI codebase to fix these problems independently efficiently, but I'm happy to pair with someone to work on this (or feel free to make your own changes).