### PR TITLE
Support output to input/generated

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -55,11 +55,18 @@ export function ensureOutputDir(
 ): string {
   if (isIgPubContext || isLegacyIgPubContext) {
     // TODO: Message includes information about legacy support for top level fsh folder. Remove when not supported.
-    const directory = isIgPubContext ? 'input/fsh' : 'fsh';
+    let directory = 'fsh';
+    let article = 'a';
+    let parentDirectory = 'fsh';
+    if (isIgPubContext) {
+      directory = 'input/fsh';
+      article = 'an';
+      parentDirectory = 'input';
+    }
     logger.info(
-      `SUSHI detected an "${directory}" directory in the input path. As a result, SUSHI will operate in "IG Publisher integration" mode. This means:\n` +
+      `SUSHI detected ${article} "${directory}" directory in the input path. As a result, SUSHI will operate in "IG Publisher integration" mode. This means:\n` +
         `  - the "${directory}" directory will be used as the input path\n` +
-        `  - the parent of the "${directory}" directory will be used as the output path unless otherwise specified with --out option\n` +
+        `  - the parent of the "${parentDirectory}" directory will be used as the output path unless otherwise specified with --out option\n` +
         '  - generation of publisher-related scripts will be suppressed (i.e., assumed to be managed by you)'
     );
   }
@@ -70,7 +77,7 @@ export function ensureOutputDir(
     outDir = path.join(input, '..');
     logger.info(`No output path specified. Output to ${outDir}`);
   } else if (isIgPubContext && !output) {
-    // When running in a legacy IG Publisher context, default output is the parent folder of the input/fsh folder
+    // When running in an IG Publisher context, default output is the parent folder of the input/fsh folder
     outDir = path.join(input, '..', '..');
     logger.info(`No output path specified. Output to ${outDir}`);
   } else if (!output) {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -88,23 +88,32 @@ describe('Processing', () => {
     it('should use and create the output directory when it is provided', () => {
       const input = path.join(tempRoot, 'my-input');
       const output = path.join(tempRoot, 'my-output');
-      const igContextOutputDir = ensureOutputDir(input, output, true);
-      const nonIgContextOutputDir = ensureOutputDir(input, output, false);
+      const legacyIgContextOutputDir = ensureOutputDir(input, output, false, true);
+      const igContextOutputDir = ensureOutputDir(input, output, true, false);
+      const nonIgContextOutputDir = ensureOutputDir(input, output, false, false);
       expect(igContextOutputDir).toBe(output);
       expect(nonIgContextOutputDir).toBe(output);
+      expect(legacyIgContextOutputDir).toBe(output);
       expect(fs.existsSync(output)).toBeTruthy();
     });
 
     it('should default the output directory to "build" when not running in IG Publisher context', () => {
       const input = path.join(tempRoot, 'my-input');
-      const outputDir = ensureOutputDir(input, undefined, false);
+      const outputDir = ensureOutputDir(input, undefined, false, false);
       expect(outputDir).toBe('build');
       expect(fs.existsSync(outputDir)).toBeTruthy();
     });
 
-    it('should default the output directory to the parent of the input when running in IG Publisher context', () => {
+    it('should default the output directory to the parent of the input when running in legacy IG Publisher context', () => {
       const input = path.join(tempRoot, 'my-input');
-      const outputDir = ensureOutputDir(input, undefined, true);
+      const outputDir = ensureOutputDir(input, undefined, false, true);
+      expect(outputDir).toBe(tempRoot);
+      expect(fs.existsSync(outputDir)).toBeTruthy();
+    });
+
+    it('should default the output directory to the grandparent of the input when running in IG Publisher context', () => {
+      const input = path.join(tempRoot, 'my-input', 'my-fsh');
+      const outputDir = ensureOutputDir(input, undefined, true, false);
       expect(outputDir).toBe(tempRoot);
       expect(fs.existsSync(outputDir)).toBeTruthy();
     });
@@ -270,10 +279,12 @@ describe('Processing', () => {
 
   describe('#writeFHIRResources()', () => {
     let tempRoot: string;
+    let tempIGPubRoot: string;
     let outPackage: Package;
 
     beforeAll(() => {
       tempRoot = temp.mkdirSync('output-dir');
+      tempIGPubRoot = temp.mkdirSync('output-ig-dir');
       const input = path.join(__dirname, 'fixtures', 'valid-yaml');
       const config = readConfig(input);
       outPackage = new Package(config);
@@ -336,83 +347,121 @@ describe('Processing', () => {
         myProfileInstance,
         myOtherInstance
       );
-      writeFHIRResources(tempRoot, outPackage, false);
     });
 
     afterAll(() => {
       temp.cleanupSync();
     });
 
-    it('should write profiles and profile instances to the "profiles" directory', () => {
-      const profilesPath = path.join(tempRoot, 'input', 'profiles');
-      expect(fs.existsSync(profilesPath)).toBeTruthy();
-      const profilesFiles = fs.readdirSync(profilesPath);
-      expect(profilesFiles.length).toBe(2);
-      expect(profilesFiles).toContain('StructureDefinition-my-profile.json');
-      expect(profilesFiles).toContain('StructureDefinition-my-profile-instance.json');
+    describe('IG Publisher mode and flat tank', () => {
+      beforeAll(() => {
+        writeFHIRResources(tempIGPubRoot, outPackage, false, true);
+      });
+
+      afterAll(() => {
+        temp.cleanupSync();
+      });
+
+      it('should write all resources to the "generated" directory', () => {
+        const generatedPath = path.join(tempIGPubRoot, 'input', 'generated');
+        expect(fs.existsSync(generatedPath)).toBeTruthy();
+        const allGeneratedFiles = fs.readdirSync(generatedPath);
+        expect(allGeneratedFiles.length).toBe(12);
+        expect(allGeneratedFiles).toContain('StructureDefinition-my-profile.json');
+        expect(allGeneratedFiles).toContain('StructureDefinition-my-profile-instance.json');
+        expect(allGeneratedFiles).toContain('StructureDefinition-my-extension.json');
+        expect(allGeneratedFiles).toContain('StructureDefinition-my-extension-instance.json');
+        expect(allGeneratedFiles).toContain('ValueSet-my-value-set.json');
+        expect(allGeneratedFiles).toContain('CodeSystem-my-code-system.json');
+        expect(allGeneratedFiles).toContain('ConceptMap-my-concept-map.json');
+        expect(allGeneratedFiles).toContain('Observation-my-example.json');
+        expect(allGeneratedFiles).toContain('CapabilityStatement-my-capabilities.json');
+        expect(allGeneratedFiles).toContain('StructureDefinition-my-model.json');
+        expect(allGeneratedFiles).toContain('OperationDefinition-my-operation.json');
+        expect(allGeneratedFiles).toContain('Observation-my-other-instance.json');
+      });
     });
 
-    it('should write extensions and extension instances to the "extensions" directory', () => {
-      const extensionsPath = path.join(tempRoot, 'input', 'extensions');
-      expect(fs.existsSync(extensionsPath)).toBeTruthy();
-      const extensionsFiles = fs.readdirSync(extensionsPath);
-      expect(extensionsFiles.length).toBe(2);
-      expect(extensionsFiles).toContain('StructureDefinition-my-extension.json');
-      expect(extensionsFiles).toContain('StructureDefinition-my-extension-instance.json');
-    });
+    describe('legacy IG Publisher mode', () => {
+      beforeAll(() => {
+        writeFHIRResources(tempRoot, outPackage, false, false);
+      });
 
-    it('should write value sets, code systems, and vocabulary instances to the "vocabulary" directory', () => {
-      const vocabularyPath = path.join(tempRoot, 'input', 'vocabulary');
-      expect(fs.existsSync(vocabularyPath)).toBeTruthy();
-      const vocabularyFiles = fs.readdirSync(vocabularyPath);
-      expect(vocabularyFiles.length).toBe(3);
-      expect(vocabularyFiles).toContain('ValueSet-my-value-set.json');
-      expect(vocabularyFiles).toContain('CodeSystem-my-code-system.json');
-      expect(vocabularyFiles).toContain('ConceptMap-my-concept-map.json');
-    });
+      afterAll(() => {
+        temp.cleanupSync();
+      });
 
-    it('should write example instances to the "examples" directory', () => {
-      const examplesPath = path.join(tempRoot, 'input', 'examples');
-      expect(fs.existsSync(examplesPath)).toBeTruthy();
-      const examplesFiles = fs.readdirSync(examplesPath);
-      expect(examplesFiles.length).toBe(1);
-      expect(examplesFiles).toContain('Observation-my-example.json');
-    });
+      it('should write profiles and profile instances to the "profiles" directory', () => {
+        const profilesPath = path.join(tempRoot, 'input', 'profiles');
+        expect(fs.existsSync(profilesPath)).toBeTruthy();
+        const profilesFiles = fs.readdirSync(profilesPath);
+        expect(profilesFiles.length).toBe(2);
+        expect(profilesFiles).toContain('StructureDefinition-my-profile.json');
+        expect(profilesFiles).toContain('StructureDefinition-my-profile-instance.json');
+      });
 
-    it('should write capability instances to the "capabilities" directory', () => {
-      const capabilitiesPath = path.join(tempRoot, 'input', 'capabilities');
-      expect(fs.existsSync(capabilitiesPath)).toBeTruthy();
-      const capabilitiesFiles = fs.readdirSync(capabilitiesPath);
-      expect(capabilitiesFiles.length).toBe(1);
-      expect(capabilitiesFiles).toContain('CapabilityStatement-my-capabilities.json');
-    });
+      it('should write extensions and extension instances to the "extensions" directory', () => {
+        const extensionsPath = path.join(tempRoot, 'input', 'extensions');
+        expect(fs.existsSync(extensionsPath)).toBeTruthy();
+        const extensionsFiles = fs.readdirSync(extensionsPath);
+        expect(extensionsFiles.length).toBe(2);
+        expect(extensionsFiles).toContain('StructureDefinition-my-extension.json');
+        expect(extensionsFiles).toContain('StructureDefinition-my-extension-instance.json');
+      });
 
-    it('should write model instances to the "models" directory', () => {
-      const modelsPath = path.join(tempRoot, 'input', 'models');
-      expect(fs.existsSync(modelsPath)).toBeTruthy();
-      const modelsFiles = fs.readdirSync(modelsPath);
-      expect(modelsFiles.length).toBe(1);
-      expect(modelsFiles).toContain('StructureDefinition-my-model.json');
-    });
+      it('should write value sets, code systems, and vocabulary instances to the "vocabulary" directory', () => {
+        const vocabularyPath = path.join(tempRoot, 'input', 'vocabulary');
+        expect(fs.existsSync(vocabularyPath)).toBeTruthy();
+        const vocabularyFiles = fs.readdirSync(vocabularyPath);
+        expect(vocabularyFiles.length).toBe(3);
+        expect(vocabularyFiles).toContain('ValueSet-my-value-set.json');
+        expect(vocabularyFiles).toContain('CodeSystem-my-code-system.json');
+        expect(vocabularyFiles).toContain('ConceptMap-my-concept-map.json');
+      });
 
-    it('should write operation instances to the "operations" directory', () => {
-      const operationsPath = path.join(tempRoot, 'input', 'operations');
-      expect(fs.existsSync(operationsPath)).toBeTruthy();
-      const operationsFiles = fs.readdirSync(operationsPath);
-      expect(operationsFiles.length).toBe(1);
-      expect(operationsFiles).toContain('OperationDefinition-my-operation.json');
-    });
+      it('should write example instances to the "examples" directory', () => {
+        const examplesPath = path.join(tempRoot, 'input', 'examples');
+        expect(fs.existsSync(examplesPath)).toBeTruthy();
+        const examplesFiles = fs.readdirSync(examplesPath);
+        expect(examplesFiles.length).toBe(1);
+        expect(examplesFiles).toContain('Observation-my-example.json');
+      });
 
-    it('should write all other non-inline instances to the "resources" directory', () => {
-      const resourcesPath = path.join(tempRoot, 'input', 'resources');
-      expect(fs.existsSync(resourcesPath)).toBeTruthy();
-      const resourcesFiles = fs.readdirSync(resourcesPath);
-      expect(resourcesFiles.length).toBe(1);
-      expect(resourcesFiles).toContain('Observation-my-other-instance.json');
-    });
+      it('should write capability instances to the "capabilities" directory', () => {
+        const capabilitiesPath = path.join(tempRoot, 'input', 'capabilities');
+        expect(fs.existsSync(capabilitiesPath)).toBeTruthy();
+        const capabilitiesFiles = fs.readdirSync(capabilitiesPath);
+        expect(capabilitiesFiles.length).toBe(1);
+        expect(capabilitiesFiles).toContain('CapabilityStatement-my-capabilities.json');
+      });
 
-    it('should write an info message with the number of instances exported', () => {
-      expect(loggerSpy.getLastMessage('info')).toMatch(/Exported 12 FHIR resources/s);
+      it('should write model instances to the "models" directory', () => {
+        const modelsPath = path.join(tempRoot, 'input', 'models');
+        expect(fs.existsSync(modelsPath)).toBeTruthy();
+        const modelsFiles = fs.readdirSync(modelsPath);
+        expect(modelsFiles.length).toBe(1);
+        expect(modelsFiles).toContain('StructureDefinition-my-model.json');
+      });
+
+      it('should write operation instances to the "operations" directory', () => {
+        const operationsPath = path.join(tempRoot, 'input', 'operations');
+        expect(fs.existsSync(operationsPath)).toBeTruthy();
+        const operationsFiles = fs.readdirSync(operationsPath);
+        expect(operationsFiles.length).toBe(1);
+        expect(operationsFiles).toContain('OperationDefinition-my-operation.json');
+      });
+
+      it('should write all other non-inline instances to the "resources" directory', () => {
+        const resourcesPath = path.join(tempRoot, 'input', 'resources');
+        expect(fs.existsSync(resourcesPath)).toBeTruthy();
+        const resourcesFiles = fs.readdirSync(resourcesPath);
+        expect(resourcesFiles.length).toBe(1);
+        expect(resourcesFiles).toContain('Observation-my-other-instance.json');
+      });
+
+      it('should write an info message with the number of instances exported', () => {
+        expect(loggerSpy.getLastMessage('info')).toMatch(/Exported 12 FHIR resources/s);
+      });
     });
   });
 


### PR DESCRIPTION
NOTE: This is currently has a base branch of `support-input-fsh`. If the base branch doesn't automatically update to `new-ig-publisher-integration`, I can update it once `support-input-fsh` gets merged.

This PR supports outputting to a `input/generated` folder when running SUSHI on a folder structure that supports our new IG Integration (i.e. it has an `input/fsh` folder) or when you just have a flat FSH tank (no publisher integration at all). When running SUSHI on a folder structure that supports the old IG Integration, output will be written to all the same subfolders that it does now (`input/profiles`, `input/extensions`, etc).

I've been testing this using a flat FSH tank (no `fsh` or `input/fsh` folders), the old IG publisher integration, and the new IG publisher integration. I've also tried to be sure to test each of those specifying an output directory and letting SUSHI decide the output, and having `FSHOnly` set to true and false. However, there's a very likely chance I missed something in one of those cases. I'm happy to walk through that with anyone reviewing it.