### PR TITLE
Find slices of choice elements

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -228,7 +228,11 @@ export class StructureDefinition {
           ...unfoldedElements
         ]);
         if (matchingSlice) {
-          newMatchingElements.push(matchingSlice, ...matchingSlice.children());
+          newMatchingElements.push(
+            matchingSlice,
+            ...matchingSlice.children(),
+            ...matchingSlice.getSlices()
+          );
           fhirPathString = matchingSlice.path;
         }
       }
@@ -699,22 +703,6 @@ export class StructureDefinition {
   ): ElementDefinition {
     let matchingSlice: ElementDefinition;
     matchingSlice = elements.find(e => e.sliceName === pathPart.brackets.join('/'));
-    if (!matchingSlice) {
-      // The element we're looking for may be a reslice of one of the elements to search through.
-      // So, find the original sliced element for that item in the list, and see if the reslice
-      // we're looking for already exists.
-      for (const e of elements) {
-        const connectedSliceElement = e.findConnectedSliceElement();
-        if (connectedSliceElement?.id.endsWith('[x]')) {
-          const matchingExistingSlice = connectedSliceElement
-            ?.getSlices()
-            .find(existing => existing.sliceName === [e.sliceName, ...pathPart.brackets].join('/'));
-          if (matchingExistingSlice) {
-            return matchingExistingSlice;
-          }
-        }
-      }
-    }
     if (!matchingSlice && pathPart.brackets?.length === 1) {
       // If the current element is a child of a slice, the match may exist on the original
       // sliced element, search for that here

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -697,7 +697,24 @@ export class StructureDefinition {
     elements: ElementDefinition[],
     fisher: Fishable
   ): ElementDefinition {
-    let matchingSlice = elements.find(e => e.sliceName === pathPart.brackets.join('/'));
+    let matchingSlice: ElementDefinition;
+    matchingSlice = elements.find(e => e.sliceName === pathPart.brackets.join('/'));
+    if (!matchingSlice) {
+      // The element we're looking for may be a reslice of one of the elements to search through.
+      // So, find the original sliced element for that item in the list, and see if the reslice
+      // we're looking for already exists.
+      for (const e of elements) {
+        const connectedSliceElement = e.findConnectedSliceElement();
+        if (connectedSliceElement?.id.endsWith('[x]')) {
+          const matchingExistingSlice = connectedSliceElement
+            ?.getSlices()
+            .find(existing => existing.sliceName === [e.sliceName, ...pathPart.brackets].join('/'));
+          if (matchingExistingSlice) {
+            return matchingExistingSlice;
+          }
+        }
+      }
+    }
     if (!matchingSlice && pathPart.brackets?.length === 1) {
       // If the current element is a child of a slice, the match may exist on the original
       // sliced element, search for that here


### PR DESCRIPTION
Fixes #567 and completes task [CIMPL-497](https://standardhealthrecord.atlassian.net/browse/CIMPL-497).

When a choice element is sliced, the new element is considered to be a
reslice of the choice slice. This does not line up perfectly with the
way PathParts are constructed, which would use the choice slice name
(such as `valueString`) as the PathPart's base. So, if one of the
elements to search through is a slice of a choice element, look for
other slices on that choice element when trying to find the matching
slice.