### PR TITLE
Add function which runs SUSHI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * as fshrules from './fshtypes/rules';
 export * as sushiExport from './export';
 export * as sushiImport from './import';
 export * as utils from './utils';
+export * as runSUSHI from './run';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ export * as fshrules from './fshtypes/rules';
 export * as sushiExport from './export';
 export * as sushiImport from './import';
 export * as utils from './utils';
-export * as runSUSHI from './run';
+export * as runSushi from './run';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ export * as fshrules from './fshtypes/rules';
 export * as sushiExport from './export';
 export * as sushiImport from './import';
 export * as utils from './utils';
-export * as runSushi from './run';
+export * as sushiClient from './run';

--- a/src/run/FshToFhir.ts
+++ b/src/run/FshToFhir.ts
@@ -1,5 +1,5 @@
 import { RawFSH } from '../import';
-import { exportFHIR, Package } from '../export';
+import { exportFHIR } from '../export';
 import { FHIRDefinitions } from '../fhirdefs';
 import { ImplementationGuideDependsOn } from '../fhirtypes';
 import {
@@ -14,7 +14,7 @@ export async function fshToFhir(
   input: string | string[],
   options: fshToFhirOptions = {}
 ): Promise<{
-  fhir: Package;
+  fhir: any[];
   errors: ErrorsAndWarnings['errors'];
   warnings: ErrorsAndWarnings['warnings'];
 }> {
@@ -65,9 +65,17 @@ export async function fshToFhir(
 
   // process FSH text into FHIR
   const outPackage = exportFHIR(tank, defs);
+  const fhir: any[] = [];
+  (['profiles', 'extensions', 'instances', 'valueSets', 'codeSystems'] as const).forEach(
+    artifactType => {
+      outPackage[artifactType].forEach((artifact: { toJSON: (snapshot: boolean) => any }) => {
+        fhir.push(artifact.toJSON(false));
+      });
+    }
+  );
 
   return {
-    fhir: outPackage,
+    fhir,
     errors: errorsAndWarnings.errors,
     warnings: errorsAndWarnings.warnings
   };

--- a/src/run/FshToFhir.ts
+++ b/src/run/FshToFhir.ts
@@ -1,0 +1,56 @@
+import { RawFSH } from '../import';
+import { exportFHIR, Package } from '../export';
+import { FHIRDefinitions } from '../fhirdefs';
+import { ImplementationGuideDependsOn } from '../fhirtypes';
+import { fillTank, loadExternalDependencies, logger, errorsAndWarnings } from '../utils';
+
+export async function fshToFhir(
+  input: string,
+  options: fshToFhirOptions
+): Promise<{
+  fhir: Package;
+  errors: { message: string; location: string }[];
+  warnings: { message: string; location: string }[];
+}> {
+  // track errors and warnings, and determine log level from options
+  errorsAndWarnings.shouldTrack = true;
+  if (options.logLevel == null) {
+    logger.transports[0].silent = true;
+  } else {
+    logger.level = options.logLevel;
+  }
+
+  // set up a config so that sushi can run
+  const config = {
+    canonical: options.canonical ?? 'http://example.org',
+    FSHOnly: true,
+    fhirVersion: ['4.0.1'],
+    dependencies: options.dependencies,
+    version: options.version
+  };
+
+  // load dependencies
+  const defs = new FHIRDefinitions();
+  await Promise.all(loadExternalDependencies(defs, config));
+
+  // load FSH text into memory
+  const rawFSH = [new RawFSH(input)];
+  const tank = fillTank(rawFSH, config);
+
+  // process FSH text into FHIR
+  const outPackage = exportFHIR(tank, defs);
+
+  // QUESTION: Could just convert to JSON here, not sure which is more useful
+  return {
+    fhir: outPackage,
+    errors: errorsAndWarnings.errors,
+    warnings: errorsAndWarnings.warnings
+  };
+}
+
+type fshToFhirOptions = {
+  canonical?: string;
+  version?: string;
+  dependencies?: ImplementationGuideDependsOn[];
+  logLevel?: string;
+};

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -1,0 +1,1 @@
+export * from './FshToFhir';

--- a/src/utils/FSHLogger.ts
+++ b/src/utils/FSHLogger.ts
@@ -105,10 +105,16 @@ class LoggerStats {
 
 export const stats = new LoggerStats();
 
-class ErrorsAndWarnings {
+export class ErrorsAndWarnings {
   public errors: { message: string; location: string }[] = [];
   public warnings: { message: string; location: string }[] = [];
   public shouldTrack = false;
+
+  reset(): void {
+    this.errors = [];
+    this.warnings = [];
+    this.shouldTrack = false;
+  }
 }
 
 export const errorsAndWarnings = new ErrorsAndWarnings();

--- a/src/utils/FSHLogger.ts
+++ b/src/utils/FSHLogger.ts
@@ -50,6 +50,18 @@ const incrementCounts = format(info => {
   return info;
 });
 
+const trackErrorsAndWarnings = format(info => {
+  if (!errorsAndWarnings.shouldTrack) {
+    return info;
+  }
+  if (info.level === 'error') {
+    errorsAndWarnings.errors.push({ message: info.message, location: info.location });
+  } else if (info.level === 'warn') {
+    errorsAndWarnings.warnings.push({ message: info.message, location: info.location });
+  }
+  return info;
+});
+
 const printer = printf(info => {
   let level;
   switch (info.level) {
@@ -73,7 +85,7 @@ const printer = printf(info => {
 });
 
 export const logger = createLogger({
-  format: combine(incrementCounts(), withLocation(), printer),
+  format: combine(incrementCounts(), trackErrorsAndWarnings(), withLocation(), printer),
   transports: [new transports.Console()]
 });
 
@@ -92,3 +104,11 @@ class LoggerStats {
 }
 
 export const stats = new LoggerStats();
+
+class ErrorsAndWarnings {
+  public errors: { message: string; location: string }[] = [];
+  public warnings: { message: string; location: string }[] = [];
+  public shouldTrack = false;
+}
+
+export const errorsAndWarnings = new ErrorsAndWarnings();

--- a/src/utils/FSHLogger.ts
+++ b/src/utils/FSHLogger.ts
@@ -55,9 +55,17 @@ const trackErrorsAndWarnings = format(info => {
     return info;
   }
   if (info.level === 'error') {
-    errorsAndWarnings.errors.push({ message: info.message, location: info.location });
+    errorsAndWarnings.errors.push({
+      message: info.message,
+      location: info.location,
+      input: info.file
+    });
   } else if (info.level === 'warn') {
-    errorsAndWarnings.warnings.push({ message: info.message, location: info.location });
+    errorsAndWarnings.warnings.push({
+      message: info.message,
+      location: info.location,
+      input: info.file
+    });
   }
   return info;
 });
@@ -106,8 +114,8 @@ class LoggerStats {
 export const stats = new LoggerStats();
 
 export class ErrorsAndWarnings {
-  public errors: { message: string; location: string }[] = [];
-  public warnings: { message: string; location: string }[] = [];
+  public errors: { message: string; location?: string; input?: string }[] = [];
+  public warnings: { message: string; location?: string; input?: string }[] = [];
   public shouldTrack = false;
 
   reset(): void {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -13,7 +13,7 @@ import {
 } from '../import';
 import { cloneDeep, padEnd } from 'lodash';
 import YAML from 'yaml';
-import { exportFHIR, Package } from '../export';
+import { Package } from '../export';
 import {
   filterInlineInstances,
   filterExampleInstances,
@@ -26,7 +26,6 @@ import {
 } from './InstanceDefinitionUtils';
 import { Configuration } from '../fshtypes';
 import { loadConfigurationFromIgResource } from '../import/loadConfigurationFromIgResource';
-import { ImplementationGuideDependsOn } from '../fhirtypes';
 
 export function findInputDir(input: string): string {
   // If no input folder is specified, set default to current directory
@@ -269,37 +268,6 @@ export function init(): void {
       '│ the SUSHI documentation:  https://fshschool.org/sushi    │\n' +
       '╰──────────────────────────────────────────────────────────╯\n'
   );
-}
-
-export async function fshToFhir(
-  input: string,
-  canonical: string,
-  dependencies: ImplementationGuideDependsOn[]
-): Promise<Package> {
-  // silence the logger
-  logger.transports[0].silent = true;
-
-  // set up a config so that sushi can run
-  const config = {
-    canonical,
-    FSHOnly: true,
-    fhirVersion: ['4.0.1'],
-    dependencies
-  };
-
-  // load dependencies
-  const defs = new FHIRDefinitions();
-  await Promise.all(loadExternalDependencies(defs, config));
-
-  // load FSH text into memory
-  const rawFSH = [new RawFSH(input)];
-  const tank = fillTank(rawFSH, config);
-
-  // process FSH text into FHIR
-  const outPackage = exportFHIR(tank, defs);
-
-  // QUESTION: Could just convert to JSON here, not sure which is more useful
-  return outPackage;
 }
 
 function getFilesRecursive(dir: string): string[] {

--- a/test/run/FshToFhir.test.ts
+++ b/test/run/FshToFhir.test.ts
@@ -5,7 +5,6 @@ import { errorsAndWarnings, logger } from '../../src/utils/';
 import { fshToFhir } from '../../src/run';
 import * as utils from '../../src/utils';
 import { Configuration } from '../../src/fshtypes';
-import { Package } from '../../src/export';
 import { FHIRDefinitions } from '../../src/fhirdefs';
 
 describe('#FshToFhir', () => {
@@ -33,7 +32,7 @@ describe('#FshToFhir', () => {
     await expect(fshToFhir('')).resolves.toEqual({
       errors: [],
       warnings: [],
-      fhir: new Package(defaultConfig)
+      fhir: []
     });
     expect(logger.level).toBe('info');
   });
@@ -49,7 +48,7 @@ describe('#FshToFhir', () => {
     });
     expect(results.errors[0].message).toMatch(/mismatched input 'Bad'/);
     expect(results.warnings).toHaveLength(0);
-    expect(results.fhir).toEqual(new Package(defaultConfig));
+    expect(results.fhir).toEqual([]);
     expect(logger.level).toBe('error');
   });
 
@@ -65,7 +64,7 @@ describe('#FshToFhir', () => {
     // errors are still tracked, even when the logger is silent
     expect(results.errors[0].message).toMatch(/mismatched input 'Bad'/);
     expect(results.warnings).toHaveLength(0);
-    expect(results.fhir).toEqual(new Package(defaultConfig));
+    expect(results.fhir).toEqual([]);
     expect(logger.transports[0].silent).toBe(true);
   });
 
@@ -90,13 +89,7 @@ describe('#FshToFhir', () => {
     ).resolves.toEqual({
       errors: [],
       warnings: [],
-      fhir: new Package({
-        canonical: 'http://mycanonical.org',
-        dependencies: [{ packageId: 'hl7.fhir.test.core', version: '1.2.3' }],
-        version: '3.2.1',
-        FSHOnly: true,
-        fhirVersion: ['4.0.1']
-      })
+      fhir: []
     });
   });
 
@@ -158,9 +151,9 @@ describe('#FshToFhir', () => {
       expect(results.errors).toHaveLength(0);
       expect(results.warnings).toHaveLength(0);
 
-      expect(results.fhir.profiles).toHaveLength(1);
-      expect(results.fhir.profiles[0].id).toBe('MyPatient');
-      const name = results.fhir.profiles[0].elements.find(e => e.id == 'Patient.name');
+      expect(results.fhir).toHaveLength(1);
+      expect(results.fhir[0].id).toBe('MyPatient');
+      const name = results.fhir[0].differential.element.find((e: any) => e.id == 'Patient.name');
       expect(name.mustSupport).toBe(true);
     });
 
@@ -179,12 +172,14 @@ describe('#FshToFhir', () => {
       ]);
       expect(results.errors).toHaveLength(0);
       expect(results.warnings).toHaveLength(0);
-      expect(results.fhir.profiles).toHaveLength(2);
-      expect(results.fhir.profiles[0].id).toBe('MyPatient1');
-      const name = results.fhir.profiles[0].elements.find(e => e.id == 'Patient.name');
+      expect(results.fhir).toHaveLength(2);
+      expect(results.fhir[0].id).toBe('MyPatient1');
+      const name = results.fhir[0].differential.element.find((e: any) => e.id == 'Patient.name');
       expect(name.mustSupport).toBe(true);
-      expect(results.fhir.profiles[1].id).toBe('MyPatient2');
-      const gender = results.fhir.profiles[1].elements.find(e => e.id == 'Patient.gender');
+      expect(results.fhir[1].id).toBe('MyPatient2');
+      const gender = results.fhir[1].differential.element.find(
+        (e: any) => e.id == 'Patient.gender'
+      );
       expect(gender.mustSupport).toBe(true);
     });
 
@@ -207,8 +202,8 @@ describe('#FshToFhir', () => {
       expect(results.errors[1].message).toMatch(/Parent AlsoFakeProfile not found/);
       expect(results.errors[1].input).toBe('Input_1');
       expect(results.warnings).toHaveLength(0);
-      expect(results.fhir.profiles).toHaveLength(0);
-      expect(results.fhir).toEqual(new Package(defaultConfig));
+      expect(results.fhir).toHaveLength(0);
+      expect(results.fhir).toEqual([]);
     });
   });
 });

--- a/test/run/FshToFhir.test.ts
+++ b/test/run/FshToFhir.test.ts
@@ -1,0 +1,149 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { loggerSpy } from '../testhelpers';
+import { errorsAndWarnings, logger } from '../../src/utils/';
+import { fshToFhir } from '../../src/run';
+import * as utils from '../../src/utils';
+import { Configuration } from '../../src/fshtypes';
+import { Package } from '../../src/export';
+import { FHIRDefinitions } from '../../src/fhirdefs';
+
+describe('FshToFhir', () => {
+  let loadSpy: jest.SpyInstance;
+  let defaultConfig: Configuration;
+
+  beforeAll(() => {
+    loadSpy = jest.spyOn(utils, 'loadExternalDependencies').mockImplementation(() => {
+      return [undefined];
+    });
+    defaultConfig = {
+      canonical: 'http://example.org',
+      FSHOnly: true,
+      fhirVersion: ['4.0.1']
+    };
+  });
+
+  beforeEach(() => {
+    loadSpy.mockClear();
+    loggerSpy.reset();
+    errorsAndWarnings.reset();
+  });
+
+  it('should use the "info" logging level by default', async () => {
+    await expect(fshToFhir('')).resolves.toEqual({
+      errors: [],
+      warnings: [],
+      fhir: new Package(defaultConfig)
+    });
+    expect(logger.level).toBe('info');
+  });
+
+  it('should use a higher logging level when specified', async () => {
+    const results = await fshToFhir('Bad FSH', { logLevel: 'error' });
+    expect(results.errors).toHaveLength(1);
+    expect(results.errors[0].location).toEqual({
+      startColumn: 1,
+      startLine: 1,
+      endColumn: 3,
+      endLine: 1
+    });
+    expect(results.errors[0].message).toMatch(/mismatched input 'Bad'/);
+    expect(results.warnings).toHaveLength(0);
+    expect(results.fhir).toEqual(new Package(defaultConfig));
+    expect(logger.level).toBe('error');
+  });
+
+  it('should mute the logger when "silent" is specified', async () => {
+    const results = await fshToFhir('Bad FSH', { logLevel: 'silent' });
+    expect(results.errors).toHaveLength(1);
+    expect(results.errors[0].location).toEqual({
+      startColumn: 1,
+      startLine: 1,
+      endColumn: 3,
+      endLine: 1
+    });
+    // errors are still tracked, even when the logger is silent
+    expect(results.errors[0].message).toMatch(/mismatched input 'Bad'/);
+    expect(results.warnings).toHaveLength(0);
+    expect(results.fhir).toEqual(new Package(defaultConfig));
+    expect(logger.transports[0].silent).toBe(true);
+  });
+
+  it('should replace configuration options when specified', async () => {
+    await expect(
+      fshToFhir('', {
+        canonical: 'http://mycanonical.org',
+        dependencies: [{ packageId: 'hl7.fhir.test.core', version: '1.2.3' }],
+        version: '3.2.1'
+      })
+    ).resolves.toEqual({
+      errors: [],
+      warnings: [],
+      fhir: new Package({
+        canonical: 'http://mycanonical.org',
+        dependencies: [{ packageId: 'hl7.fhir.test.core', version: '1.2.3' }],
+        version: '3.2.1',
+        FSHOnly: true,
+        fhirVersion: ['4.0.1']
+      })
+    });
+  });
+
+  it('should load external dependencies', async () => {
+    fshToFhir('');
+    expect(loadSpy.mock.calls).toHaveLength(1);
+    expect(loadSpy.mock.calls[0]).toEqual([new FHIRDefinitions(), defaultConfig]);
+  });
+
+  it('should convert valid FSH into FHIR', async () => {
+    // Set up the FHIRDefinitions with required R4 defintiions so that we can convert from FSH
+    const sd = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          __dirname,
+          '..',
+          'testhelpers',
+          'testdefs',
+          'package',
+          'StructureDefinition-StructureDefinition.json'
+        ),
+        'utf-8'
+      )
+    );
+    const patient = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          __dirname,
+          '..',
+          'testhelpers',
+          'testdefs',
+          'package',
+          'StructureDefinition-Patient.json'
+        ),
+        'utf-8'
+      )
+    );
+    loadSpy.mockImplementation(defs => {
+      defs.add(sd);
+      defs.add(patient);
+      return [undefined];
+    });
+
+    const results = await fshToFhir(
+      `
+    Profile: MyPatient
+    Parent: Patient
+    * name MS
+    `
+    );
+    expect(results.errors).toHaveLength(0);
+    expect(results.warnings).toHaveLength(0);
+    loadSpy.mockImplementation(() => {
+      return [undefined];
+    });
+    expect(results.fhir.profiles).toHaveLength(1);
+    expect(results.fhir.profiles[0].id).toBe('MyPatient');
+    const name = results.fhir.profiles[0].elements.find(e => e.id == 'Patient.name');
+    expect(name.mustSupport).toBe(true);
+  });
+});

--- a/test/utils/FSHLogger.test.ts
+++ b/test/utils/FSHLogger.test.ts
@@ -1,4 +1,4 @@
-import { logger, stats } from '../../src/utils/FSHLogger';
+import { logger, stats, errorsAndWarnings } from '../../src/utils/FSHLogger';
 
 // MUTE_LOGS controls whether or not logs get printed during testing.
 // Usually, we don't want logs actually printed, as they cause clutter.
@@ -9,6 +9,7 @@ describe('FSHLogger', () => {
 
   beforeEach(() => {
     stats.reset();
+    errorsAndWarnings.reset();
     if (MUTE_LOGS) {
       originalWriteFn = logger.transports[0]['write'];
       logger.transports[0]['write'] = jest.fn(() => true);
@@ -72,5 +73,42 @@ describe('FSHLogger', () => {
     expect(stats.numInfo).toBe(0);
     expect(stats.numWarn).toBe(0);
     expect(stats.numError).toBe(0);
+  });
+
+  it('should not track errors and warnings when shouldTrack is false', () => {
+    logger.warn('warn1');
+    logger.error('error1');
+    expect(errorsAndWarnings.shouldTrack).toBe(false);
+    expect(errorsAndWarnings.errors).toHaveLength(0);
+    expect(errorsAndWarnings.warnings).toHaveLength(0);
+  });
+
+  it('should track errors and warnings when shouldTrack is true', () => {
+    errorsAndWarnings.shouldTrack = true;
+    logger.warn('warn1', { location: [1, 2, 3, 4] });
+    logger.warn('warn2');
+    logger.error('error1');
+    logger.error('error2');
+    expect(errorsAndWarnings.shouldTrack).toBe(true);
+    expect(errorsAndWarnings.warnings).toHaveLength(2);
+    expect(errorsAndWarnings.warnings).toContainEqual({ location: [1, 2, 3, 4], message: 'warn1' });
+    expect(errorsAndWarnings.warnings).toContainEqual({ message: 'warn2' });
+    expect(errorsAndWarnings.errors).toHaveLength(2);
+    expect(errorsAndWarnings.errors).toContainEqual({ message: 'error1' });
+    expect(errorsAndWarnings.errors).toContainEqual({ message: 'error2' });
+  });
+
+  it('should reset errors and warnings', () => {
+    errorsAndWarnings.shouldTrack = true;
+    logger.warn('warn1');
+    logger.error('error1');
+    expect(errorsAndWarnings.shouldTrack).toBe(true);
+    expect(errorsAndWarnings.warnings).toHaveLength(1);
+    expect(errorsAndWarnings.warnings).toContainEqual({ message: 'warn1' });
+    expect(errorsAndWarnings.errors).toHaveLength(1);
+    expect(errorsAndWarnings.errors).toContainEqual({ message: 'error1' });
+    errorsAndWarnings.reset();
+    expect(errorsAndWarnings.errors).toHaveLength(0);
+    expect(errorsAndWarnings.warnings).toHaveLength(0);
   });
 });

--- a/test/utils/FSHLogger.test.ts
+++ b/test/utils/FSHLogger.test.ts
@@ -85,13 +85,17 @@ describe('FSHLogger', () => {
 
   it('should track errors and warnings when shouldTrack is true', () => {
     errorsAndWarnings.shouldTrack = true;
-    logger.warn('warn1', { location: [1, 2, 3, 4] });
+    logger.warn('warn1', { location: [1, 2, 3, 4], file: 'Input_0' });
     logger.warn('warn2');
     logger.error('error1');
     logger.error('error2');
     expect(errorsAndWarnings.shouldTrack).toBe(true);
     expect(errorsAndWarnings.warnings).toHaveLength(2);
-    expect(errorsAndWarnings.warnings).toContainEqual({ location: [1, 2, 3, 4], message: 'warn1' });
+    expect(errorsAndWarnings.warnings).toContainEqual({
+      location: [1, 2, 3, 4],
+      message: 'warn1',
+      input: 'Input_0'
+    });
     expect(errorsAndWarnings.warnings).toContainEqual({ message: 'warn2' });
     expect(errorsAndWarnings.errors).toHaveLength(2);
     expect(errorsAndWarnings.errors).toContainEqual({ message: 'error1' });


### PR DESCRIPTION
This adds a `fshToFhir` function, which can be called to convert FSH definitions to FHIR. The function also tracks errors and warnings that occur during the running of SUSHI. The function runs a simplified version of SUSHI, no `IGExporter` specific processing is done, only the conversion from FSH to FHIR. The function takes a set of options that can be used to change the configuration that SUSHI runs with. The options allow you to set the logging level, set dependencies, set the version, and set a canonical. If no options are given, SUSHI runs with default values for each of these things.