### PR TITLE
Fix nested ad hoc extensions

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -472,7 +472,7 @@ export class StructureDefinition {
       // Allow for adding extension elements to the instance that are not on the SD
       if (!currentElement && pathPart.base === 'extension') {
         // Get extension element (if currentPath is A.B.extension[C], get A.B.extension)
-        const extensionPath = `${previousPath ? `${previousPath}'.'` : ''}${pathPart.base}`;
+        const extensionPath = `${previousPath ? `${previousPath}.` : ''}${pathPart.base}`;
         const extensionElement = this.findElementByPath(extensionPath, fisher);
         // Get the extension being referred to
         const extension = fisher.fishForMetadata(pathPart.brackets[0]);

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -1166,6 +1166,22 @@ describe('StructureDefinition', () => {
       expect(respRate.elements.length).toBe(originalLength + 5);
     });
 
+    it('should allow setting nested arbitrary defined extensions', () => {
+      const originalLength = respRate.elements.length;
+      const { assignedValue, pathParts } = respRate.validateValueAtPath(
+        'extension[0].extension[patient-mothersMaidenName].value[x]',
+        'foo',
+        fisher
+      );
+      expect(assignedValue).toBe('foo');
+      expect(pathParts.length).toBe(3);
+      expect(pathParts[1]).toEqual({
+        base: 'extension',
+        brackets: ['patient-mothersMaidenName', '0']
+      });
+      expect(respRate.elements.length).toBe(originalLength + 9);
+    });
+
     it('should not allow setting arbitrary undefined extensions', () => {
       expect(() => {
         respRate.validateValueAtPath('extension[fake-extension].value[x]', 'foo', fisher);


### PR DESCRIPTION
Fixes https://github.com/FHIR/sushi/issues/621.

See the issue for an example of the bug. To test this, you can run that example on `master` and observe the errors, and note that no `extensions` are created within `item` objects on the instance. Then, run this example on this branch, and notice that those errors go away (still expect to see other errors and warnings related to elements not having correct cardinality, please excuse those), and the extensions are added to the `item` objects.