### PR TITLE
Change configuration format to support separate group names and IDs

### DIFF
--- a/src/fshtypes/Configuration.ts
+++ b/src/fshtypes/Configuration.ts
@@ -138,6 +138,7 @@ export type Configuration = {
 };
 
 export type ConfigurationGroup = {
+  id: string;
   name: string;
   description?: string;
   resources: string[];

--- a/src/import/YAMLConfiguration.ts
+++ b/src/import/YAMLConfiguration.ts
@@ -318,6 +318,7 @@ export type YAMLConfigurationGlobalMap = {
 
 export type YAMLConfigurationGroupMap = {
   [key: string]: {
+    name?: ImplementationGuide['name'];
     description?: ImplementationGuideDefinitionGrouping['description']; // string
     resources: string[];
   };

--- a/src/import/importConfiguration.ts
+++ b/src/import/importConfiguration.ts
@@ -589,8 +589,16 @@ function parseGroups(yamlGroups: YAMLConfigurationGroupMap): ConfigurationGroup[
   if (yamlGroups == null) {
     return;
   }
-  return Object.entries(yamlGroups).map(([name, details]) => {
-    return { name, ...details };
+  return Object.entries(yamlGroups).map(([id, groupObj]) => {
+    if (groupObj.name === undefined) {
+      groupObj.name = id;
+    }
+    return {
+      id: id,
+      name: groupObj.name,
+      description: groupObj.description,
+      resources: groupObj.resources
+    };
   });
 }
 

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -451,12 +451,14 @@ describe('IGExporter', () => {
     it('should create groups for each configured group', () => {
       config.groups = [
         {
-          name: 'MyPatientGroup',
+          id: 'MyPatientGroup',
+          name: 'My Patient Group',
           description: 'Group for some patient-related things.',
           resources: ['StructureDefinition/sample-patient', 'Patient/patient-example']
         },
         {
-          name: 'MyObservationGroup',
+          id: 'MyObservationGroup',
+          name: 'My Observation Group',
           description: 'Group for some observation-related things.',
           resources: ['StructureDefinition/sample-observation']
         }
@@ -467,12 +469,12 @@ describe('IGExporter', () => {
       const content = fs.readJSONSync(igPath);
       expect(content.definition.grouping).toContainEqual({
         id: 'MyPatientGroup',
-        name: 'MyPatientGroup',
+        name: 'My Patient Group',
         description: 'Group for some patient-related things.'
       });
       expect(content.definition.grouping).toContainEqual({
         id: 'MyObservationGroup',
-        name: 'MyObservationGroup',
+        name: 'My Observation Group',
         description: 'Group for some observation-related things.'
       });
       const samplePatient: ImplementationGuideDefinitionResource = content.definition.resource.find(
@@ -495,7 +497,8 @@ describe('IGExporter', () => {
     it('should log an error when a group is configured with a nonexistent resource', () => {
       config.groups = [
         {
-          name: 'BananaGroup',
+          id: 'BananaGroup',
+          name: 'Banana Group',
           description: 'Holds all the bananas.',
           resources: ['StructureDefinition/sample-banana']
         }
@@ -515,6 +518,7 @@ describe('IGExporter', () => {
       ];
       config.groups = [
         {
+          id: 'Capulets',
           name: 'Capulets',
           resources: ['StructureDefinition/sample-patient']
         }
@@ -534,7 +538,8 @@ describe('IGExporter', () => {
       ];
       config.groups = [
         {
-          name: 'JustOneGroup',
+          id: 'JustOneGroup',
+          name: 'Just One Group',
           resources: ['StructureDefinition/sample-patient']
         }
       ];

--- a/test/ig/IGExporter.test.ts
+++ b/test/ig/IGExporter.test.ts
@@ -89,7 +89,8 @@ describe('IGExporter', () => {
       const igPath = path.join(tempOut, 'input', 'ImplementationGuide-fhir.us.example.json');
       const igContent = fs.readJSONSync(igPath);
       expect(igContent.definition.grouping).toHaveLength(2);
-      expect(igContent.definition.grouping[0].name).toBe('GroupA');
+      expect(igContent.definition.grouping[0].id).toBe('GroupA');
+      expect(igContent.definition.grouping[0].name).toBe('Group A');
       expect(igContent.definition.resource).toHaveLength(1);
       expect(igContent.definition.resource[0].name).toBe('My Example Patient');
       expect(igContent.definition.page.page).toHaveLength(3);

--- a/test/import/YAMLConfiguration.test.ts
+++ b/test/import/YAMLConfiguration.test.ts
@@ -70,10 +70,12 @@ describe('YAMLConfiguration', () => {
       });
       expect(config.groups).toEqual({
         GroupA: {
+          name: 'Group A',
           description: 'The Alpha Group',
           resources: ['StructureDefinition/animal-patient', 'StructureDefinition/arm-procedure']
         },
         GroupB: {
+          name: 'Group B',
           description: 'The Beta Group',
           resources: ['StructureDefinition/bark-control', 'StructureDefinition/bee-sting']
         }

--- a/test/import/fixtures/example-config.yaml
+++ b/test/import/fixtures/example-config.yaml
@@ -109,11 +109,13 @@ resources:
 # resource entries with the corresponding groupIds.
 groups:
   GroupA:
+    name: Group A
     description: The Alpha Group
     resources:
     - StructureDefinition/animal-patient
     - StructureDefinition/arm-procedure
   GroupB:
+    name: Group B
     description: The Beta Group
     resources:
     - StructureDefinition/bark-control

--- a/test/import/importConfiguration.test.ts
+++ b/test/import/importConfiguration.test.ts
@@ -116,12 +116,14 @@ describe('importConfiguration', () => {
       ],
       groups: [
         {
-          name: 'GroupA',
+          id: 'GroupA',
+          name: 'Group A',
           description: 'The Alpha Group',
           resources: ['StructureDefinition/animal-patient', 'StructureDefinition/arm-procedure']
         },
         {
-          name: 'GroupB',
+          id: 'GroupB',
+          name: 'Group B',
           description: 'The Beta Group',
           resources: ['StructureDefinition/bark-control', 'StructureDefinition/bee-sting']
         }
@@ -1450,6 +1452,7 @@ describe('importConfiguration', () => {
     it('should convert the groups map to a list', () => {
       minYAML.groups = {
         GroupA: {
+          name: 'Group A',
           description: 'The Alpha Group',
           resources: ['StructureDefinition/animal-patient', 'StructureDefinition/arm-procedure']
         },
@@ -1461,11 +1464,13 @@ describe('importConfiguration', () => {
       const config = importConfiguration(minYAML, 'test-config.yaml');
       expect(config.groups).toEqual([
         {
-          name: 'GroupA',
+          id: 'GroupA',
+          name: 'Group A',
           description: 'The Alpha Group',
           resources: ['StructureDefinition/animal-patient', 'StructureDefinition/arm-procedure']
         },
         {
+          id: 'GroupB',
           name: 'GroupB',
           description: 'The Beta Group',
           resources: ['StructureDefinition/bark-control', 'StructureDefinition/bee-sting']


### PR DESCRIPTION
Previously, custom groups defined in `sushi-config.yaml` used the same string for both the `id` and `name` properties for a given group.

For example, given the following YAML:

    groups:
      GroupA:
        name: Group A
        description: The Alpha Group
        resources:
        - StructureDefinition/animal-patient
        - StructureDefinition/arm-procedure

Previously, both the `name` and `id` properties in the generated IG JSON would have been `Group A`. This caused errors like the following when building the IG with the FHIR publisher:

> ImplementationGuide.definition.resource[0].groupingId
> id value 'Group A' is not valid

This commit changes SUSHI to set `id` to `GroupA` and `name` to `Group A`. This avoids the error when building the IG.

Groups where `name` is undefined are still supported:

    groups:
      GroupB:
        description: The Beta Group
        resources:
        ...

In this case, both `id` and `name` will be `GroupB`.

This is related to #590.