### PR TITLE
Group properties when exporting Instances

### DIFF
--- a/src/fhirtypes/InstanceDefinition.ts
+++ b/src/fhirtypes/InstanceDefinition.ts
@@ -1,6 +1,6 @@
-import { difference } from 'lodash';
+import { difference, remove, pull, cloneDeep } from 'lodash';
 import { Meta } from './specialTypes';
-import { HasId, orderedCloneDeep } from './common';
+import { HasId } from './common';
 import { applyMixins } from '../utils';
 import { InstanceUsage } from '../fshtypes';
 
@@ -44,6 +44,46 @@ export class InstanceDefinition {
       instanceDefinition._instanceMeta.name = json.id;
     }
     return instanceDefinition;
+  }
+}
+
+/**
+ * Make a deep clone recursively, adding properties in the order expected for exported JSON.
+ * If a list of keys is provided, use those properties from the input.
+ * Otherwise, use all properties from the input.
+ *
+ * @param input - the value to clone
+ * @param keys - optionally, the properties of the value to include in the clone
+ * @returns {any} - a clone of the input, with reordered properties
+ */
+function orderedCloneDeep(input: any, keys: string[] = Object.keys(input)): any {
+  // non-objects should be cloned normally
+  // arrays should get a recursive call on their elements, but don't need reordering
+  if (typeof input !== 'object') {
+    return cloneDeep(input);
+  } else if (Array.isArray(input)) {
+    return input.map(element => orderedCloneDeep(element));
+  } else {
+    const underscoreKeys = remove(keys, key => key.startsWith('_'));
+    const orderedKeys: string[] = [];
+    const result: any = {};
+
+    keys.forEach(key => {
+      orderedKeys.push(key);
+      if (underscoreKeys.includes(`_${key}`)) {
+        orderedKeys.push(`_${key}`);
+        pull(underscoreKeys, `_${key}`);
+      }
+    });
+    underscoreKeys.forEach(key => {
+      orderedKeys.push(key);
+    });
+
+    orderedKeys.forEach(key => {
+      result[key] = orderedCloneDeep(input[key]);
+    });
+
+    return result;
   }
 }
 

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -1,3 +1,4 @@
+import { isEmpty, cloneDeep } from 'lodash';
 import {
   StructureDefinition,
   PathPart,
@@ -31,10 +32,8 @@ import {
 } from '../fshtypes';
 import { FSHTank } from '../import';
 import { Type, Fishable } from '../utils/Fishable';
-import cloneDeep = require('lodash/cloneDeep');
 import { logger } from '../utils';
 import { FHIRId, idRegex } from './primitiveTypes';
-import { isEmpty, remove, pull } from 'lodash';
 
 export function splitOnPathPeriods(path: string): string[] {
   return path.split(/\.(?![^\[]*\])/g); // match a period that isn't within square brackets
@@ -594,46 +593,6 @@ export function getUrlFromFshDefinition(
     fhirType = 'StructureDefinition';
   }
   return `${canonical}/${fhirType}/${fshDefinition.id}`;
-}
-
-/**
- * Make a deep clone recursively, adding properties in the order expected for exported JSON.
- * If a list of keys is provided, use those properties from the input.
- * Otherwise, use all properties from the input.
- *
- * @param input - the value to clone
- * @param keys - optionally, the properties of the value to include in the clone
- * @returns {any} - a clone of the input, with reordered properties
- */
-export function orderedCloneDeep(input: any, keys: string[] = Object.keys(input)): any {
-  // non-objects should be cloned normally
-  // arrays should get a recursive call on their elements, but don't need reordering
-  if (typeof input !== 'object') {
-    return cloneDeep(input);
-  } else if (Array.isArray(input)) {
-    return input.map(element => orderedCloneDeep(element));
-  } else {
-    const underscoreKeys = remove(keys, key => key.startsWith('_'));
-    const orderedKeys: string[] = [];
-    const result: any = {};
-
-    keys.forEach(key => {
-      orderedKeys.push(key);
-      if (underscoreKeys.includes(`_${key}`)) {
-        orderedKeys.push(`_${key}`);
-        pull(underscoreKeys, `_${key}`);
-      }
-    });
-    underscoreKeys.forEach(key => {
-      orderedKeys.push(key);
-    });
-
-    orderedKeys.forEach(key => {
-      result[key] = orderedCloneDeep(input[key]);
-    });
-
-    return result;
-  }
 }
 
 const nameRegex = /^[A-Z]([A-Za-z0-9_]){0,254}$/;

--- a/test/fhirtypes/InstanceDefinition.test.ts
+++ b/test/fhirtypes/InstanceDefinition.test.ts
@@ -60,5 +60,20 @@ describe('InstanceDefinition', () => {
       expect(keys.indexOf('id') + 1).toBe(keys.indexOf('_id'));
       expect(keys.indexOf('status') + 1).toBe(keys.indexOf('_status'));
     });
+
+    it('should serialize subproperties such that underscore properties come immediately after their non-underscore counterparts', () => {
+      patientInstance.name[0]._family = {
+        extension: {
+          url: 'http://question.org/wait/really?',
+          valueBoolean: false
+        }
+      };
+      const originalKeys = Object.keys(patientInstance.name[0]);
+      expect(originalKeys.indexOf('family') + 1).not.toBe(originalKeys.indexOf('_family'));
+
+      const newJSON = patientInstance.toJSON();
+      const nameKeys = Object.keys(newJSON.name[0]);
+      expect(nameKeys.indexOf('family') + 1).toBe(nameKeys.indexOf('_family'));
+    });
   });
 });

--- a/test/fhirtypes/InstanceDefinition.test.ts
+++ b/test/fhirtypes/InstanceDefinition.test.ts
@@ -35,5 +35,30 @@ describe('InstanceDefinition', () => {
       const newJSON = patientInstance.toJSON();
       expect(newJSON).toEqual(patientInstanceJSON);
     });
+
+    it('should serialize properties such that underscore properties come immediately after their non-underscore counterparts', () => {
+      patientInstance._status = {
+        extension: [
+          {
+            url: 'SomeExtension',
+            valueCode: 'someCode'
+          }
+        ]
+      };
+      patientInstance._id = {
+        extension: [
+          {
+            url: 'SomeExtension',
+            valueCode: 'someCode'
+          }
+        ]
+      };
+      patientInstance.status = 'active';
+
+      const newJSON = patientInstance.toJSON();
+      const keys = Object.keys(newJSON);
+      expect(keys.indexOf('id') + 1).toBe(keys.indexOf('_id'));
+      expect(keys.indexOf('status') + 1).toBe(keys.indexOf('_status'));
+    });
   });
 });


### PR DESCRIPTION
Completes task [CIMPL-571](https://standardhealthrecord.atlassian.net/browse/CIMPL-571). Fixes #632 .

A primitive property on an Instance may have extensions or other nested attributes on it. This is represented on the Instance with a property whose key begins with an underscore. For easier reading, when a property and its underscored version both exist on an Instance, those properties should be grouped together on the serialized Instance.

Object keys are technically unordered, but this implementation seems to exhibit the desired behavior. A potentially more robust solution would be building a `Map`, which has ordered keys, in `toJSON`. But, this would then remove the "round-trip" nature of `toJSON` and `fromJSON`, and it would also require a custom serializer, because `JSON.stringify` [will only return a Map's enumerable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description), not its key-value pairs.