### PR TITLE
Merge existing Mappings

### DIFF
--- a/src/export/MappingExporter.ts
+++ b/src/export/MappingExporter.ts
@@ -96,6 +96,14 @@ export class MappingExporter {
             fshDefinition.sourceInfo
           );
           return;
+        } else {
+          // Update parent mapping with additional or changed metadata (comment is the only property this can be the case for)
+          const inheritedMapping = sourceStructDef.mapping.find(
+            m => m.identity === fshDefinition.id
+          );
+          if (fshDefinition.description) {
+            inheritedMapping.comment = fshDefinition.description;
+          }
         }
       } else {
         // Only add metadata if it does not already exist on the parent

--- a/src/export/MappingExporter.ts
+++ b/src/export/MappingExporter.ts
@@ -89,10 +89,7 @@ export class MappingExporter {
         const isMatchingTarget = fshDefinition.target
           ? fshDefinition.target === matchingParentMapping.uri
           : true;
-        const isMatchingDescription = fshDefinition.description
-          ? fshDefinition.description === matchingParentMapping.comment
-          : true;
-        if (!isMatchingTitle || !isMatchingTarget || !isMatchingDescription) {
+        if (!isMatchingTitle || !isMatchingTarget) {
           // If the mapping identity matches one on the parent, all other metadata must also match in order to merge MappingRules
           logger.error(
             `Unable to add Mapping ${fshDefinition.name} because it conflicts with one already on the parent of ${fshDefinition.source}.`,

--- a/test/export/MappingExporter.test.ts
+++ b/test/export/MappingExporter.test.ts
@@ -194,6 +194,116 @@ describe('MappingExporter', () => {
       exporter.export();
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
+
+    it('should not log an error and not add metadata but add rules for a simple Mapping that is inherited from the parent', () => {
+      /**
+       * Mapping: rim
+       * Source: MyObservation
+       * * status -> "Something.new"
+       */
+
+      const mapping = new Mapping('rim');
+      mapping.source = 'MyObservation';
+      const newRule = new MappingRule('status');
+      newRule.map = 'Something.new';
+      mapping.rules.push(newRule);
+      doc.mappings.set(mapping.name, mapping);
+
+      const originalMappingLength = observation.mapping.length;
+      const status = observation.elements.find(e => e.id === 'Observation.status');
+      const originalStatusMappingLength = status.mapping.length;
+
+      exporter.export();
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(observation.mapping.length).toBe(originalMappingLength); // No metadata added
+      expect(status.mapping.length).toBe(originalStatusMappingLength + 1); // New rule added to status element
+    });
+
+    it('should not log an error and not add metadata but add rules for a Mapping that is inherited from the parent with the same metdata', () => {
+      /**
+       * Mapping: rim
+       * Id: rim
+       * Source: MyObservation
+       * Title: "RIM Mapping"
+       * Target: "http://hl7.org/v3"
+       * * status -> "Something.new"
+       */
+
+      const mapping = new Mapping('rim');
+      mapping.source = 'MyObservation';
+      mapping.id = 'rim';
+      mapping.title = 'RIM Mapping';
+      mapping.target = 'http://hl7.org/v3';
+      const newRule = new MappingRule('status');
+      newRule.map = 'Something.new';
+      mapping.rules.push(newRule);
+      doc.mappings.set(mapping.name, mapping);
+
+      const originalMappingLength = observation.mapping.length;
+      const status = observation.elements.find(e => e.id === 'Observation.status');
+      const originalStatusMappingLength = status.mapping.length;
+
+      exporter.export();
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(observation.mapping.length).toBe(originalMappingLength); // No metadata added
+      expect(status.mapping.length).toBe(originalStatusMappingLength + 1); // New rule added to status element
+    });
+
+    it('should log an error and not add mapping or rules when a Mapping has the same identity as one on the parent but has other metadata that differs', () => {
+      /**
+       * Mapping: rim
+       * Id: rim
+       * Source: MyObservation
+       * Title: "RIM Mapping"
+       * Target: "http://real.org/not"
+       * * status -> "Something.new"
+       */
+
+      const mapping = new Mapping('rim');
+      mapping.source = 'MyObservation';
+      mapping.id = 'rim';
+      mapping.title = 'RIM Mapping';
+      mapping.target = 'http://real.org/not';
+      const newRule = new MappingRule('status');
+      newRule.map = 'Something.new';
+      mapping.rules.push(newRule);
+      doc.mappings.set(mapping.name, mapping);
+
+      const originalMappingLength = observation.mapping.length;
+      const status = observation.elements.find(e => e.id === 'Observation.status');
+      const originalStatusMappingLength = status.mapping.length;
+
+      exporter.export();
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
+      expect(observation.mapping.length).toBe(originalMappingLength); // No metadata added
+      expect(status.mapping.length).toBe(originalStatusMappingLength); // No rule added to status element
+    });
+
+    it('should log an error and not add mapping or rules when a Mapping has the same identity as one on the parent and has additional metadata not on the parent', () => {
+      /**
+       * Mapping: rim
+       * Source: MyObservation
+       * Description: "A totally different description"
+       * * status -> "Something.new"
+       */
+
+      const mapping = new Mapping('rim');
+      mapping.source = 'MyObservation';
+      mapping.description = 'A totally different description';
+      const newRule = new MappingRule('status');
+      newRule.map = 'Something.new';
+      mapping.rules.push(newRule);
+      doc.mappings.set(mapping.name, mapping);
+
+      const originalMappingLength = observation.mapping.length;
+      const status = observation.elements.find(e => e.id === 'Observation.status');
+      const originalStatusMappingLength = status.mapping.length;
+
+      exporter.export();
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
+      expect(observation.mapping.length).toBe(originalMappingLength); // No metadata added
+      expect(status.mapping.length).toBe(originalStatusMappingLength); // No rule added to status element
+    });
   });
 
   describe('#setMappingRules', () => {

--- a/test/export/MappingExporter.test.ts
+++ b/test/export/MappingExporter.test.ts
@@ -255,36 +255,6 @@ describe('MappingExporter', () => {
       expect(status.mapping.length).toBe(originalStatusMappingLength + 1); // New rule added to status element
     });
 
-    it('should log an error and not add mapping or rules when a Mapping has the same identity as one on the parent but name or uri differs', () => {
-      /**
-       * Mapping: rim
-       * Id: rim
-       * Source: MyObservation
-       * Title: "RIM Mapping"
-       * Target: "http://real.org/not"
-       * * status -> "Something.new"
-       */
-
-      const mapping = new Mapping('rim');
-      mapping.source = 'MyObservation';
-      mapping.id = 'rim';
-      mapping.title = 'RIM Mapping';
-      mapping.target = 'http://real.org/not';
-      const newRule = new MappingRule('status');
-      newRule.map = 'Something.new';
-      mapping.rules.push(newRule);
-      doc.mappings.set(mapping.name, mapping);
-
-      const originalMappingLength = observation.mapping.length;
-      const status = observation.elements.find(e => e.id === 'Observation.status');
-      const originalStatusMappingLength = status.mapping.length;
-
-      exporter.export();
-      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
-      expect(observation.mapping.length).toBe(originalMappingLength); // No metadata added
-      expect(status.mapping.length).toBe(originalStatusMappingLength); // No rule added to status element
-    });
-
     it('should not log an error, should update metadata, and should add rules for a Mapping that is inherited from the parent and has additional metadata not on the parent', () => {
       /**
        * Mapping: rim
@@ -315,6 +285,36 @@ describe('MappingExporter', () => {
       const rimMapping = observation.mapping.find(m => m.identity === 'rim');
       originalRimMapping.comment = 'A totally new description'; // Description is added
       expect(rimMapping).toEqual(originalRimMapping);
+    });
+
+    it('should log an error and not add mapping or rules when a Mapping has the same identity as one on the parent but name or uri differs', () => {
+      /**
+       * Mapping: rim
+       * Id: rim
+       * Source: MyObservation
+       * Title: "RIM Mapping"
+       * Target: "http://real.org/not"
+       * * status -> "Something.new"
+       */
+
+      const mapping = new Mapping('rim');
+      mapping.source = 'MyObservation';
+      mapping.id = 'rim';
+      mapping.title = 'RIM Mapping';
+      mapping.target = 'http://real.org/not';
+      const newRule = new MappingRule('status');
+      newRule.map = 'Something.new';
+      mapping.rules.push(newRule);
+      doc.mappings.set(mapping.name, mapping);
+
+      const originalMappingLength = observation.mapping.length;
+      const status = observation.elements.find(e => e.id === 'Observation.status');
+      const originalStatusMappingLength = status.mapping.length;
+
+      exporter.export();
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
+      expect(observation.mapping.length).toBe(originalMappingLength); // No metadata added
+      expect(status.mapping.length).toBe(originalStatusMappingLength); // No rule added to status element
     });
   });
 

--- a/test/export/MappingExporter.test.ts
+++ b/test/export/MappingExporter.test.ts
@@ -279,17 +279,17 @@ describe('MappingExporter', () => {
       expect(status.mapping.length).toBe(originalStatusMappingLength); // No rule added to status element
     });
 
-    it('should log an error and not add mapping or rules when a Mapping has the same identity as one on the parent and has additional metadata not on the parent', () => {
+    it('should not log an error and not add metadata but add rules for a Mapping that is inherited from the parent and has additional metadata not on the parent', () => {
       /**
        * Mapping: rim
        * Source: MyObservation
-       * Description: "A totally different description"
+       * Description: "A totally new description"
        * * status -> "Something.new"
        */
 
       const mapping = new Mapping('rim');
       mapping.source = 'MyObservation';
-      mapping.description = 'A totally different description';
+      mapping.description = 'A totally new description';
       const newRule = new MappingRule('status');
       newRule.map = 'Something.new';
       mapping.rules.push(newRule);
@@ -300,9 +300,9 @@ describe('MappingExporter', () => {
       const originalStatusMappingLength = status.mapping.length;
 
       exporter.export();
-      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       expect(observation.mapping.length).toBe(originalMappingLength); // No metadata added
-      expect(status.mapping.length).toBe(originalStatusMappingLength); // No rule added to status element
+      expect(status.mapping.length).toBe(originalStatusMappingLength + 1); // New rule added to status element
     });
   });
 


### PR DESCRIPTION
This PR adds support for adding rules to existing `Mapping`s on StructureDefinitions ([CIMPL-583](https://standardhealthrecord.atlassian.net/browse/CIMPL-583)).

On master, if you were to make a `Mapping` that has the same `id` as one that is already on the Parent of the Profile you are adding the mapping to, SUSHI will add a duplicate Mapping at the top level of the StructureDefinition and will also add any rules. This PR makes it so that you can add a `Mapping` that has the same `id` as one already on the SD and add rules. As long as any specified metadata matches what is on the existing `Mapping`, no metadata will be added to the SD but any rules on the `Mapping` will be added to the SD. If there is any metadata specified on the `Mapping` that does not match what is on the Mapping on the SD, an error will be logged and no rules will be added.

I had also intended to include fixes for the two things @cmoesel pointed out [here](https://github.com/FHIR/GoFSH/pull/28#pullrequestreview-519770578), but after looking at the original US Core SDs, these changes seem to be caused by the caret value rules GoFSH was creating since we were accessing indexes in arrays in the differential. I believe all the mapping information should be the same as the original US Core SDs.