### PR TITLE
Inline extensions are not allowed on profiles

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -322,6 +322,10 @@ export class StructureDefinitionExporter implements Fishable {
           this
         );
         urlElement.assignValue(slice.sliceName, true);
+        // Inline extensions should not be used on profiles
+        if (fshDefinition instanceof Profile) {
+          logger.error('Inline extensions should not be used on profiles.', rule.sourceInfo);
+        }
       }
     });
   }

--- a/test/export/StructureDefinition.ExtensionExporter.test.ts
+++ b/test/export/StructureDefinition.ExtensionExporter.test.ts
@@ -6,6 +6,7 @@ import { loggerSpy } from '../testhelpers/loggerSpy';
 import { TestFisher } from '../testhelpers';
 import path from 'path';
 import { minimalConfig } from '../utils/minimalConfig';
+import { ContainsRule } from '../../src/fshtypes/rules';
 
 describe('ExtensionExporter', () => {
   let defs: FHIRDefinitions;
@@ -144,5 +145,21 @@ describe('ExtensionExporter', () => {
     expect(exported[2].name).toBe('Foo');
     expect(exported[1].baseDefinition === exported[0].url);
     expect(exported[2].baseDefinition === exported[1].url);
+  });
+
+  it('should not log an error when an inline extension is used', () => {
+    loggerSpy.reset();
+    const extension = new Extension('MyExtension');
+    const containsRule = new ContainsRule('extension')
+      .withFile('MyExtension.fsh')
+      .withLocation([3, 8, 3, 25]);
+    containsRule.items.push({
+      name: 'SomeExtension'
+    });
+    extension.rules.push(containsRule);
+    doc.extensions.set(extension.name, extension);
+    exporter.export();
+
+    expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Completes task [CIMPL-592](https://standardhealthrecord.atlassian.net/browse/CIMPL-592) and fixes #591 .

Log an error when an inline extension would be used on a profile. Many existing test cases were using inline extensions on profiles, so those tests are updated such that they still test the same code. Inline extensions are still allowed on extensions.