### PR TITLE
Log dependencies individually when extracted from IG

### DIFF
--- a/src/import/loadConfigurationFromIgResource.ts
+++ b/src/import/loadConfigurationFromIgResource.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import ini from 'ini';
 import { Fhir as FHIRConverter } from 'fhir/fhir';
 import { Configuration } from '../fshtypes';
-import { ImplementationGuide, ImplementationGuideDependsOn } from '../fhirtypes';
+import { ImplementationGuide } from '../fhirtypes';
 import { logger } from '../utils';
 
 /**
@@ -67,10 +67,10 @@ export function loadConfigurationFromIgResource(igRoot: string): Configuration |
     };
     logger.info(`Extracting FSHOnly configuration from ${igPath}:`);
     Object.entries(config).forEach(e => {
-      if (e[0] === 'dependencies') {
-        (e[1] as ImplementationGuideDependsOn[])?.forEach((dep, i) =>
-          logger.info(`  dependencies[${i}]: ${JSON.stringify(dep)}`)
-        );
+      if (Array.isArray(e[1])) {
+        e[1].forEach((sub: any, i: number) => {
+          logger.info(`  ${e[0]}[${i}]: ${JSON.stringify(sub)}`);
+        });
       } else {
         logger.info(`  ${e[0]}: ${JSON.stringify(e[1])}`);
       }

--- a/src/import/loadConfigurationFromIgResource.ts
+++ b/src/import/loadConfigurationFromIgResource.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import ini from 'ini';
 import { Fhir as FHIRConverter } from 'fhir/fhir';
 import { Configuration } from '../fshtypes';
-import { ImplementationGuide } from '../fhirtypes';
+import { ImplementationGuide, ImplementationGuideDependsOn } from '../fhirtypes';
 import { logger } from '../utils';
 
 /**
@@ -66,7 +66,15 @@ export function loadConfigurationFromIgResource(igRoot: string): Configuration |
       FSHOnly: true
     };
     logger.info(`Extracting FSHOnly configuration from ${igPath}:`);
-    Object.entries(config).forEach(e => logger.info(`  ${e[0]}: ${JSON.stringify(e[1])}`));
+    Object.entries(config).forEach(e => {
+      if (e[0] === 'dependencies') {
+        (e[1] as ImplementationGuideDependsOn[])?.forEach((dep, i) =>
+          logger.info(`  dependencies[${i}]: ${JSON.stringify(dep)}`)
+        );
+      } else {
+        logger.info(`  ${e[0]}: ${JSON.stringify(e[1])}`);
+      }
+    });
     return config;
   }
   return null;

--- a/test/import/loadConfigurationFromIgResource.test.ts
+++ b/test/import/loadConfigurationFromIgResource.test.ts
@@ -50,9 +50,12 @@ describe('loadConfigurationFromIgResource', () => {
     expect(loggerSpy.getMessageAtIndex(2, 'info')).toEqual('  version: "1.0.0"');
     expect(loggerSpy.getMessageAtIndex(3, 'info')).toEqual('  fhirVersion: ["4.0.1"]');
     expect(loggerSpy.getMessageAtIndex(4, 'info')).toEqual(
-      '  dependencies: [{"packageId":"foo.bar","version":"1.2.3"},{"packageId":"bar.foo","version":"current"}]'
+      '  dependencies[0]: {"packageId":"foo.bar","version":"1.2.3"}'
     );
-    expect(loggerSpy.getMessageAtIndex(5, 'info')).toEqual('  FSHOnly: true');
+    expect(loggerSpy.getMessageAtIndex(5, 'info')).toEqual(
+      '  dependencies[1]: {"packageId":"bar.foo","version":"current"}'
+    );
+    expect(loggerSpy.getMessageAtIndex(6, 'info')).toEqual('  FSHOnly: true');
   });
 
   it('should extract an XML configuration with a url and dependencies', () => {

--- a/test/import/loadConfigurationFromIgResource.test.ts
+++ b/test/import/loadConfigurationFromIgResource.test.ts
@@ -48,7 +48,7 @@ describe('loadConfigurationFromIgResource', () => {
     );
     expect(loggerSpy.getMessageAtIndex(1, 'info')).toEqual('  canonical: "http://example.org"');
     expect(loggerSpy.getMessageAtIndex(2, 'info')).toEqual('  version: "1.0.0"');
-    expect(loggerSpy.getMessageAtIndex(3, 'info')).toEqual('  fhirVersion: ["4.0.1"]');
+    expect(loggerSpy.getMessageAtIndex(3, 'info')).toEqual('  fhirVersion[0]: "4.0.1"');
     expect(loggerSpy.getMessageAtIndex(4, 'info')).toEqual(
       '  dependencies[0]: {"packageId":"foo.bar","version":"1.2.3"}'
     );


### PR DESCRIPTION
When a configuration is extracted from an ImplementationGuide resource, info messages are logged for the elements of the configuration. The dependencies array may have many elements. To avoid an overly-long message, each element of the array is logged separately.