### PR TITLE
Switch antlr4 deps from ^ to ~

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/antlr4": "^4.7.2",
+    "@types/antlr4": "~4.7.2",
     "@types/fs-extra": "^8.1.0",
     "@types/html-minifier": "^3.5.3",
     "@types/ini": "^1.3.30",
@@ -71,7 +71,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "antlr4": "^4.8.0",
+    "antlr4": "~4.8.0",
     "axios": "^0.19.2",
     "chalk": "^3.0.0",
     "commander": "^4.1.1",


### PR DESCRIPTION
We only want patch upgrades on antlr4.  I thought I did this before, but apparenlty:
```
$ npm install --save antlr4@~4.8.0
```
results in `^4.8.0` in the `package.json`.  Seems like a bug to me.