### PR TITLE
Switch package-lock to npm-shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1216,9 +1216,10 @@
       }
     },
     "@types/antlr4": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@types/antlr4/-/antlr4-4.7.1.tgz",
-      "integrity": "sha512-mjQv+WtdJnwI5qhNh5yJkZ9rVFdRClUyaO5KebaLSJFHT6uSyDLAK9jUke4zLKZXk6vQQ/QJN2j7QV2q7l5Slw=="
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@types/antlr4/-/antlr4-4.7.2.tgz",
+      "integrity": "sha512-v6NASzZa4pUgO2QJJqGHTRRBfZDTOk2savuugSfCLatRTd2q+UtW0I7ub9mjzERhm7aWqGxBi886HnJkLYiIEA==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/antlr4": "~4.7.2",
     "@types/fs-extra": "^8.1.0",
     "@types/html-minifier": "^3.5.3",
     "@types/ini": "^1.3.30",
@@ -69,8 +70,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@types/antlr4": "^4.7.1",
-    "antlr4": "^4.8.0",
+    "antlr4": "~4.8.0",
     "axios": "^0.19.2",
     "chalk": "^3.0.0",
     "commander": "^4.1.1",


### PR DESCRIPTION
Same as #675 but for 0.16.x.  This PR switches `package-lock.json` to `npm-shrinkwrap.json`.  This PR also takes the extra precaution of changing dependencies on antlr4 to use `~` instead of `^`.  `~` will allow patch upgrades (e.g., `4.8.x`) but does not allow minor upgrades (e.g. `4.9.0`).

It's easiest to test this if you are running Node 12 or below.  In that case, do this on the branch `v0.x`:
```
$ npm pack
$ npm install -g ./fsh-sushi-1.0.1.tgz
```

You will see a message like this:
> npm WARN notsup Unsupported engine for antlr4@4.9.0: wanted: {"node":">=14"} (current: {"node":"12.19.0","npm":"6.14.8"})
> npm WARN notsup Not compatible with your version of node/npm: antlr4@4.9.0

Now do the same on this PR branch (pack and install) and you will no longer get that message.
