### PR TITLE
Update FshCode toString to support spaces in codes

### DIFF
--- a/src/fshtypes/FshCode.ts
+++ b/src/fshtypes/FshCode.ts
@@ -7,7 +7,7 @@ export class FshCode extends FshEntity {
   }
 
   toString(): string {
-    const str = `${this.system ?? ''}#${this.code}`;
+    const str = `${this.system ?? ''}#${this.code.includes(' ') ? `"${this.code}"` : this.code}`;
     return this.display ? `${str} "${this.display}"` : str;
   }
 

--- a/test/fshtypes/FshCode.test.ts
+++ b/test/fshtypes/FshCode.test.ts
@@ -1,0 +1,44 @@
+import { FshCode } from '../../src/fshtypes';
+
+describe('FshCode', () => {
+  describe('#constructor', () => {
+    it('should set the properties correctly', () => {
+      const p = new FshCode('my-code', 'http://important.com', 'My Important Code');
+      expect(p.code).toBe('my-code');
+      expect(p.system).toBe('http://important.com');
+      expect(p.display).toBe('My Important Code');
+    });
+  });
+
+  describe('#toString', () => {
+    it('should return string for basic code', () => {
+      const code = new FshCode('my-code');
+      const result = code.toString();
+      expect(result).toEqual('#my-code');
+    });
+
+    it('should return string for code with system', () => {
+      const code = new FshCode('my-code', 'http://foo.com');
+      const result = code.toString();
+      expect(result).toEqual('http://foo.com#my-code');
+    });
+
+    it('should return string for code with display', () => {
+      const code = new FshCode('my-code', null, 'Display');
+      const result = code.toString();
+      expect(result).toEqual('#my-code "Display"');
+    });
+
+    it('should return string for code with system and display', () => {
+      const code = new FshCode('my-code', 'http://foo.com', 'Display');
+      const result = code.toString();
+      expect(result).toEqual('http://foo.com#my-code "Display"');
+    });
+
+    it('should return string for code with code with spaces', () => {
+      const code = new FshCode('my spacey code');
+      const result = code.toString();
+      expect(result).toEqual('#"my spacey code"');
+    });
+  });
+});


### PR DESCRIPTION
This PR updates the `toString` method of `FshCode` to support codes that have spaces in them. Codes with spaces should be wrapped in quotation marks. I also added tests to test the `toString` function, which includes a test that checks for codes with spaces. That particular test would not pass without the update to the `toString` function. Since there were not tests for FshCode to start with, I haven't tested every function in the class, but I can add those if we think that's something we need and I should include now.

Note that using these changes with GoFSH will also allow us to correctly generate FSH from codes that had spaces in them, which is where we originally noticed this issue.