### PR TITLE
Support for loading FHIR R5 pre-releases

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ import { pad, padStart, sample, padEnd } from 'lodash';
 import { FSHTank, RawFSH } from './import';
 import { exportFHIR, Package } from './export';
 import { IGExporter } from './ig';
-import { logger, stats, Type } from './utils';
+import { logger, stats, isSupportedFHIRVersion, Type } from './utils';
 import { loadCustomResources } from './fhirdefs';
 import { FHIRDefinitions } from './fhirdefs';
 import { Configuration } from './fshtypes';
@@ -153,9 +153,9 @@ async function app() {
 
   // Check for StructureDefinition
   const structDef = defs.fishForFHIR('StructureDefinition', Type.Resource);
-  if (structDef?.version !== '4.0.1') {
+  if (structDef == null || !isSupportedFHIRVersion(structDef.version)) {
     logger.error(
-      'StructureDefinition resource not found for v4.0.1. The FHIR R4 package in local cache' +
+      'Valid StructureDefinition resource not found. The FHIR package in your local cache' +
         ' may be corrupt. Local FHIR cache can be found at <home-directory>/.fhir/packages.' +
         ' For more information, see https://wiki.hl7.org/FHIR_Package_Cache#Location.'
     );

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -65,7 +65,8 @@ export class ElementDefinitionType {
     const fhirTypeExtension = this.extension?.find(
       ext => ext.url === 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type'
     );
-    return fhirTypeExtension?.valueUrl ?? this._code;
+    // R4 uses valueUrl; R5 uses valueUri
+    return fhirTypeExtension?.valueUrl ?? fhirTypeExtension?.valueUri ?? this._code;
   }
 
   set code(c: string) {
@@ -2033,6 +2034,7 @@ export type ElementDefinitionExtension = {
   url: string;
   // TODO: support all the value[x]
   valueUrl?: string;
+  valueUri?: string;
 };
 
 export type ElementDefinitionExample = {

--- a/src/import/YAMLConfiguration.ts
+++ b/src/import/YAMLConfiguration.ts
@@ -78,7 +78,7 @@ export type YAMLConfiguration = {
   license?: ImplementationGuide['license']; // string
 
   // Although fhirVersions is 0..* in the ImplementationGuide resource, it can be a single item OR
-  // an array here (but so far SUSHI only supports 4.0.1 anyway).
+  // an array here (NOTE: SUSHI only supports FHIR 4.x versions).
   fhirVersion:
     | ImplementationGuide['fhirVersion'][0] // string
     | ImplementationGuide['fhirVersion']; // string[]

--- a/src/import/ensureConfigurationFile.ts
+++ b/src/import/ensureConfigurationFile.ts
@@ -209,15 +209,22 @@ function generateConfiguration(root: string, allowFromScratch: boolean): string 
     contents.add(new YAMLPair('license', packageJSON.license ?? igIni.license));
   }
   // fhirVersion
-  contents.add(new YAMLPair('fhirVersion', '4.0.1'));
+  const fhirDependency =
+    packageJSON.dependencies?.['hl7.fhir.r4.core'] ??
+    packageJSON.dependencies?.['hl7.fhir.r5.core'] ??
+    DEFAULT_PACKAGE_JSON.dependencies['hl7.fhir.r4.core'];
+  contents.add(new YAMLPair('fhirVersion', fhirDependency));
   // dependencies
   const packageWithDeps =
     packageJSON.dependencies &&
-    Object.keys(packageJSON.dependencies)?.some(k => k !== 'hl7.fhir.r4.core')
+    Object.keys(packageJSON.dependencies)?.some(
+      k => k !== 'hl7.fhir.r4.core' && k !== 'hl7.fhir.r5.core'
+    )
       ? packageJSON
       : DEFAULT_PACKAGE_JSON;
   const dependencies = cloneDeep(packageWithDeps.dependencies);
   delete dependencies['hl7.fhir.r4.core'];
+  delete dependencies['hl7.fhir.r5.core'];
   if (packageWithDeps !== DEFAULT_PACKAGE_JSON) {
     contents.add(new YAMLPair('dependencies', dependencies));
   }
@@ -638,7 +645,7 @@ const DEFAULT_PACKAGE_LIST: any = {
     },
     {
       version: DEFAULT_PACKAGE_JSON.version,
-      fhirversion: '4.0.1',
+      fhirversion: DEFAULT_PACKAGE_JSON.dependencies['hl7.fhir.r4.core'],
       date: '2099-01-01',
       desc: 'Initial STU ballot (Mmm yyyy Ballot)',
       path: 'http://example.org/fhir/STU1',

--- a/src/run/FshToFhir.ts
+++ b/src/run/FshToFhir.ts
@@ -15,7 +15,7 @@ import {
  * NOTE: This function is not safe for true asynchronous usage. If two calls of this function are running at once, the error and warnings reported
  * will be inconsistent. Always ensure a given call to this function completes before making a new call.
  * @param {string|string[]} input - A string or array of strings containing FSH
- * @param {fshToFhirOptions} options - An object containing options for processing. Options include canonical, version, dependencies, and logLevel
+ * @param {fshToFhirOptions} options - An object containing options for processing. Options include canonical, version, fhirVersion, dependencies, and logLevel
  * @returns {Promise<{fhir: any[]; errors: ErrorsAndWarnings['errors']; warnings: ErrorsAndWarnings['warnings'];}>} - Object containing generated fhir, and errors/warnings from processing
  */
 export async function fshToFhir(
@@ -52,7 +52,7 @@ export async function fshToFhir(
   const config = {
     canonical: options.canonical ?? 'http://example.org',
     FSHOnly: true,
-    fhirVersion: ['4.0.1'],
+    fhirVersion: [options.fhirVersion ?? '4.0.1'],
     dependencies: options.dependencies,
     version: options.version
   };
@@ -93,6 +93,7 @@ export async function fshToFhir(
 type fshToFhirOptions = {
   canonical?: string;
   version?: string;
+  fhirVersion?: string;
   dependencies?: ImplementationGuideDependsOn[];
   logLevel?: Level;
 };

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -181,7 +181,7 @@ export function loadExternalDependencies(
   const fhirPackageId = fhirVersion.startsWith('4.0') ? 'hl7.fhir.r4.core' : 'hl7.fhir.r5.core';
   if (fhirPackageId === 'hl7.fhir.r5.core') {
     logger.warn(
-      'SUSHI support for pre-release versions of FHIR is experimental.  Use at your own risk!'
+      'SUSHI support for pre-release versions of FHIR is experimental. Use at your own risk!'
     );
   }
   dependencies.push({ packageId: fhirPackageId, version: fhirVersion });

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -6,6 +6,7 @@ import { TestFisher } from '../testhelpers';
 import { Type } from '../../src/utils/Fishable';
 import { Invariant, FshCode } from '../../src/fshtypes';
 import path from 'path';
+import { cloneDeep } from 'lodash';
 
 describe('ElementDefinition', () => {
   let defs: FHIRDefinitions;
@@ -653,12 +654,26 @@ describe('ElementDefinition', () => {
   });
 
   describe('#ElementDefinitionType get code', () => {
-    it('should return valueUrl value when extension of fhir-type', () => {
+    it('should return valueUrl value when extension of fhir-type (R4)', () => {
       const code = valueId.type[0].code;
       const trueCodeValue = valueId.type[0].getActualCode();
       expect(code).toEqual('string');
       expect(trueCodeValue).toEqual('http://hl7.org/fhirpath/System.String');
     });
+
+    it('should return valueUri value when extension of fhir-type (R5)', () => {
+      // Create an R5 representation of the valueId (using valueUri instead of valueUrl)
+      const jsonValueIdR5 = cloneDeep(jsonValueId);
+      delete jsonValueIdR5.type[0].extension[0].valueUrl;
+      jsonValueIdR5.type[0].extension[0].valueUri = 'string';
+      const valueIdR5 = ElementDefinition.fromJSON(jsonValueIdR5);
+
+      const code = valueIdR5.type[0].code;
+      const trueCodeValue = valueIdR5.type[0].getActualCode();
+      expect(code).toEqual('string');
+      expect(trueCodeValue).toEqual('http://hl7.org/fhirpath/System.String');
+    });
+
     it('should return code value when extension is not of fhir-type', () => {
       const code = valueX.type[0].code;
       expect(code).toEqual('Quantity');

--- a/test/import/ensureConfigurationFile.test.ts
+++ b/test/import/ensureConfigurationFile.test.ts
@@ -358,6 +358,32 @@ describe('ensureConfigurationFile', () => {
     });
   });
 
+  it('should generate an appropriate config for a tank w/ R5 package.json', () => {
+    // Copy the fixture to a temp folder since we actually create files in the tank
+    const tank = temp.mkdirSync('sushi-test');
+    fs.copySync(path.join(__dirname, 'fixtures', 'package-json-only'), tank);
+
+    // Tweak the JSON to remove optional fields
+    const packageJSON = fs.readJsonSync(path.join(tank, 'package.json'));
+    delete packageJSON.url;
+    delete packageJSON.title;
+    delete packageJSON.description;
+    delete packageJSON.dependencies;
+    delete packageJSON.author;
+    delete packageJSON.maintainers;
+    delete packageJSON.license;
+    packageJSON.dependencies = { 'hl7.fhir.r5.core': '4.5.0' };
+    fs.writeJsonSync(path.join(tank, 'package.json'), packageJSON);
+
+    // ensureConfiguration
+    const configPath = ensureConfiguration(tank);
+    const configText = fs.readFileSync(configPath, 'utf8');
+    const configJSON = YAML.parse(configText);
+
+    // We've tested most of this already.  We only care about the fhirVersion.
+    expect(configJSON.fhirVersion).toEqual('4.5.0');
+  });
+
   it('should generate an appropriate config for a tank w/ a package.json and legacy ig.ini', () => {
     // Copy the fixture to a temp folder since we actually create files in the tank
     const tank = temp.mkdirSync('sushi-test');

--- a/test/run/FshToFhir.test.ts
+++ b/test/run/FshToFhir.test.ts
@@ -83,12 +83,20 @@ describe('#FshToFhir', () => {
       fshToFhir('', {
         canonical: 'http://mycanonical.org',
         dependencies: [{ packageId: 'hl7.fhir.test.core', version: '1.2.3' }],
+        fhirVersion: '4.5.0',
         version: '3.2.1'
       })
     ).resolves.toEqual({
       errors: [],
       warnings: [],
       fhir: []
+    });
+    expect(loadSpy.mock.calls[0][1]).toEqual({
+      FSHOnly: true,
+      canonical: 'http://mycanonical.org',
+      dependencies: [{ packageId: 'hl7.fhir.test.core', version: '1.2.3' }],
+      fhirVersion: ['4.5.0'],
+      version: '3.2.1'
     });
   });
 

--- a/test/utils/fixtures/fhir-current/sushi-config.yaml
+++ b/test/utils/fixtures/fhir-current/sushi-config.yaml
@@ -1,0 +1,9 @@
+id: fhir.us.minimal
+canonical: http://hl7.org/fhir/us/minimal
+name: MinimalIG
+status: draft
+version: 1.0.0
+fhirVersion: current
+copyrightYear: 2020+
+releaseLabel: Build CI
+template: hl7.fhir.template#0.0.5

--- a/test/utils/fixtures/fhir-four-oh-oh/sushi-config.yaml
+++ b/test/utils/fixtures/fhir-four-oh-oh/sushi-config.yaml
@@ -1,0 +1,9 @@
+id: fhir.us.minimal
+canonical: http://hl7.org/fhir/us/minimal
+name: MinimalIG
+status: draft
+version: 1.0.0
+fhirVersion: 4.0.0
+copyrightYear: 2020+
+releaseLabel: Build CI
+template: hl7.fhir.template#0.0.5

--- a/test/utils/fixtures/fhir-r5/sushi-config.yaml
+++ b/test/utils/fixtures/fhir-r5/sushi-config.yaml
@@ -1,0 +1,9 @@
+id: fhir.us.minimal
+canonical: http://hl7.org/fhir/us/minimal
+name: MinimalIG
+status: draft
+version: 1.0.0
+fhirVersion: 4.5.0
+copyrightYear: 2020+
+releaseLabel: Build CI
+template: hl7.fhir.template#0.0.5


### PR DESCRIPTION
This allows users to specify FHIR versions > 4.0.1.  In that case, the user will receive a warning that support for pre-releases is experimental.

NOTE: this does not add support for new datatypes like integer64 or CodeableReference.

To test this on a real SUSHI project, checkout the [r5-experimental](https://github.com/HL7/fhir-mCODE-ig/tree/r5-experimental) branch on mCODE.  You can also change its FHIR version to `current` to test w/ current FHIR build.  Note that I did not have success building w/ the FHIR IG Publisher, but the errors did not seem to be related to faults in what SUSHI was doing.