### PR TITLE
Log less confusing error on inline instance assignment

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -162,7 +162,15 @@ export class StructureDefinitionExporter implements Fishable {
               const instanceExporter = new InstanceExporter(this.tank, this.pkg, this.fisher);
               const instance = instanceExporter.fishForFHIR(rule.value as string);
               if (instance == null) {
-                logger.error(`Cannot find definition for Instance: ${rule.value}. Skipping rule.`);
+                if (element.type?.length === 1) {
+                  logger.error(
+                    `Cannot assign Instance at ${rule.value} to element of type ${element.type[0].code}. Instance definition not found.`
+                  );
+                } else {
+                  logger.error(
+                    `Cannot find definition for Instance: ${rule.value}. Skipping rule.`
+                  );
+                }
                 continue;
               }
               rule.value = instance;

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -164,7 +164,7 @@ export class StructureDefinitionExporter implements Fishable {
               if (instance == null) {
                 if (element.type?.length === 1) {
                   logger.error(
-                    `Cannot assign Instance at ${rule.value} to element of type ${element.type[0].code}. Instance definition not found.`
+                    `Cannot assign Instance at path ${rule.path} to element of type ${element.type[0].code}. Definition not found for Instance: ${rule.value}.`
                   );
                 } else {
                   logger.error(

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1745,7 +1745,7 @@ describe('StructureDefinitionExporter', () => {
     expect(assignedAddress.patternAddress).toBeUndefined();
     expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
     expect(loggerSpy.getLastMessage('error')).toMatch(
-      /Cannot find definition for Instance: FakeInstance. Skipping rule.\D*/s
+      /Cannot assign Instance at FakeInstance to element of type Address\D*/s
     );
   });
 

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1745,7 +1745,7 @@ describe('StructureDefinitionExporter', () => {
     expect(assignedAddress.patternAddress).toBeUndefined();
     expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
     expect(loggerSpy.getLastMessage('error')).toMatch(
-      /Cannot assign Instance at FakeInstance to element of type Address\D*/s
+      /Cannot assign Instance at path address to element of type Address.*FakeInstance\D*/s
     );
   });
 


### PR DESCRIPTION
Fixes https://github.com/FHIR/sushi/issues/703 by slightly clarifying the error message we log when someone assigns an inline instance. I don't think there is a clear way here to guess the intent of the user. Even if the element is of type CodeableConcept, the user could be trying to assign an inline instance of a CodeableConcept to that element. So all this PR does is log the type of the element being assigned onto, if it is possible. I think this should potentially help people understand what is going wrong when they assign a value.

If this doesn't seem sufficient, and someone sees a better way to log this message and/or guess the intent of the user, let me know.