### PR TITLE
Update the publisher scripts location

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -371,14 +371,14 @@ export async function init(): Promise<void> {
     path.join(outputDir, 'input', 'ignoreWarnings.txt')
   );
   // Add the _updatePublisher, _genonce, and _gencontinuous scripts
-  console.log('Downloading publisher scripts from https://github.com/FHIR/sample-ig');
+  console.log('Downloading publisher scripts from https://github.com/HL7/ig-publisher-scripts');
   for (const script of [
     '_genonce.bat',
     '_genonce.sh',
     '_updatePublisher.bat',
     '_updatePublisher.sh'
   ]) {
-    const url = `http://raw.githubusercontent.com/FHIR/sample-ig/master/${script}`;
+    const url = `http://raw.githubusercontent.com/HL7/ig-publisher-scripts/master/${script}`;
     try {
       const res = await axios.get(url);
       fs.writeFileSync(path.join(outputDir, script), res.data);

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -378,7 +378,7 @@ export async function init(): Promise<void> {
     '_updatePublisher.bat',
     '_updatePublisher.sh'
   ]) {
-    const url = `http://raw.githubusercontent.com/HL7/ig-publisher-scripts/master/${script}`;
+    const url = `http://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/${script}`;
     try {
       const res = await axios.get(url);
       fs.writeFileSync(path.join(outputDir, script), res.data);

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -770,7 +770,7 @@ describe('Processing', () => {
       expect(copyFileSpy.mock.calls[2][1]).toMatch(/.*ExampleIG.*input.*ignoreWarnings\.txt/);
 
       expect(getSpy.mock.calls).toHaveLength(4);
-      const base = 'http://raw.githubusercontent.com/FHIR/sample-ig/master/';
+      const base = 'http://raw.githubusercontent.com/HL7/ig-publisher-scripts/master/';
       expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
       expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
       expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
@@ -837,7 +837,7 @@ describe('Processing', () => {
       );
 
       expect(getSpy.mock.calls).toHaveLength(4);
-      const base = 'http://raw.githubusercontent.com/FHIR/sample-ig/master/';
+      const base = 'http://raw.githubusercontent.com/HL7/ig-publisher-scripts/master/';
       expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
       expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
       expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -770,7 +770,7 @@ describe('Processing', () => {
       expect(copyFileSpy.mock.calls[2][1]).toMatch(/.*ExampleIG.*input.*ignoreWarnings\.txt/);
 
       expect(getSpy.mock.calls).toHaveLength(4);
-      const base = 'http://raw.githubusercontent.com/HL7/ig-publisher-scripts/master/';
+      const base = 'http://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
       expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
       expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
       expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
@@ -837,7 +837,7 @@ describe('Processing', () => {
       );
 
       expect(getSpy.mock.calls).toHaveLength(4);
-      const base = 'http://raw.githubusercontent.com/HL7/ig-publisher-scripts/master/';
+      const base = 'http://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
       expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
       expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
       expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');


### PR DESCRIPTION
Fixes https://github.com/FHIR/sushi/issues/718 by updating `sushi --init` to look in the new location for the IG Publisher scripts, which is this URL: https://github.com/HL7/ig-publisher-scripts.

For testing, I think just running `sushi --init`, making sure the scripts download and can then be run to generate the simple example IG is sufficient.