### PR TITLE
Regression should use npx diff2html-cli

### DIFF
--- a/regression/run-regression.ts
+++ b/regression/run-regression.ts
@@ -335,7 +335,7 @@ async function generateDiff(repo: Repo, config: Config, htmlTemplate: string): P
       'npx',
       [
         '-q',
-        'diff2html',
+        'diff2html-cli',
         '-i',
         'file',
         '-s',


### PR DESCRIPTION
The npm module name is actually diff2html-cli (although, once installed, the binary command is diff2html).

This corresponds to FHIR/GoFSH#65 which makes a similar change.