### PR TITLE
Fix handling of empty string ruleset parameters

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1559,7 +1559,7 @@ export class FSHImporter extends FSHVisitor {
           // then, make all the replacements: closing parenthesis and comma
           return substrComma.replace(/\\\)/g, ')').replace(/\\,/g, ',');
         })
-        .filter(s => s); // Filter out any null values from incorrectly split escaped commas
+        .filter(s => s != null); // Filter out any null values from incorrectly split escaped commas
     });
     const paramList: string[] = [];
     // if splitComma has more than one list, that means we split on literal backslash

--- a/test/import/FSHImporter.Instance.test.ts
+++ b/test/import/FSHImporter.Instance.test.ts
@@ -252,6 +252,31 @@ describe('FSHImporter', () => {
         expect(instance.rules).toHaveLength(1);
         assertInsertRule(instance.rules[0], 'MyRuleSet');
       });
+
+      it('should parse an insert rule with an empty parameter value', () => {
+        // Example taken from open-hie/case-reporting, which failed a regression in this area
+        const input = `
+        RuleSet: Question(context, linkId, text, type, repeats)
+        * {context}item[+].linkId = "{linkId}"
+        * {context}item[=].text = "{text}"
+        * {context}item[=].type = #{type}
+        * {context}item[=].repeats = {repeats}
+
+        Instance: case-reporting-questionnaire
+        InstanceOf: Questionnaire
+        * insert Question(,title, HIV Case Report, display, false)
+        `;
+        const result = importSingleText(input, 'Insert.fsh');
+        const instance = result.instances.get('case-reporting-questionnaire');
+        expect(instance.rules).toHaveLength(1);
+        assertInsertRule(instance.rules[0], 'Question', [
+          '',
+          'title',
+          'HIV Case Report',
+          'display',
+          'false'
+        ]);
+      });
     });
 
     describe('#instanceMetadata', () => {


### PR DESCRIPTION
To manually test this (and see broken behavior vs fixed behavior

* Locally edit `regression/repos-select.txt` so it contains only one line:
  ```
  openhie/case-reporting#master
  ```
* Run regression: `npm run regression`

Note that in the results, the master branch produces 12 errors and this branch produces 0 errors.  Also note that in the diff, this branch's questionnaire instance contains many items missing from the master branch's instance.