### PR TITLE
Extensions can now be referenced by URL on Instances

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -22,6 +22,7 @@ import {
 import { Fishable, Type } from '../utils/Fishable';
 import { applyMixins, parseFSHPath, assembleFSHPath } from '../utils';
 import { InstanceDefinition } from './InstanceDefinition';
+import { isUri } from 'valid-url';
 
 /**
  * A class representing a FHIR R4 StructureDefinition.  For the most part, each allowable property in a StructureDefinition
@@ -481,7 +482,9 @@ export class StructureDefinition {
           if (!extensionElement.slicing) {
             extensionElement.sliceIt('value', 'url');
           }
-          const slice = extensionElement.addSlice(pathPart.brackets[0]);
+          // If an extension is referenced by url, we'll want to add the slice with it's id instead
+          const sliceName = isUri(pathPart.brackets[0]) ? extension.id : pathPart.brackets[0];
+          const slice = extensionElement.addSlice(sliceName);
           if (!slice.type[0].profile) {
             slice.type[0].profile = [];
           }

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -1204,6 +1204,23 @@ describe('StructureDefinition', () => {
       expect(respRate.elements.length).toBe(originalLength + 5);
     });
 
+    it('should allow setting abritrary defined extensions by url', () => {
+      const originalLength = respRate.elements.length;
+      const { assignedValue, pathParts } = respRate.validateValueAtPath(
+        'extension[http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName].value[x]',
+        'foo',
+        fisher
+      );
+      expect(assignedValue).toBe('foo');
+      expect(pathParts.length).toBe(2);
+      expect(pathParts[0]).toEqual({
+        base: 'extension',
+        brackets: ['http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName', '0'],
+        slices: ['http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName']
+      });
+      expect(respRate.elements.length).toBe(originalLength + 5);
+    });
+
     it('should allow setting nested arbitrary defined extensions', () => {
       const originalLength = respRate.elements.length;
       const { assignedValue, pathParts } = respRate.validateValueAtPath(


### PR DESCRIPTION
Fixes #674 and addresses [CIMPL-605](https://standardhealthrecord.atlassian.net/browse/CIMPL-605), fixing a bug where extensions would fail to be referenced by URL. On master, the following assignment rule on a Patient instance should generate an error...
```
* extension[http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity].extension[text].valueString = "Not Hispanic or Latino"
```
while simply setting an alias for the url would work just fine...
```
Alias:  USCoreEthnicity = http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity
* extension[USCoreEthnicity].extension[text].valueString = "Not Hispanic or Latino"
```
Both methods of referencing the extension should work in this PR. This is a pretty simple fix, simply creating a new slice on the extension element using the referenced extensions `id` property rather than its Url. This allows the extension being reference to be found by `findElementByPath` without any changes to that function.