### PR TITLE
Fix Extension URL on Instance

### DIFF
--- a/regression/run-regression.ts
+++ b/regression/run-regression.ts
@@ -8,7 +8,7 @@ import program from 'commander';
 import readlineSync from 'readline-sync';
 import extract from 'extract-zip';
 import opener from 'opener';
-import { union } from 'lodash';
+import { isEqual, union } from 'lodash';
 import { createTwoFilesPatch } from 'diff';
 
 // Track temporary files so they are deleted when the process exits
@@ -315,6 +315,12 @@ async function generateDiff(repo: Repo, config: Config, htmlTemplate: string): P
     const v1File = path.join(repoSUSHIDir1, file);
     const v2File = path.join(repoSUSHIDir2, file);
     const [v1Contents, v2Contents] = await Promise.all([readFile(v1File), readFile(v2File)]);
+
+    try {
+      if (isEqual(JSON.parse(v1Contents), JSON.parse(v2Contents))) {
+        continue;
+      }
+    } catch {}
 
     const v1Label = path.relative(config.getRepoDir(repo), v1File);
     const v2Label = path.relative(config.getRepoDir(repo), v2File);

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -1582,6 +1582,33 @@ describe('InstanceExporter', () => {
       ]);
     });
 
+    it('should assign a nested sliced extension element that is referred to by name', () => {
+      const fooExtension = new Extension('FooExtension');
+      doc.extensions.set(fooExtension.name, fooExtension);
+      const containsRule = new ContainsRule('maritalStatus.extension');
+      containsRule.items = [{ name: 'foo', type: 'FooExtension' }];
+      patient.rules.push(containsRule);
+      const barRule = new AssignmentRule('maritalStatus.extension[foo].valueString');
+      barRule.value = 'bar';
+      const maritalRule = new AssignmentRule('maritalStatus');
+      maritalRule.value = new FshCode('boo');
+      patientInstance.rules.push(maritalRule, barRule);
+      const exported = exportInstance(patientInstance);
+      expect(exported.maritalStatus).toEqual({
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/FooExtension',
+            valueString: 'bar'
+          }
+        ],
+        coding: [
+          {
+            code: 'boo'
+          }
+        ]
+      });
+    });
+
     it('should assign a sliced extension element that is referred to by url', () => {
       const fooExtension = new Extension('FooExtension');
       doc.extensions.set(fooExtension.name, fooExtension);
@@ -2509,9 +2536,7 @@ describe('InstanceExporter', () => {
         // * valueQuantity = MyAge
         respRateInstance.rules.push(inlineRule);
         const exported = exportInstance(respRateInstance);
-        expect(exported.valueQuantity).toEqual({
-          value: 42
-        });
+        expect(exported.valueQuantity.value).toBe(42);
       });
 
       it('should not overwrite the value property when assigning a Quantity object', () => {
@@ -2565,9 +2590,7 @@ describe('InstanceExporter', () => {
         // * valueQuantity = MySimple
         respRateInstance.rules.push(inlineRule);
         const exported = exportInstance(respRateInstance);
-        expect(exported.valueQuantity).toEqual({
-          value: 7
-        });
+        expect(exported.valueQuantity.value).toBe(7);
       });
 
       it('should assign an inline instance of a FSH defined profile of a type to an instance', () => {
@@ -2590,9 +2613,7 @@ describe('InstanceExporter', () => {
         // * valueQuantity = MyQuantity
         respRateInstance.rules.push(inlineRule);
         const exported = exportInstance(respRateInstance);
-        expect(exported.valueQuantity).toEqual({
-          value: 7
-        });
+        expect(exported.valueQuantity.value).toBe(7);
       });
 
       it('should assign an inline instance of an extension to an instance', () => {


### PR DESCRIPTION
Fixes https://github.com/FHIR/sushi/issues/751.

The bug described in the issue would happen because `type.extension.url` is an implied rule, and implied rules are applied before explicit rules. So this rule would be applied, but this line:
```
* type = StraumannCSFDAProductCode#NHA "Abutment, Implant, Dental, Endosseous"
```
would overwrite the value of `type` entirely, removing the `type.extension.url` value. To fix this, this PR makes it so that implied rules are applied to one copy of the instance, and explicit rules are applied to another. Then these two objects are merged together. If the implicit and explicit rules conflict, the explicit rules will win, but values that can coexist, like in this bug, are not overwritten.

To test this, you can run the example given in the issue on `master`, and notice that `type.extension[0].url` is not set, and an error is emitted about this. On this branch, that value does get set, and there is no error. You can also try the test on https://github.com/FHIR/sushi/commit/7b003f31ba6f857a9e175a96256b627d57b1a153 and note that it fails, but on the latest commit it will pass.