### PR TITLE
Expand ValueSet

### DIFF
--- a/src/export/FHIRExporter.ts
+++ b/src/export/FHIRExporter.ts
@@ -37,8 +37,8 @@ export class FHIRExporter {
 
   export(): Package {
     this.structureDefinitionExporter.export();
-    this.valueSetExporter.export();
     this.codeSystemExporter.export();
+    this.valueSetExporter.export();
     this.instanceExporter.export();
     this.structureDefinitionExporter.applyDeferredRules();
     this.mappingExporter.export();

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -2,7 +2,8 @@ import {
   ValueSet,
   ValueSetComposeIncludeOrExclude,
   ValueSetComposeConcept,
-  StructureDefinition
+  StructureDefinition,
+  ValueSetExpansionContains
 } from '../fhirtypes';
 import { FSHTank } from '../import/FSHTank';
 import { FshValueSet, FshCode, ValueSetFilterValue } from '../fshtypes';
@@ -18,6 +19,10 @@ import {
 } from '../fshtypes/rules';
 import { setPropertyOnInstance, applyInsertRules } from '../fhirtypes/common';
 import { isUri } from 'valid-url';
+import fromPairs from 'lodash/fromPairs';
+import cloneDeep from 'lodash/cloneDeep';
+import flatMap from 'lodash/flatMap';
+
 export class ValueSetExporter {
   constructor(private readonly tank: FSHTank, private pkg: Package, private fisher: MasterFisher) {}
 
@@ -130,6 +135,155 @@ export class ValueSetExporter {
     }
   }
 
+  private performExpansion(valueSet: ValueSet) {
+    if (
+      valueSet.expansion?.parameter?.find(
+        parameter => parameter.name === 'sushi-generated' && parameter.valueBoolean === true
+      )
+    ) {
+      const errors: string[] = [];
+      // the compose property must be defined
+      if (!valueSet.compose) {
+        errors.push('No composition defined.');
+      }
+      // filter operators are prohibited
+      if (
+        [...(valueSet.compose?.include ?? []), ...(valueSet.compose?.exclude ?? [])].some(
+          compose => {
+            return compose.filter?.some(filter => {
+              return filter.op?.length;
+            });
+          }
+        )
+      ) {
+        errors.push('Composition contains filter operators.');
+      }
+      // including/excluding value sets are prohibited
+      if (
+        [...(valueSet.compose?.include ?? []), ...(valueSet.compose?.exclude ?? [])].some(
+          compose => {
+            return compose.valueSet?.length && !compose.concept?.length;
+          }
+        )
+      ) {
+        errors.push('Composition contains other value sets.');
+      }
+      // full usage of non-local code systems are prohibited
+      const referencedCodeSystems = fromPairs(
+        [...(valueSet.compose?.include ?? []), ...(valueSet.compose?.exclude ?? [])]
+          .filter(compose => {
+            return !compose.concept?.length && compose.system;
+          })
+          .map(compose => [
+            compose.system,
+            this.fisher.fishForFHIR(compose.system, Type.CodeSystem)
+          ])
+      );
+      // if we were able to fish up definitions for all of these systems, we're good
+      if (Object.values(referencedCodeSystems).includes(undefined)) {
+        errors.push('Composition contains code systems without available concept lists.');
+      }
+
+      // what we like best of all is when we just have a list of concepts. they'll even have a system specified already!
+      if (errors.length) {
+        logger.error(`Unable to expand ValueSet ${valueSet.name}: ${errors.join(' ')}`);
+      } else {
+        valueSet.expansion.contains = [];
+
+        valueSet.compose.include.forEach(compose => {
+          // add specific included codes
+          compose.concept?.forEach(concept => {
+            const containedItem: ValueSetExpansionContains = {
+              system: compose.system,
+              code: concept.code
+            };
+            if (compose.version) {
+              containedItem.version = compose.version;
+            }
+            if (concept.display) {
+              containedItem.display = concept.display;
+            }
+            if (concept.designation) {
+              containedItem.designation = cloneDeep(concept.designation);
+            }
+            // remove before adding, since we do not want it to be present multiple times
+            this.removeConcept(containedItem, valueSet.expansion.contains);
+            valueSet.expansion.contains.push(containedItem);
+          });
+          // add known included code systems
+          if (!compose.concept?.length && compose.system) {
+            const codeSystem = referencedCodeSystems[compose.system];
+            const newConcepts = this.getConcepts(codeSystem, codeSystem.concept);
+            // flatten so we can remove each existing concept before adding
+            const newConceptsFlat = flatMap(newConcepts, extractContained);
+            newConceptsFlat.forEach(concept =>
+              this.removeConcept(concept, valueSet.expansion.contains)
+            );
+            valueSet.expansion.contains.push(...newConcepts);
+          }
+        });
+        valueSet.compose.exclude?.forEach(compose => {
+          // remove specific excluded codes
+          compose.concept?.forEach(concept => {
+            this.removeConcept(
+              { system: compose.system, code: concept.code },
+              valueSet.expansion.contains
+            );
+          });
+          // remove known excluded code systems
+          // this is a little unusual to do, but we'll allow it.
+          if (!compose.concept?.length && compose.system) {
+            const codeSystem = referencedCodeSystems[compose.system];
+            const conceptsToRemove = flatMap(this.getConcepts(codeSystem, codeSystem.concept));
+            conceptsToRemove.forEach(concept =>
+              this.removeConcept(concept, valueSet.expansion.contains)
+            );
+          }
+        });
+      }
+    }
+  }
+
+  private getConcepts(system: any, concepts: any[]): ValueSetExpansionContains[] {
+    return concepts.map(concept => {
+      const contained: ValueSetExpansionContains = {
+        system: system.url,
+        code: concept.code
+      };
+      if (system.version) {
+        contained.version = system.version;
+      }
+      if (concept.display) {
+        contained.display = concept.display;
+      }
+      if (concept.concept?.length > 0) {
+        contained.contains = this.getConcepts(system, concept.concept);
+      }
+      return contained;
+    });
+  }
+
+  private removeConcept(target: ValueSetExpansionContains, concepts: ValueSetExpansionContains[]) {
+    const targetIndex = concepts.findIndex(concept => {
+      return concept.code === target.code && concept.system === target.system;
+    });
+    if (targetIndex > -1) {
+      const [removedConcept] = concepts.splice(targetIndex, 1);
+      if (removedConcept.contains?.length) {
+        concepts.splice(targetIndex, 0, ...removedConcept.contains);
+      }
+    } else {
+      concepts.forEach(concept => {
+        if (concept.contains?.length) {
+          this.removeConcept(target, concept.contains);
+          if (concept.contains.length === 0) {
+            delete concept.contains;
+          }
+        }
+      });
+    }
+  }
+
   export(): Package {
     const valueSets = this.tank.getAllValueSets();
     for (const valueSet of valueSets) {
@@ -166,6 +320,7 @@ export class ValueSetExporter {
     if (vs.compose && vs.compose.include.length == 0) {
       throw new ValueSetComposeError(fshDefinition.name);
     }
+    this.performExpansion(vs);
 
     // check for another value set with the same id
     // see https://www.hl7.org/fhir/resource.html#id
@@ -179,4 +334,10 @@ export class ValueSetExporter {
     this.pkg.valueSets.push(vs);
     return vs;
   }
+}
+
+// If the minimum node version reaches 11 or higher, Array.prototype.flat becomes available
+// and this can be reimplemented without needing lodash.
+function extractContained(c: ValueSetExpansionContains): ValueSetExpansionContains[] {
+  return [{ code: c.code, system: c.system }, ...flatMap(c.contains || [], extractContained)];
 }

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -161,7 +161,7 @@ export class ValueSetExporter {
         ...(valueSet.compose?.exclude ?? [])
       ].some(compose => compose.valueSet?.length);
       if (usesValueSet) {
-        errors.push('Composition contains other value sets.');
+        errors.push('Composition contains other ValueSets.');
       }
       // usage of a code system that we can't fish up is prohibited.
       // the code system's content must be "complete" or "example".
@@ -185,7 +185,7 @@ export class ValueSetExporter {
       });
       // if we were able to fish up definitions for all of these systems, we're good
       if (hasUnavailableCodeSystem) {
-        errors.push('Composition contains code systems without available concept lists.');
+        errors.push('Composition contains CodeSystems without available concept lists.');
       }
 
       // what we like best of all is when we just have a list of concepts. they'll even have a system specified already!

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -164,7 +164,7 @@ export class ValueSetExporter {
         errors.push('Composition contains other ValueSets.');
       }
       // usage of a code system that we can't fish up is prohibited.
-      // the code system's content must be "complete" or "example".
+      // the code system's content must be "complete".
       // if the compose specifies a version, the code system's version must match it.
       const referencedCodeSystems = fromPairs(
         [...(valueSet.compose?.include ?? []), ...(valueSet.compose?.exclude ?? [])]

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -181,7 +181,7 @@ export class ValueSetExporter {
           })
       );
       const hasUnavailableCodeSystem = Object.values(referencedCodeSystems).some(codeSystem => {
-        return codeSystem == null || !['complete', 'example'].includes(codeSystem.content);
+        return codeSystem?.content !== 'complete';
       });
       // if we were able to fish up definitions for all of these systems, we're good
       if (hasUnavailableCodeSystem) {

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -247,6 +247,9 @@ export class ValueSetExporter {
             );
           }
         });
+        // Now that we're done, let's add a timestamp and a total
+        valueSet.expansion.timestamp = `${new Date()}`;
+        valueSet.expansion.total = flatMap(valueSet.expansion.contains, extractContained).length;
       }
     }
   }

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -248,7 +248,7 @@ export class ValueSetExporter {
           }
         });
         // Now that we're done, let's add a timestamp and a total
-        valueSet.expansion.timestamp = `${new Date()}`;
+        valueSet.expansion.timestamp = new Date().toISOString();
         valueSet.expansion.total = flatMap(valueSet.expansion.contains, extractContained).length;
       }
     }

--- a/src/fhirtypes/ValueSet.ts
+++ b/src/fhirtypes/ValueSet.ts
@@ -100,6 +100,8 @@ export type ValueSetComposeFilter = {
 export type ValueSetExpansion = {
   parameter: ValueSetExpansionParameter[];
   contains: ValueSetExpansionContains[];
+  timestamp: string;
+  total?: number;
 };
 
 export type ValueSetExpansionContains = ValueSetComposeConcept & {

--- a/src/fhirtypes/ValueSet.ts
+++ b/src/fhirtypes/ValueSet.ts
@@ -40,6 +40,7 @@ export class ValueSet {
   purpose: string;
   copyright: string;
   compose: ValueSetCompose;
+  expansion: ValueSetExpansion;
 
   /**
    * Get the file name for serializing to disk.
@@ -94,4 +95,26 @@ export type ValueSetComposeFilter = {
   property: string;
   op: string;
   value: string;
+};
+
+export type ValueSetExpansion = {
+  parameter: ValueSetExpansionParameter[];
+  contains: ValueSetExpansionContains[];
+};
+
+export type ValueSetExpansionContains = ValueSetComposeConcept & {
+  system: string;
+  version?: string;
+  contains?: ValueSetExpansionContains[];
+};
+
+export type ValueSetExpansionParameter = {
+  name: string;
+  valueString?: string;
+  valueBoolean?: boolean;
+  valueInteger?: number;
+  valueDecimal?: number;
+  valueUri?: string;
+  valueCode?: string;
+  valueDateTime?: string;
 };

--- a/test/export/FHIRExporter.test.ts
+++ b/test/export/FHIRExporter.test.ts
@@ -3,8 +3,8 @@ import { exportFHIR, Package, FHIRExporter } from '../../src/export';
 import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, loadFromPath } from '../../src/fhirdefs';
 import { minimalConfig } from '../utils/minimalConfig';
-import { Instance, Profile } from '../../src/fshtypes';
-import { CaretValueRule } from '../../src/fshtypes/rules';
+import { Instance, Profile, FshCodeSystem, FshValueSet } from '../../src/fshtypes';
+import { CaretValueRule, ConceptRule, ValueSetFilterComponentRule } from '../../src/fshtypes/rules';
 import { TestFisher, loggerSpy } from '../testhelpers';
 
 describe('FHIRExporter', () => {
@@ -126,6 +126,52 @@ describe('FHIRExporter', () => {
       expect(loggerSpy.getLastMessage('error')).toMatch(
         /Could not find a resource named oops-no-resource/s
       );
+    });
+
+    it('should allow a value set to be expanded when it refers to an exported code system', () => {
+      // CodeSystem: DessertCodes
+      // * #cake "Cake"
+      // * #icecream "Ice Cream"
+      const codeSystem = new FshCodeSystem('DessertCodes');
+      codeSystem.rules.push(
+        new ConceptRule('cake', 'Cake'),
+        new ConceptRule('icecream', 'Ice Cream')
+      );
+      doc.codeSystems.set(codeSystem.name, codeSystem);
+      // ValueSet: MyValueSet
+      // * ^expansion.parameter.name = "sushi-generated"
+      // * ^expansion.parameter.valueBoolean = true
+      // * include codes from DessertCodes
+      const valueSet = new FshValueSet('MyValueSet');
+      const expansionName = new CaretValueRule('');
+      expansionName.caretPath = 'expansion.parameter.name';
+      expansionName.value = 'sushi-generated';
+      const expansionValue = new CaretValueRule('');
+      expansionValue.caretPath = 'expansion.parameter.valueBoolean';
+      expansionValue.value = true;
+      valueSet.rules.push(expansionName, expansionValue);
+      const includeAllergy = new ValueSetFilterComponentRule(true);
+      includeAllergy.from.system = 'DessertCodes';
+      valueSet.rules.push(includeAllergy);
+      doc.valueSets.set(valueSet.name, valueSet);
+
+      const result = exporter.export();
+      expect(result.valueSets).toHaveLength(1);
+      const expansion = result.valueSets[0].expansion.contains;
+      expect(expansion).toHaveLength(2);
+      expect(expansion).toContainEqual({
+        code: 'cake',
+        display: 'Cake',
+        system: 'http://hl7.org/fhir/us/minimal/CodeSystem/DessertCodes',
+        version: '1.0.0'
+      });
+      expect(expansion).toContainEqual({
+        code: 'icecream',
+        display: 'Ice Cream',
+        system: 'http://hl7.org/fhir/us/minimal/CodeSystem/DessertCodes',
+        version: '1.0.0'
+      });
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
   });
 });

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -715,6 +715,8 @@ describe('ValueSetExporter', () => {
 
   describe('#expansion', () => {
     let valueSet: FshValueSet;
+    // dateTime format from http://hl7.org/fhir/R4/datatypes.html#dateTime
+    const dateTimeFormat = /([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?/;
 
     beforeEach(() => {
       valueSet = new FshValueSet('MyValueSet');
@@ -770,7 +772,7 @@ describe('ValueSetExporter', () => {
         system: 'http://zoo.org/animals',
         version: '1.1'
       });
-      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.timestamp).toMatch(dateTimeFormat);
       expect(exported.expansion.total).toBe(3);
     });
 
@@ -805,7 +807,7 @@ describe('ValueSetExporter', () => {
           }
         ]
       });
-      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.timestamp).toMatch(dateTimeFormat);
       expect(exported.expansion.total).toBe(3);
     });
 
@@ -840,7 +842,7 @@ describe('ValueSetExporter', () => {
           }
         ]
       });
-      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.timestamp).toMatch(dateTimeFormat);
       expect(exported.expansion.total).toBe(3);
     });
 
@@ -880,7 +882,7 @@ describe('ValueSetExporter', () => {
       valueSet.rules.push(includeResolved, includeAllergy);
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toHaveLength(3);
-      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.timestamp).toMatch(dateTimeFormat);
       expect(exported.expansion.total).toBe(3);
     });
 
@@ -902,7 +904,7 @@ describe('ValueSetExporter', () => {
       valueSet.rules.push(includeAllergy, includeResolved);
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toHaveLength(2);
-      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.timestamp).toMatch(dateTimeFormat);
       expect(exported.expansion.total).toBe(3);
     });
 
@@ -935,7 +937,7 @@ describe('ValueSetExporter', () => {
           }
         ]
       });
-      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.timestamp).toMatch(dateTimeFormat);
       expect(exported.expansion.total).toBe(2);
     });
 
@@ -968,7 +970,7 @@ describe('ValueSetExporter', () => {
         system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
         version: '4.0.1'
       });
-      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.timestamp).toMatch(dateTimeFormat);
       expect(exported.expansion.total).toBe(2);
     });
 
@@ -1002,7 +1004,7 @@ describe('ValueSetExporter', () => {
         system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
         version: '4.0.1'
       });
-      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.timestamp).toMatch(dateTimeFormat);
       expect(exported.expansion.total).toBe(2);
     });
 
@@ -1036,7 +1038,7 @@ describe('ValueSetExporter', () => {
         system: 'http://zoo.org/animals',
         version: '1.0'
       });
-      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.timestamp).toMatch(dateTimeFormat);
       expect(exported.expansion.total).toBe(1);
     });
 

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -770,6 +770,8 @@ describe('ValueSetExporter', () => {
         system: 'http://zoo.org/animals',
         version: '1.1'
       });
+      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.total).toBe(3);
     });
 
     it('should expand a value set that contains locally defined code systems from JSON', () => {
@@ -803,6 +805,8 @@ describe('ValueSetExporter', () => {
           }
         ]
       });
+      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.total).toBe(3);
     });
 
     it('should expand a value set that contains a matching version of a locally defined code system', () => {
@@ -836,6 +840,8 @@ describe('ValueSetExporter', () => {
           }
         ]
       });
+      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.total).toBe(3);
     });
 
     it('should not expand a value set that contains a different version of a locally defined code system', () => {
@@ -849,6 +855,8 @@ describe('ValueSetExporter', () => {
 
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toBeUndefined();
+      expect(exported.expansion.timestamp).toBeUndefined();
+      expect(exported.expansion.total).toBeUndefined();
       expect(loggerSpy.getLastMessage('error')).toMatch(
         /Composition contains CodeSystems without available concept lists\./s
       );
@@ -872,6 +880,8 @@ describe('ValueSetExporter', () => {
       valueSet.rules.push(includeResolved, includeAllergy);
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toHaveLength(3);
+      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.total).toBe(3);
     });
 
     it('should not change the hierarchy of included codes when a duplicate is added', () => {
@@ -892,6 +902,8 @@ describe('ValueSetExporter', () => {
       valueSet.rules.push(includeAllergy, includeResolved);
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toHaveLength(2);
+      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.total).toBe(3);
     });
 
     it('should remove excluded concepts from the expansion', () => {
@@ -923,6 +935,8 @@ describe('ValueSetExporter', () => {
           }
         ]
       });
+      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.total).toBe(2);
     });
 
     it('should remove a contained excluded concept', () => {
@@ -954,6 +968,8 @@ describe('ValueSetExporter', () => {
         system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
         version: '4.0.1'
       });
+      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.total).toBe(2);
     });
 
     it('should keep contained concepts when excluding the top-level concept', () => {
@@ -986,6 +1002,8 @@ describe('ValueSetExporter', () => {
         system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
         version: '4.0.1'
       });
+      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.total).toBe(2);
     });
 
     it('should remove all concepts from an excluded code system', () => {
@@ -1018,6 +1036,8 @@ describe('ValueSetExporter', () => {
         system: 'http://zoo.org/animals',
         version: '1.0'
       });
+      expect(exported.expansion.timestamp).toBeDefined();
+      expect(exported.expansion.total).toBe(1);
     });
 
     it('should not expand a value set that does not define its composition', () => {
@@ -1026,6 +1046,8 @@ describe('ValueSetExporter', () => {
       // * ^expansion.parameter.valueBoolean = true
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toBeUndefined();
+      expect(exported.expansion.timestamp).toBeUndefined();
+      expect(exported.expansion.total).toBeUndefined();
       expect(loggerSpy.getLastMessage('error')).toMatch(/No composition defined\./s);
     });
 
@@ -1045,6 +1067,8 @@ describe('ValueSetExporter', () => {
 
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toBeUndefined();
+      expect(exported.expansion.timestamp).toBeUndefined();
+      expect(exported.expansion.total).toBeUndefined();
       expect(loggerSpy.getLastMessage('error')).toMatch(/Composition contains filter operators\./s);
     });
 
@@ -1059,6 +1083,8 @@ describe('ValueSetExporter', () => {
 
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toBeUndefined();
+      expect(exported.expansion.timestamp).toBeUndefined();
+      expect(exported.expansion.total).toBeUndefined();
       expect(loggerSpy.getLastMessage('error')).toMatch(/Composition contains other ValueSets\./s);
     });
 
@@ -1074,6 +1100,8 @@ describe('ValueSetExporter', () => {
 
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toBeUndefined();
+      expect(exported.expansion.timestamp).toBeUndefined();
+      expect(exported.expansion.total).toBeUndefined();
       expect(loggerSpy.getLastMessage('error')).toMatch(
         /Composition contains CodeSystems without available concept lists\./s
       );
@@ -1090,6 +1118,8 @@ describe('ValueSetExporter', () => {
 
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toBeUndefined();
+      expect(exported.expansion.timestamp).toBeUndefined();
+      expect(exported.expansion.total).toBeUndefined();
       expect(loggerSpy.getLastMessage('error')).toMatch(
         /Composition contains CodeSystems without available concept lists\./s
       );

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -1079,7 +1079,7 @@ describe('ValueSetExporter', () => {
       );
     });
 
-    it('should not expand value sets that refer to code systems with content that is not example or complete', () => {
+    it('should not expand value sets that refer to code systems with content that is not complete', () => {
       // ValueSet: MyValueSet
       // * ^expansion.parameter.name = "sushi-generated"
       // * ^expansion.parameter.valueBoolean = true

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -850,7 +850,7 @@ describe('ValueSetExporter', () => {
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toBeUndefined();
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Composition contains code systems without available concept lists\./s
+        /Composition contains CodeSystems without available concept lists\./s
       );
     });
 
@@ -1059,7 +1059,7 @@ describe('ValueSetExporter', () => {
 
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toBeUndefined();
-      expect(loggerSpy.getLastMessage('error')).toMatch(/Composition contains other value sets\./s);
+      expect(loggerSpy.getLastMessage('error')).toMatch(/Composition contains other ValueSets\./s);
     });
 
     it('should not expand value sets that refer to code systems without available definitions', () => {
@@ -1075,7 +1075,7 @@ describe('ValueSetExporter', () => {
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toBeUndefined();
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Composition contains code systems without available concept lists\./s
+        /Composition contains CodeSystems without available concept lists\./s
       );
     });
 
@@ -1091,7 +1091,7 @@ describe('ValueSetExporter', () => {
       const exported = exporter.exportValueSet(valueSet);
       expect(exported.expansion.contains).toBeUndefined();
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Composition contains code systems without available concept lists\./s
+        /Composition contains CodeSystems without available concept lists\./s
       );
     });
   });

--- a/test/testhelpers/testdefs/CodeSystem-fragment.json
+++ b/test/testhelpers/testdefs/CodeSystem-fragment.json
@@ -1,0 +1,19 @@
+{
+  "resourceType": "CodeSystem",
+  "status": "active",
+  "content": "fragment",
+  "name": "ZooFragmentSet",
+  "id": "ZooFragmentSet",
+  "version": "1.0.0",
+  "url": "http://example.org/CodeSystem/ZooFragmentSet",
+  "concept": [
+    {
+      "code": "bear",
+      "display": "Bear"
+    },
+    {
+      "code": "tiger",
+      "display": "Tiger"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #736 and completes task [CIMPL-655](https://standardhealthrecord.atlassian.net/browse/CIMPL-655).

Authors can request a value set expansion from SUSHI by setting caret value rules on the value set. Expansion is only possible for specific concepts and known code systems. If there are filter operators, included value sets, or unknown code systems involved, expansion will fail.