### PR TITLE
Support any type of whitespace in a code

### DIFF
--- a/src/fshtypes/FshCode.ts
+++ b/src/fshtypes/FshCode.ts
@@ -7,7 +7,7 @@ export class FshCode extends FshEntity {
   }
 
   toString(): string {
-    const str = `${this.system ?? ''}#${this.code.includes(' ') ? `"${this.code}"` : this.code}`;
+    const str = `${this.system ?? ''}#${/\s/.test(this.code) ? `"${this.code}"` : this.code}`;
     return this.display ? `${str} "${this.display}"` : str;
   }
 

--- a/test/fshtypes/FshCode.test.ts
+++ b/test/fshtypes/FshCode.test.ts
@@ -35,10 +35,16 @@ describe('FshCode', () => {
       expect(result).toEqual('http://foo.com#my-code "Display"');
     });
 
-    it('should return string for code with code with spaces', () => {
+    it('should return string for code with spaces', () => {
       const code = new FshCode('my spacey code');
       const result = code.toString();
       expect(result).toEqual('#"my spacey code"');
+    });
+
+    it('should return string for code with tabs', () => {
+      const code = new FshCode('my\ttabby\tcode');
+      const result = code.toString();
+      expect(result).toEqual('#"my\ttabby\tcode"');
     });
   });
 });


### PR DESCRIPTION
Very small PR for supporting any type of whitespace in a code. This came out of a suggestion on a [GoFSH PR](https://github.com/FHIR/GoFSH/pull/99). This just adds the equivalent change to SUSHI. 