### PR TITLE
Support Canonical for Instances

### DIFF
--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -1321,6 +1321,27 @@ describe('InstanceExporter', () => {
       });
     });
 
+    it('should apply an Assignment rule with Canonical of a Questionnaire instance', () => {
+      const questionnaireInstance = new Instance('MyQuestionnaire');
+      questionnaireInstance.usage = 'Definition';
+      const urlRule = new AssignmentRule('url');
+      urlRule.value = 'http://my.awesome.questions.org/Questionnaire/MyQuestionnaire';
+      questionnaireInstance.rules.push(urlRule);
+      doc.instances.set(questionnaireInstance.name, questionnaireInstance);
+
+      const responseInstance = new Instance('MyQuestionnaireResponse');
+      responseInstance.instanceOf = 'QuestionnaireResponse';
+      const assignedValueRule = new AssignmentRule('questionnaire');
+      assignedValueRule.value = new FshCanonical('MyQuestionnaire');
+      responseInstance.rules.push(assignedValueRule);
+      doc.instances.set(responseInstance.name, responseInstance);
+
+      const exported = exportInstance(responseInstance);
+      expect(exported.questionnaire).toEqual(
+        'http://my.awesome.questions.org/Questionnaire/MyQuestionnaire'
+      );
+    });
+
     it('should apply an Assignment rule with Canonical of an inline instance', () => {
       const observationInstance = new Instance('MyObservation');
       observationInstance.instanceOf = 'Observation';

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1691,6 +1691,30 @@ describe('StructureDefinitionExporter', () => {
     expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
   });
 
+  it('should apply an Assignment rule with Canonical of a Questionnaire instance', () => {
+    const questionnaireInstance = new Instance('MyQuestionnaire');
+    questionnaireInstance.usage = 'Definition';
+    const urlRule = new AssignmentRule('url');
+    urlRule.value = 'http://my.awesome.questions.org/Questionnaire/MyQuestionnaire';
+    questionnaireInstance.rules.push(urlRule);
+    doc.instances.set(questionnaireInstance.name, questionnaireInstance);
+
+    const profile = new Profile('MyQuestionnaireResponse');
+    profile.parent = 'QuestionnaireResponse';
+    const assignedValueRule = new AssignmentRule('questionnaire');
+    assignedValueRule.value = new FshCanonical('MyQuestionnaire');
+    profile.rules.push(assignedValueRule);
+    doc.profiles.set(profile.name, profile);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+    const assignedQ = sd.findElement('QuestionnaireResponse.questionnaire');
+    expect(assignedQ.patternCanonical).toEqual(
+      'http://my.awesome.questions.org/Questionnaire/MyQuestionnaire'
+    );
+    expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+  });
+
   it('should apply an Assignment rule with Canonical of an inline instance', () => {
     const profile = new Profile('MyObservation');
     profile.parent = 'Observation';


### PR DESCRIPTION
Allow the Canonical(...) construct to target an instance.  This required updating the tank fisher to return instance url values when fishing for metadata.

If you want to test manually, you can use this modified example from the original bug reported on Zulip:
```
Instance: WhoCrQuestionnaireCovid19Surveillance
InstanceOf: Questionnaire
Description: "TODO"
Title: "Revised case report form for Confirmed Novel Coronavirus COVID-19"
Usage: #definition
* url = "http://openhie.github.io/covid-19/Questionnaire/WhoCrQuestionnaireCovid19Surveillance"
* status = #active

Profile:    WhoCrQuestionnaireResponseCovid19Surveillance
Parent:     QuestionnaireResponse
Description: "Who Case Reporting QuestionnaireResponse"
Title:      "Who Case Reporting QuestionnaireResponse"
* questionnaire = Canonical(WhoCrQuestionnaireCovid19Surveillance)
```
It will have an error on `master`:
> error Cannot use canonical URL of WhoCrQuestionnaireCovid19Surveillance because it does not exist. Be sure that WhoCrQuestionnaireCovid19Surveillance exists and it has a URL.

But it will succeed on this branch.

Fixes #743