### PR TITLE
Fix assigned value on sliced children bug

### DIFF
--- a/src/errors/ValueConflictsWithClosedSlicingError.ts
+++ b/src/errors/ValueConflictsWithClosedSlicingError.ts
@@ -1,0 +1,7 @@
+export class ValueConflictsWithClosedSlicingError extends Error {
+  constructor(public requestedValue: boolean | number | string) {
+    super(
+      `Cannot assign ${requestedValue} to this element since it conflicts with all values of the closed slicing.`
+    );
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -44,3 +44,4 @@ export * from './InvalidResourceTypeError';
 export * from './InvalidExtensionParentError';
 export * from './InvalidTypeAccessError';
 export * from './NonAbstractParentOfSpecializationError';
+export * from './ValueConflictsWithClosedSlicingError';

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -2064,6 +2064,156 @@ describe('InstanceExporter', () => {
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
 
+    it('should not assign a value which violates a closed child slicing', () => {
+      // Profile: MyProfile
+      // Parent: Observation
+      // * category.coding ^slicing.discriminator.type = #value
+      // * category.coding ^slicing.discriminator.path = "coding"
+      // * category.coding ^slicing.rules = #closed
+      // * category.coding contains slice1 0..1
+      // * category.coding[slice1] = http://example.com#foo
+      const profile = new Profile('MyProfile');
+      profile.parent = 'Observation';
+      const typeRule = new CaretValueRule('category.coding');
+      typeRule.caretPath = 'slicing.discriminator[0].type';
+      typeRule.value = new FshCode('pattern');
+      const pathRule = new CaretValueRule('category.coding');
+      pathRule.caretPath = 'slicing.discriminator[0].path';
+      pathRule.value = 'code';
+      const rulesRule = new CaretValueRule('category.coding');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('closed');
+      const containsRule = new ContainsRule('category.coding');
+      containsRule.items.push({ name: 'slice1' });
+      const assignmentRule = new AssignmentRule('category.coding[slice1]');
+      assignmentRule.value = new FshCode('foo', 'http://example.com');
+      profile.rules.push(typeRule, pathRule, rulesRule, containsRule, assignmentRule);
+      doc.profiles.set(profile.name, profile);
+
+      // Instance: MyInstance
+      // InstanceOf: MyProfile
+      // * category[0] = http://not-example.org#bar
+      const instance = new Instance('MyInstance');
+      instance.instanceOf = 'MyProfile';
+      const categoryRule = new AssignmentRule('category[0]');
+      categoryRule.value = new FshCode('bar', 'http://not-example.com');
+      instance.rules.push(categoryRule);
+      doc.instances.set(instance.name, instance);
+
+      sdExporter.export();
+      const exported = exporter.export().instances;
+      const exportedInstance = exported.find(i => i._instanceMeta.name === 'MyInstance');
+      expect(exportedInstance.category).toBeUndefined();
+      expect(loggerSpy.getAllMessages('error')).toContainEqual(
+        'Cannot assign {"coding":[{"code":"bar","system":"http://not-example.com"}]} to this element since it conflicts with all values of the closed slicing.'
+      );
+    });
+
+    it('should assign a value which does not violate all elements of a closed child slicing', () => {
+      // Profile: MyProfile
+      // Parent: Observation
+      // * category.coding ^slicing.discriminator.type = #value
+      // * category.coding ^slicing.discriminator.path = "coding"
+      // * category.coding ^slicing.rules = #closed
+      // * category.coding contains slice1 0..1 and slice2 0..1
+      // * category.coding[slice1] = http://example.com#foo
+      // * category.coding[slice2] = http://example.com#bar
+      const profile = new Profile('MyProfile');
+      profile.parent = 'Observation';
+      const typeRule = new CaretValueRule('category.coding');
+      typeRule.caretPath = 'slicing.discriminator[0].type';
+      typeRule.value = new FshCode('pattern');
+      const pathRule = new CaretValueRule('category.coding');
+      pathRule.caretPath = 'slicing.discriminator[0].path';
+      pathRule.value = 'code';
+      const rulesRule = new CaretValueRule('category.coding');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('closed');
+      const containsRule = new ContainsRule('category.coding');
+      containsRule.items.push({ name: 'slice1' });
+      containsRule.items.push({ name: 'slice2' });
+      const assignmentRule = new AssignmentRule('category.coding[slice1]');
+      assignmentRule.value = new FshCode('foo', 'http://example.com');
+      const assignmentRule2 = new AssignmentRule('category.coding[slice2]');
+      assignmentRule2.value = new FshCode('bar', 'http://example.com');
+      profile.rules.push(
+        typeRule,
+        pathRule,
+        rulesRule,
+        containsRule,
+        assignmentRule,
+        assignmentRule2
+      );
+      doc.profiles.set(profile.name, profile);
+
+      // Instance: MyInstance
+      // InstanceOf: MyProfile
+      // * category[0] = http://example#bar
+      const instance = new Instance('MyInstance');
+      instance.instanceOf = 'MyProfile';
+      const categoryRule = new AssignmentRule('category[0]');
+      categoryRule.value = new FshCode('bar', 'http://example.com');
+      instance.rules.push(categoryRule);
+      doc.instances.set(instance.name, instance);
+
+      sdExporter.export();
+      const exported = exporter.export().instances;
+      const exportedInstance = exported.find(i => i._instanceMeta.name === 'MyInstance');
+      expect(exportedInstance.category).toEqual([
+        { coding: [{ code: 'bar', system: 'http://example.com' }] }
+      ]);
+      expect(loggerSpy.getAllMessages('error')).not.toContainEqual(
+        'Cannot assign {"coding":[{"code":"bar","system":"http://not-example.com"}]} to this element since it conflicts with all values of the closed slicing.'
+      );
+    });
+
+    it('should assign a value which violates an open child slicing', () => {
+      // Profile: MyProfile
+      // Parent: Observation
+      // * category.coding ^slicing.discriminator.type = #value
+      // * category.coding ^slicing.discriminator.path = "coding"
+      // * category.coding ^slicing.rules = #open
+      // * category.coding contains slice1 0..1
+      // * category.coding[slice1] = http://example.com#foo
+      const profile = new Profile('MyProfile');
+      profile.parent = 'Observation';
+      const typeRule = new CaretValueRule('category.coding');
+      typeRule.caretPath = 'slicing.discriminator[0].type';
+      typeRule.value = new FshCode('pattern');
+      const pathRule = new CaretValueRule('category.coding');
+      pathRule.caretPath = 'slicing.discriminator[0].path';
+      pathRule.value = 'code';
+      const rulesRule = new CaretValueRule('category.coding');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      const containsRule = new ContainsRule('category.coding');
+      containsRule.items.push({ name: 'slice1' });
+      const assignmentRule = new AssignmentRule('category.coding[slice1]');
+      assignmentRule.value = new FshCode('foo', 'http://example.com');
+      profile.rules.push(typeRule, pathRule, rulesRule, containsRule, assignmentRule);
+      doc.profiles.set(profile.name, profile);
+
+      // Instance: MyInstance
+      // InstanceOf: MyProfile
+      // * category[0] = http://not-example.org#bar
+      const instance = new Instance('MyInstance');
+      instance.instanceOf = 'MyProfile';
+      const categoryRule = new AssignmentRule('category[0]');
+      categoryRule.value = new FshCode('bar', 'http://not-example.com');
+      instance.rules.push(categoryRule);
+      doc.instances.set(instance.name, instance);
+
+      sdExporter.export();
+      const exported = exporter.export().instances;
+      const exportedInstance = exported.find(i => i._instanceMeta.name === 'MyInstance');
+      expect(exportedInstance.category).toEqual([
+        { coding: [{ code: 'bar', system: 'http://not-example.com' }] }
+      ]);
+      expect(loggerSpy.getAllMessages('error')).not.toContainEqual(
+        'Cannot assign {"coding":[{"code":"bar","system":"http://not-example.com"}]} to this element since it conflicts with all values of the closed slicing.'
+      );
+    });
+
     it('should only export an instance once', () => {
       const bundleInstance = new Instance('MyBundle');
       bundleInstance.instanceOf = 'Bundle';

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -2101,7 +2101,7 @@ describe('StructureDefinitionExporter', () => {
     // Parent: Patient
     // * address.line ^slicing.discriminator[0].type = #pattern
     // * address.line ^slicing.discriminator[0].path = "$this"
-    // * address.line ^slicing.rules = #open
+    // * address.line ^slicing.rules = #closed
     // * address.line contains SpecificLine 1..1
     // * address.line[SpecificLine] = "Specific part of address"
     // * address ^slicing.discriminator[0].type = #pattern
@@ -2120,7 +2120,7 @@ describe('StructureDefinitionExporter', () => {
     slicingPathLine.value = 'code';
     const slicingRulesLine = new CaretValueRule('address.line');
     slicingRulesLine.caretPath = 'slicing.rules';
-    slicingRulesLine.value = new FshCode('open');
+    slicingRulesLine.value = new FshCode('closed');
     const containsSpecificLine = new ContainsRule('address.line');
     containsSpecificLine.items.push({ name: 'SpecificLine' });
     const specificLineCard = new CardRule('address.line[SpecificLine]');
@@ -2171,7 +2171,7 @@ describe('StructureDefinitionExporter', () => {
     expect(addressLineElement.patternString).toBeDefined();
     expect(addressSliceElement.patternAddress).toBeUndefined();
     expect(loggerSpy.getLastMessage('error')).toMatch(
-      /Cannot assign First part of address to this element.*File: Assigned\.fsh.*Line: 12\D*/s
+      /Cannot assign.*First part of address.*to this element.*File: Assigned\.fsh.*Line: 12\D*/s
     );
   });
 


### PR DESCRIPTION
This fixes #748. It is easiest to illustrate with an example. You can use the example cited in the issue, but here is a slightly simpler example I've been using:
```
Profile: MyProfile
Parent: Observation
* category.coding ^slicing.discriminator.type = #value
* category.coding ^slicing.discriminator.path = "coding"
* category.coding ^slicing.rules = #open
* category.coding contains slice1 0..1
* category.coding[slice1] = http://example.com#foo

Instance: MyInstance
InstanceOf: MyProfile
* category[0] = http://example.com#bar
* status = #active
* code = #final
```

In this example, `category.coding` is sliced, and the slice has a value set on it, but the slicing is `#open`, so any other values can also be added to the `category.coding` array. But, if you run this example on `master`, you will get an error like:
```
Cannot assign [object Object] to this element; a different Coding is already assigned: {"code":"foo","system":"http://example.com"}.
```
which is a bug, since the `http://example.com#foo` is assigned to a specific slice, not the entire `coding` array. If you run that example on this branch, you will see no errors, and the first instance rule will be correctly applied.

To further test this PR, change the slicing from `#open` to `#closed`. Now slicing is closed, so every element in the `coding` array must match a slice, and since the `http://example.com#bar` value does not, an error will be logged indicating that this value does not satisfy any slice, and cannot be assigned.

Now try changing `http://example.com#bar` to `http://example.com#foo`. This now does satisfy at least one slice in the closed slicing, so the assignment will be allowed.