### PR TITLE
Clean up extensions on primitives

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -564,7 +564,15 @@ export class StructureDefinitionExporter implements Fishable {
     this.preprocessStructureDefinition(fshDefinition, structDef.type === 'Extension');
 
     this.setRules(structDef, fshDefinition);
-    cleanResource(structDef, (prop: string) => prop == 'elements' || prop.indexOf('_') == 0);
+    // Properties added by SUSHI should be skipped. These properties all start with "_",
+    // but so do the extra properties on primitive-type elements. So, check for a sibling
+    // property with the same name, but no underscore, to identify the primitive-type
+    // extra property objects that should _not_ get skipped.
+    cleanResource(
+      structDef,
+      (object: { [key: string]: any }, prop: string) =>
+        prop == 'elements' || (prop.indexOf('_') == 0 && object[prop.slice(1)] == null)
+    );
     structDef.inProgress = false;
 
     // check for another structure definition with the same id

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -564,14 +564,10 @@ export class StructureDefinitionExporter implements Fishable {
     this.preprocessStructureDefinition(fshDefinition, structDef.type === 'Extension');
 
     this.setRules(structDef, fshDefinition);
-    // Properties added by SUSHI should be skipped. These properties all start with "_",
-    // but so do the extra properties on primitive-type elements. So, check for a sibling
-    // property with the same name, but no underscore, to identify the primitive-type
-    // extra property objects that should _not_ get skipped.
-    cleanResource(
-      structDef,
-      (object: { [key: string]: any }, prop: string) =>
-        prop == 'elements' || (prop.indexOf('_') == 0 && object[prop.slice(1)] == null)
+    // The elements list does not need to be cleaned up.
+    // And, the _sliceName and _primitive properties added by SUSHI should be skipped.
+    cleanResource(structDef, (prop: string) =>
+      ['elements', '_sliceName', '_primitive'].includes(prop)
     );
     structDef.inProgress = false;
 

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -315,12 +315,12 @@ export function replaceField(
   object: { [key: string]: any },
   matchFn: (object: { [key: string]: any }, prop: string) => boolean,
   replaceFn: (object: { [key: string]: any }, prop: string) => void,
-  skipFn: (object: { [key: string]: any }, prop: string) => boolean
+  skipFn: (prop: string) => boolean
 ): void {
   for (const prop in object) {
     if (matchFn(object, prop)) {
       replaceFn(object, prop);
-    } else if (typeof object[prop] === 'object' && !skipFn(object, prop)) {
+    } else if (typeof object[prop] === 'object' && !skipFn(prop)) {
       replaceField(object[prop], matchFn, replaceFn, skipFn);
     }
   }
@@ -333,7 +333,7 @@ export function replaceField(
  */
 export function cleanResource(
   resourceDef: StructureDefinition | InstanceDefinition,
-  skipFn: (object: { [key: string]: any }, prop: string) => boolean = () => false
+  skipFn: (prop: string) => boolean = () => false
 ): void {
   // Remove all _sliceName fields
   replaceField(

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -309,18 +309,18 @@ export function getSliceName(pathPart: PathPart): string {
  * @param { {[key: string]: any} } object - The object to replace fields on
  * @param {(object: { [key: string]: any }, prop: string) => boolean} matchFn - The function to match with
  * @param {(object: { [key: string]: any }, prop: string) => void} replaceFn - The function to replace with
- * @param {string => boolean} skipFn - A function that returns true if a property should not be traversed
+ * @param {(object: { [key: string]: any }, prop: string) => boolean} skipFn - A function that returns true if a property should not be traversed
  */
 export function replaceField(
   object: { [key: string]: any },
   matchFn: (object: { [key: string]: any }, prop: string) => boolean,
   replaceFn: (object: { [key: string]: any }, prop: string) => void,
-  skipFn: (prop: string) => boolean
+  skipFn: (object: { [key: string]: any }, prop: string) => boolean
 ): void {
   for (const prop in object) {
     if (matchFn(object, prop)) {
       replaceFn(object, prop);
-    } else if (typeof object[prop] === 'object' && !skipFn(prop)) {
+    } else if (typeof object[prop] === 'object' && !skipFn(object, prop)) {
       replaceField(object[prop], matchFn, replaceFn, skipFn);
     }
   }
@@ -333,7 +333,7 @@ export function replaceField(
  */
 export function cleanResource(
   resourceDef: StructureDefinition | InstanceDefinition,
-  skipFn: (prop: string) => boolean = () => false
+  skipFn: (object: { [key: string]: any }, prop: string) => boolean = () => false
 ): void {
   // Remove all _sliceName fields
   replaceField(

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -3071,19 +3071,19 @@ describe('StructureDefinitionExporter', () => {
     onlyBoolean.types.push({ type: 'boolean' });
     extension.rules.push(onlyBoolean);
     doc.extensions.set(extension.name, extension);
-    // Profile: ExtensionOnStatus
+    // Profile: ExtensionOnPublisher
     // Parent: Patient
-    // * ^status.extension[MyBooleanExtension].valueBoolean = true
-    const profile = new Profile('ExtensionOnStatus');
+    // * ^publisher.extension[MyBooleanExtension].valueBoolean = true
+    const profile = new Profile('ExtensionOnPublisher');
     profile.parent = 'Patient';
     const rule = new CaretValueRule('');
-    rule.caretPath = 'status.extension[MyBooleanExtension].valueBoolean';
+    rule.caretPath = 'publisher.extension[MyBooleanExtension].valueBoolean';
     rule.value = true;
     profile.rules.push(rule);
 
     exporter.exportStructDef(profile);
     const sd = pkg.profiles[0];
-    expect(sd).toHaveProperty('_status', {
+    expect(sd).toHaveProperty('_publisher', {
       extension: [
         {
           url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/MyBooleanExtension',

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -3063,6 +3063,36 @@ describe('StructureDefinitionExporter', () => {
     expect(sd).toHaveProperty('_url', { id: 'my-id' });
   });
 
+  it('should apply a CaretValueRule on an extension of a primitive element without a path', () => {
+    // Extension: MyBooleanExtension
+    // * value[x] only boolean
+    const extension = new Extension('MyBooleanExtension');
+    const onlyBoolean = new OnlyRule('value[x]');
+    onlyBoolean.types.push({ type: 'boolean' });
+    extension.rules.push(onlyBoolean);
+    doc.extensions.set(extension.name, extension);
+    // Profile: ExtensionOnStatus
+    // Parent: Patient
+    // * ^status.extension[MyBooleanExtension].valueBoolean = true
+    const profile = new Profile('ExtensionOnStatus');
+    profile.parent = 'Patient';
+    const rule = new CaretValueRule('');
+    rule.caretPath = 'status.extension[MyBooleanExtension].valueBoolean';
+    rule.value = true;
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = pkg.profiles[0];
+    expect(sd).toHaveProperty('_status', {
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/MyBooleanExtension',
+          valueBoolean: true
+        }
+      ]
+    });
+  });
+
   it('should not apply an invalid CaretValueRule on an element without a path', () => {
     const profile = new Profile('Foo');
     profile.parent = 'Observation';


### PR DESCRIPTION
Fixes #752 and completes task [CIMPL-668](https://standardhealthrecord.atlassian.net/browse/CIMPL-668).

When cleaning up properties on a StructureDefinition, properties are recursively traversed to find and remove those that were added by SUSHI to help in the export process. Properties that were added by SUSHI start with an underscore character. Properties that contain extra attributes of primitives also start with an underscore character, but will have a
sibling property with the same name without the underscore. Therefore, if such a sibling property is present, the property being examined is a true member of the StructureDefinition, and should be included in the cleanup traversal.

Basically, I'm _pretty_ sure that doing this won't ever get us into trouble, but I might be wrong.