### PR TITLE
Add Constructor Names

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -477,7 +477,7 @@ export function applyInsertRules(
           expandedRules.push(cloneDeep(ruleSetRule));
         } else {
           logger.error(
-            `Rule of type ${ruleSetRule.constructor.name} cannot be applied to entity of type ${fshDefinition.constructor.name}`,
+            `Rule of type ${ruleSetRule.constructorName} cannot be applied to entity of type ${fshDefinition.constructorName}`,
             ruleSetRule.sourceInfo
           );
         }

--- a/src/fshtypes/Extension.ts
+++ b/src/fshtypes/Extension.ts
@@ -2,7 +2,6 @@ import { FshEntity } from './FshEntity';
 import { SdRule } from './rules';
 
 export class Extension extends FshEntity {
-  constructorName = 'Extension';
   id: string;
   parent: string;
   title?: string;
@@ -19,5 +18,9 @@ export class Extension extends FshEntity {
     this.parent = 'Extension'; // init to 'Extension'
     this.mixins = [];
     this.rules = [];
+  }
+
+  get constructorName() {
+    return 'Extension';
   }
 }

--- a/src/fshtypes/Extension.ts
+++ b/src/fshtypes/Extension.ts
@@ -2,6 +2,7 @@ import { FshEntity } from './FshEntity';
 import { SdRule } from './rules';
 
 export class Extension extends FshEntity {
+  constructorName = 'Extension';
   id: string;
   parent: string;
   title?: string;

--- a/src/fshtypes/FshCodeSystem.ts
+++ b/src/fshtypes/FshCodeSystem.ts
@@ -7,6 +7,7 @@ import { CaretValueRule, InsertRule, ConceptRule } from './rules';
  * @see {@link http://hl7.org/fhir/codesystem-definitions.html}
  */
 export class FshCodeSystem extends FshEntity {
+  constructorName = 'FshCodeSystem';
   id: string;
   title?: string;
   description?: string;

--- a/src/fshtypes/FshCodeSystem.ts
+++ b/src/fshtypes/FshCodeSystem.ts
@@ -7,7 +7,6 @@ import { CaretValueRule, InsertRule, ConceptRule } from './rules';
  * @see {@link http://hl7.org/fhir/codesystem-definitions.html}
  */
 export class FshCodeSystem extends FshEntity {
-  constructorName = 'FshCodeSystem';
   id: string;
   title?: string;
   description?: string;
@@ -17,6 +16,10 @@ export class FshCodeSystem extends FshEntity {
     super();
     this.id = name;
     this.rules = [];
+  }
+
+  get constructorName() {
+    return 'FshCodeSystem';
   }
 
   addConcept(newConcept: ConceptRule) {

--- a/src/fshtypes/FshValueSet.ts
+++ b/src/fshtypes/FshValueSet.ts
@@ -6,7 +6,6 @@ import { CaretValueRule, InsertRule, ValueSetComponentRule } from './rules';
  * @see {@link http://hl7.org/fhir/valueset-definitions.html#ValueSet.compose}
  */
 export class FshValueSet extends FshEntity {
-  constructorName = 'FshValueSet';
   id: string;
   title?: string;
   description?: string;
@@ -16,5 +15,9 @@ export class FshValueSet extends FshEntity {
     super();
     this.id = name;
     this.rules = [];
+  }
+
+  get constructorName() {
+    return 'FshValueSet';
   }
 }

--- a/src/fshtypes/FshValueSet.ts
+++ b/src/fshtypes/FshValueSet.ts
@@ -6,6 +6,7 @@ import { CaretValueRule, InsertRule, ValueSetComponentRule } from './rules';
  * @see {@link http://hl7.org/fhir/valueset-definitions.html#ValueSet.compose}
  */
 export class FshValueSet extends FshEntity {
+  constructorName = 'FshValueSet';
   id: string;
   title?: string;
   description?: string;

--- a/src/fshtypes/Instance.ts
+++ b/src/fshtypes/Instance.ts
@@ -2,6 +2,7 @@ import { AssignmentRule, InsertRule } from './rules';
 import { FshEntity } from './FshEntity';
 
 export class Instance extends FshEntity {
+  constructorName = 'Instance';
   id: string;
   title?: string;
   instanceOf: string;

--- a/src/fshtypes/Instance.ts
+++ b/src/fshtypes/Instance.ts
@@ -2,7 +2,6 @@ import { AssignmentRule, InsertRule } from './rules';
 import { FshEntity } from './FshEntity';
 
 export class Instance extends FshEntity {
-  constructorName = 'Instance';
   id: string;
   title?: string;
   instanceOf: string;
@@ -17,6 +16,10 @@ export class Instance extends FshEntity {
     this.mixins = [];
     this.rules = [];
     this.usage = 'Example'; // init to Example (default)
+  }
+
+  get constructorName() {
+    return 'Instance';
   }
 }
 

--- a/src/fshtypes/Mapping.ts
+++ b/src/fshtypes/Mapping.ts
@@ -5,7 +5,6 @@ import { InsertRule, MappingRule } from './rules';
  * The Mapping class is used to contain mapping info for SDs
  */
 export class Mapping extends FshEntity {
-  constructorName = 'Mapping';
   id: string;
   source?: string;
   target?: string;
@@ -17,5 +16,9 @@ export class Mapping extends FshEntity {
     super();
     this.id = name; // init same as name
     this.rules = [];
+  }
+
+  get constructorName() {
+    return 'Mapping';
   }
 }

--- a/src/fshtypes/Mapping.ts
+++ b/src/fshtypes/Mapping.ts
@@ -5,6 +5,7 @@ import { InsertRule, MappingRule } from './rules';
  * The Mapping class is used to contain mapping info for SDs
  */
 export class Mapping extends FshEntity {
+  constructorName = 'Mapping';
   id: string;
   source?: string;
   target?: string;

--- a/src/fshtypes/Profile.ts
+++ b/src/fshtypes/Profile.ts
@@ -2,6 +2,7 @@ import { FshEntity } from './FshEntity';
 import { SdRule } from './rules';
 
 export class Profile extends FshEntity {
+  constructorName = 'Profile';
   id: string;
   parent?: string;
   title?: string;

--- a/src/fshtypes/Profile.ts
+++ b/src/fshtypes/Profile.ts
@@ -2,7 +2,6 @@ import { FshEntity } from './FshEntity';
 import { SdRule } from './rules';
 
 export class Profile extends FshEntity {
-  constructorName = 'Profile';
   id: string;
   parent?: string;
   title?: string;
@@ -15,5 +14,9 @@ export class Profile extends FshEntity {
     this.id = name; // init same as name
     this.mixins = [];
     this.rules = [];
+  }
+
+  get constructorName() {
+    return 'Profile';
   }
 }

--- a/src/fshtypes/RuleSet.ts
+++ b/src/fshtypes/RuleSet.ts
@@ -5,6 +5,7 @@ import { Rule } from './rules/Rule';
  * The RuleSet class is used to represent re-usable groups of rules
  */
 export class RuleSet extends FshEntity {
+  constructorName = 'RuleSet';
   rules: Rule[];
 
   constructor(public name: string) {

--- a/src/fshtypes/RuleSet.ts
+++ b/src/fshtypes/RuleSet.ts
@@ -5,12 +5,15 @@ import { Rule } from './rules/Rule';
  * The RuleSet class is used to represent re-usable groups of rules
  */
 export class RuleSet extends FshEntity {
-  constructorName = 'RuleSet';
   rules: Rule[];
 
   constructor(public name: string) {
     super();
     this.rules = [];
+  }
+
+  get constructorName() {
+    return 'RuleSet';
   }
 
   /**

--- a/src/fshtypes/rules/AssignmentRule.ts
+++ b/src/fshtypes/rules/AssignmentRule.ts
@@ -16,12 +16,15 @@ export type AssignmentValueType =
   | InstanceDefinition;
 
 export class AssignmentRule extends Rule {
-  constructorName = 'AssignmentRule';
   value: AssignmentValueType;
   exactly: boolean;
   isInstance: boolean;
 
   constructor(path: string) {
     super(path);
+  }
+
+  get constructorName() {
+    return 'AssignmentRule';
   }
 }

--- a/src/fshtypes/rules/AssignmentRule.ts
+++ b/src/fshtypes/rules/AssignmentRule.ts
@@ -16,6 +16,7 @@ export type AssignmentValueType =
   | InstanceDefinition;
 
 export class AssignmentRule extends Rule {
+  constructorName = 'AssignmentRule';
   value: AssignmentValueType;
   exactly: boolean;
   isInstance: boolean;

--- a/src/fshtypes/rules/BindingRule.ts
+++ b/src/fshtypes/rules/BindingRule.ts
@@ -1,11 +1,14 @@
 import { Rule } from './Rule';
 
 export class BindingRule extends Rule {
-  constructorName = 'BindingRule';
   valueSet: string;
   strength: string;
 
   constructor(path: string) {
     super(path);
+  }
+
+  get constructorName() {
+    return 'BindingRule';
   }
 }

--- a/src/fshtypes/rules/BindingRule.ts
+++ b/src/fshtypes/rules/BindingRule.ts
@@ -1,6 +1,7 @@
 import { Rule } from './Rule';
 
 export class BindingRule extends Rule {
+  constructorName = 'BindingRule';
   valueSet: string;
   strength: string;
 

--- a/src/fshtypes/rules/CardRule.ts
+++ b/src/fshtypes/rules/CardRule.ts
@@ -1,11 +1,14 @@
 import { Rule } from './Rule';
 
 export class CardRule extends Rule {
-  constructorName = 'CardRule';
   min: number;
   max: string;
 
   constructor(path: string) {
     super(path);
+  }
+
+  get constructorName() {
+    return 'CardRule';
   }
 }

--- a/src/fshtypes/rules/CardRule.ts
+++ b/src/fshtypes/rules/CardRule.ts
@@ -1,6 +1,7 @@
 import { Rule } from './Rule';
 
 export class CardRule extends Rule {
+  constructorName = 'CardRule';
   min: number;
   max: string;
 

--- a/src/fshtypes/rules/CaretValueRule.ts
+++ b/src/fshtypes/rules/CaretValueRule.ts
@@ -2,6 +2,7 @@ import { Rule } from './Rule';
 import { AssignmentValueType } from './AssignmentRule';
 
 export class CaretValueRule extends Rule {
+  constructorName = 'CaretValueRule';
   caretPath: string;
   value: AssignmentValueType;
   isInstance: boolean;

--- a/src/fshtypes/rules/CaretValueRule.ts
+++ b/src/fshtypes/rules/CaretValueRule.ts
@@ -2,12 +2,15 @@ import { Rule } from './Rule';
 import { AssignmentValueType } from './AssignmentRule';
 
 export class CaretValueRule extends Rule {
-  constructorName = 'CaretValueRule';
   caretPath: string;
   value: AssignmentValueType;
   isInstance: boolean;
 
   constructor(path: string) {
     super(path);
+  }
+
+  get constructorName() {
+    return 'CaretValueRule';
   }
 }

--- a/src/fshtypes/rules/ConceptRule.ts
+++ b/src/fshtypes/rules/ConceptRule.ts
@@ -1,6 +1,7 @@
 import { Rule } from './Rule';
 
 export class ConceptRule extends Rule {
+  constructorName = 'ConceptRule';
   // Allow a system, even though it is unused, to help resolve conflicts between ConceptRule and
   // ValueSetConceptComponentRule on RuleSets
   system: string;

--- a/src/fshtypes/rules/ConceptRule.ts
+++ b/src/fshtypes/rules/ConceptRule.ts
@@ -1,11 +1,14 @@
 import { Rule } from './Rule';
 
 export class ConceptRule extends Rule {
-  constructorName = 'ConceptRule';
   // Allow a system, even though it is unused, to help resolve conflicts between ConceptRule and
   // ValueSetConceptComponentRule on RuleSets
   system: string;
   constructor(public code: string, public display?: string, public definition?: string) {
     super('');
+  }
+
+  get constructorName() {
+    return 'ConceptRule';
   }
 }

--- a/src/fshtypes/rules/ContainsRule.ts
+++ b/src/fshtypes/rules/ContainsRule.ts
@@ -1,6 +1,7 @@
 import { Rule } from './Rule';
 
 export class ContainsRule extends Rule {
+  constructorName = 'ContainsRule';
   items: ContainsRuleItem[];
 
   constructor(path: string) {

--- a/src/fshtypes/rules/ContainsRule.ts
+++ b/src/fshtypes/rules/ContainsRule.ts
@@ -1,12 +1,15 @@
 import { Rule } from './Rule';
 
 export class ContainsRule extends Rule {
-  constructorName = 'ContainsRule';
   items: ContainsRuleItem[];
 
   constructor(path: string) {
     super(path);
     this.items = [];
+  }
+
+  get constructorName() {
+    return 'ContainsRule';
   }
 }
 

--- a/src/fshtypes/rules/FlagRule.ts
+++ b/src/fshtypes/rules/FlagRule.ts
@@ -1,7 +1,6 @@
 import { Rule } from './Rule';
 
 export class FlagRule extends Rule {
-  constructorName = 'FlagRule';
   mustSupport: boolean;
   summary: boolean;
   modifier: boolean;
@@ -11,5 +10,9 @@ export class FlagRule extends Rule {
 
   constructor(path: string) {
     super(path);
+  }
+
+  get constructorName() {
+    return 'FlagRule';
   }
 }

--- a/src/fshtypes/rules/FlagRule.ts
+++ b/src/fshtypes/rules/FlagRule.ts
@@ -1,6 +1,7 @@
 import { Rule } from './Rule';
 
 export class FlagRule extends Rule {
+  constructorName = 'FlagRule';
   mustSupport: boolean;
   summary: boolean;
   modifier: boolean;

--- a/src/fshtypes/rules/InsertRule.ts
+++ b/src/fshtypes/rules/InsertRule.ts
@@ -1,12 +1,15 @@
 import { Rule } from './Rule';
 
 export class InsertRule extends Rule {
-  constructorName = 'InsertRule';
   ruleSet: string;
   params: string[];
 
   constructor() {
     super('');
     this.params = [];
+  }
+
+  get constructorName() {
+    return 'InsertRule';
   }
 }

--- a/src/fshtypes/rules/InsertRule.ts
+++ b/src/fshtypes/rules/InsertRule.ts
@@ -1,6 +1,7 @@
 import { Rule } from './Rule';
 
 export class InsertRule extends Rule {
+  constructorName = 'InsertRule';
   ruleSet: string;
   params: string[];
 

--- a/src/fshtypes/rules/MappingRule.ts
+++ b/src/fshtypes/rules/MappingRule.ts
@@ -2,6 +2,7 @@ import { Rule } from './Rule';
 import { FshCode } from '../FshCode';
 
 export class MappingRule extends Rule {
+  constructorName = 'MappingRule';
   map: string;
   language?: FshCode;
   comment?: string;

--- a/src/fshtypes/rules/MappingRule.ts
+++ b/src/fshtypes/rules/MappingRule.ts
@@ -2,12 +2,15 @@ import { Rule } from './Rule';
 import { FshCode } from '../FshCode';
 
 export class MappingRule extends Rule {
-  constructorName = 'MappingRule';
   map: string;
   language?: FshCode;
   comment?: string;
 
   constructor(path: string) {
     super(path);
+  }
+
+  get constructorName() {
+    return 'MappingRule';
   }
 }

--- a/src/fshtypes/rules/ObeysRule.ts
+++ b/src/fshtypes/rules/ObeysRule.ts
@@ -1,10 +1,13 @@
 import { Rule } from './Rule';
 
 export class ObeysRule extends Rule {
-  constructorName = 'ObeysRule';
   invariant: string;
 
   constructor(path: string) {
     super(path);
+  }
+
+  get constructorName() {
+    return 'ObeysRule';
   }
 }

--- a/src/fshtypes/rules/ObeysRule.ts
+++ b/src/fshtypes/rules/ObeysRule.ts
@@ -1,6 +1,7 @@
 import { Rule } from './Rule';
 
 export class ObeysRule extends Rule {
+  constructorName = 'ObeysRule';
   invariant: string;
 
   constructor(path: string) {

--- a/src/fshtypes/rules/OnlyRule.ts
+++ b/src/fshtypes/rules/OnlyRule.ts
@@ -1,11 +1,14 @@
 import { Rule } from './Rule';
 
 export class OnlyRule extends Rule {
-  constructorName = 'OnlyRule';
   types: OnlyRuleType[] = [];
 
   constructor(path: string) {
     super(path);
+  }
+
+  get constructorName() {
+    return 'OnlyRule';
   }
 }
 

--- a/src/fshtypes/rules/OnlyRule.ts
+++ b/src/fshtypes/rules/OnlyRule.ts
@@ -1,6 +1,7 @@
 import { Rule } from './Rule';
 
 export class OnlyRule extends Rule {
+  constructorName = 'OnlyRule';
   types: OnlyRuleType[] = [];
 
   constructor(path: string) {

--- a/src/fshtypes/rules/Rule.ts
+++ b/src/fshtypes/rules/Rule.ts
@@ -1,8 +1,11 @@
 import { FshEntity } from '../FshEntity';
 
 export class Rule extends FshEntity {
-  constructorName = 'Rule';
   constructor(public path: string) {
     super();
+  }
+
+  get constructorName() {
+    return 'Rule';
   }
 }

--- a/src/fshtypes/rules/Rule.ts
+++ b/src/fshtypes/rules/Rule.ts
@@ -1,6 +1,7 @@
 import { FshEntity } from '../FshEntity';
 
 export class Rule extends FshEntity {
+  constructorName = 'Rule';
   constructor(public path: string) {
     super();
   }

--- a/src/fshtypes/rules/ValueSetComponentRule.ts
+++ b/src/fshtypes/rules/ValueSetComponentRule.ts
@@ -3,6 +3,7 @@ import { Rule } from './Rule';
 import { ValueSetComponentFrom, ValueSetFilter } from '..';
 
 export class ValueSetComponentRule extends Rule {
+  constructorName = 'ValueSetComponentRule';
   public from: ValueSetComponentFrom = {};
   constructor(public inclusion: boolean) {
     super('');
@@ -10,9 +11,11 @@ export class ValueSetComponentRule extends Rule {
 }
 
 export class ValueSetConceptComponentRule extends ValueSetComponentRule {
+  constructorName = 'ValueSetConceptComponentRule';
   public concepts: FshCode[] = [];
 }
 
 export class ValueSetFilterComponentRule extends ValueSetComponentRule {
+  constructorName = 'ValueSetFilterComponentRule';
   public filters: ValueSetFilter[] = [];
 }

--- a/src/fshtypes/rules/ValueSetComponentRule.ts
+++ b/src/fshtypes/rules/ValueSetComponentRule.ts
@@ -3,19 +3,28 @@ import { Rule } from './Rule';
 import { ValueSetComponentFrom, ValueSetFilter } from '..';
 
 export class ValueSetComponentRule extends Rule {
-  constructorName = 'ValueSetComponentRule';
   public from: ValueSetComponentFrom = {};
   constructor(public inclusion: boolean) {
     super('');
   }
+
+  get constructorName() {
+    return 'ValueSetComponentRule';
+  }
 }
 
 export class ValueSetConceptComponentRule extends ValueSetComponentRule {
-  constructorName = 'ValueSetConceptComponentRule';
   public concepts: FshCode[] = [];
+
+  get constructorName() {
+    return 'ValueSetConceptComponentRule';
+  }
 }
 
 export class ValueSetFilterComponentRule extends ValueSetComponentRule {
-  constructorName = 'ValueSetFilterComponentRule';
   public filters: ValueSetFilter[] = [];
+
+  get constructorName() {
+    return 'ValueSetFilterComponentRule';
+  }
 }

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -27,7 +27,7 @@ import {
   InsertRule,
   ConceptRule
 } from '../../src/fshtypes/rules';
-import { loggerSpy, TestFisher } from '../testhelpers';
+import { assertCardRule, assertContainsRule, loggerSpy, TestFisher } from '../testhelpers';
 import { ElementDefinitionType } from '../../src/fhirtypes';
 import path from 'path';
 import { withDebugLogging } from '../testhelpers/withDebugLogging';
@@ -3788,38 +3788,12 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(extension);
     expect(extension.rules).toHaveLength(6);
-    expect(extension.rules).toEqual([
-      {
-        sourceInfo: {},
-        path: 'extension',
-        items: [{ name: 'sliceA' }, { name: 'sliceB' }]
-      },
-      {
-        sourceInfo: {},
-        path: 'extension[sliceA].extension',
-        min: 1,
-        max: '*'
-      },
-      {
-        sourceInfo: {},
-        path: 'extension[sliceA].value[x]',
-        min: 0,
-        max: '0'
-      },
-      {
-        sourceInfo: {},
-        path: 'extension[sliceB].value[x]',
-        min: 1,
-        max: '1'
-      },
-      {
-        sourceInfo: {},
-        path: 'extension[sliceB].extension',
-        min: 0,
-        max: '0'
-      },
-      { sourceInfo: {}, path: 'value[x]', min: 0, max: '0' } // The only rule inferred
-    ]);
+    assertContainsRule(extension.rules[0], 'extension', 'sliceA', 'sliceB');
+    assertCardRule(extension.rules[1], 'extension[sliceA].extension', 1, '*');
+    assertCardRule(extension.rules[2], 'extension[sliceA].value[x]', 0, '0');
+    assertCardRule(extension.rules[3], 'extension[sliceB].value[x]', 1, '1');
+    assertCardRule(extension.rules[4], 'extension[sliceB].extension', 0, '0');
+    assertCardRule(extension.rules[5], 'value[x]', 0, '0'); // The only rule inferred
     expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
   });
 


### PR DESCRIPTION
This PR fixes #750.

It turns out that this issue only showed up in FSH Online because we were using `constructor.name` in our error message, and the constructor names are minimized when we build FSH Online for production. I couldn't find a way to avoid this happening in the built code, so I decided to implement this change in SUSHI. This adds a string `constructorName` to each of the rules and entities that are used in the error message. This shouldn't change how SUSHI works, but should let the error message be correct when we get it in FSH Online. The linked issue has an example of how to replicate the error in SUSHI and FSH Online.