### PR TITLE
AddElementRule, Logical, and Resource classes

### DIFF
--- a/src/fshtypes/Extension.ts
+++ b/src/fshtypes/Extension.ts
@@ -1,23 +1,16 @@
-import { FshEntity } from './FshEntity';
+import { FshStructure } from './FshStructure';
 import { SdRule } from './rules';
 
-export class Extension extends FshEntity {
-  id: string;
-  parent: string;
-  title?: string;
-  description?: string;
+export class Extension extends FshStructure {
   mixins?: string[];
   rules: SdRule[];
 
   constructor(public name: string) {
-    super();
-    // Init id to be same as name.  This can be overridden using FSH syntax (Id: keyword)
-    this.id = name;
+    super(name);
     // Init the parent to 'Extension', as this is what 99% of extensions do.
     // This can still be overridden via the FSH syntax (using Parent: keyword).
     this.parent = 'Extension'; // init to 'Extension'
     this.mixins = [];
-    this.rules = [];
   }
 
   get constructorName() {

--- a/src/fshtypes/FshStructure.ts
+++ b/src/fshtypes/FshStructure.ts
@@ -1,12 +1,12 @@
 import { FshEntity } from './FshEntity';
-import { SdRule, AddElementRule } from './rules';
+import { Rule } from './rules';
 
-export abstract class Model extends FshEntity {
+export abstract class FshStructure extends FshEntity {
   id: string;
   parent?: string;
   title?: string;
   description?: string;
-  rules: (SdRule | AddElementRule)[];
+  rules: Rule[];
 
   constructor(public name: string) {
     super();

--- a/src/fshtypes/FshStructure.ts
+++ b/src/fshtypes/FshStructure.ts
@@ -15,6 +15,6 @@ export abstract class FshStructure extends FshEntity {
   }
 
   get constructorName() {
-    return 'Model';
+    return 'FshStructure';
   }
 }

--- a/src/fshtypes/Logical.ts
+++ b/src/fshtypes/Logical.ts
@@ -1,0 +1,7 @@
+import { Model } from './Model';
+
+export class Logical extends Model {
+  get constructorName() {
+    return 'Logical';
+  }
+}

--- a/src/fshtypes/Logical.ts
+++ b/src/fshtypes/Logical.ts
@@ -1,6 +1,9 @@
-import { Model } from './Model';
+import { FshStructure } from './FshStructure';
+import { AddElementRule, SdRule } from './rules';
 
-export class Logical extends Model {
+export class Logical extends FshStructure {
+  rules: (AddElementRule | SdRule)[];
+
   get constructorName() {
     return 'Logical';
   }

--- a/src/fshtypes/Model.ts
+++ b/src/fshtypes/Model.ts
@@ -1,0 +1,20 @@
+import { FshEntity } from './FshEntity';
+import { SdRule, AddElementRule } from './rules';
+
+export abstract class Model extends FshEntity {
+  id: string;
+  parent?: string;
+  title?: string;
+  description?: string;
+  rules: (SdRule | AddElementRule)[];
+
+  constructor(public name: string) {
+    super();
+    this.id = name; // init same as name
+    this.rules = [];
+  }
+
+  get constructorName() {
+    return 'Model';
+  }
+}

--- a/src/fshtypes/Profile.ts
+++ b/src/fshtypes/Profile.ts
@@ -1,19 +1,13 @@
-import { FshEntity } from './FshEntity';
+import { FshStructure } from './FshStructure';
 import { SdRule } from './rules';
 
-export class Profile extends FshEntity {
-  id: string;
-  parent?: string;
-  title?: string;
-  description?: string;
+export class Profile extends FshStructure {
   mixins?: string[];
   rules: SdRule[];
 
   constructor(public name: string) {
-    super();
-    this.id = name; // init same as name
+    super(name);
     this.mixins = [];
-    this.rules = [];
   }
 
   get constructorName() {

--- a/src/fshtypes/Resource.ts
+++ b/src/fshtypes/Resource.ts
@@ -1,6 +1,9 @@
-import { Model } from './Model';
+import { FshStructure } from './FshStructure';
+import { AddElementRule, SdRule } from './rules';
 
-export class Resource extends Model {
+export class Resource extends FshStructure {
+  rules: (AddElementRule | SdRule)[];
+
   get constructorName() {
     return 'Resource';
   }

--- a/src/fshtypes/Resource.ts
+++ b/src/fshtypes/Resource.ts
@@ -1,0 +1,7 @@
+import { Model } from './Model';
+
+export class Resource extends Model {
+  get constructorName() {
+    return 'Resource';
+  }
+}

--- a/src/fshtypes/index.ts
+++ b/src/fshtypes/index.ts
@@ -18,3 +18,5 @@ export * from './ParamRuleSet';
 export * from './Mapping';
 export * from './Configuration';
 export * from './AllowedRules';
+export * from './Logical';
+export * from './Resource';

--- a/src/fshtypes/rules/AddElementRule.ts
+++ b/src/fshtypes/rules/AddElementRule.ts
@@ -1,0 +1,24 @@
+import { Rule } from './Rule';
+import { OnlyRuleType } from './OnlyRule';
+
+export class AddElementRule extends Rule {
+  min: number;
+  max: string;
+  types: OnlyRuleType[] = [];
+  mustSupport?: boolean;
+  summary?: boolean;
+  modifier?: boolean;
+  trialUse?: boolean;
+  normative?: boolean;
+  draft?: boolean;
+  short?: string;
+  definition?: string;
+
+  constructor(path: string) {
+    super(path);
+  }
+
+  get constructorName() {
+    return 'AddElementRule';
+  }
+}

--- a/src/fshtypes/rules/index.ts
+++ b/src/fshtypes/rules/index.ts
@@ -11,4 +11,5 @@ export * from './MappingRule';
 export * from './InsertRule';
 export * from './ValueSetComponentRule';
 export * from './ConceptRule';
+export * from './AddElementRule';
 export * from './SdRule';

--- a/test/fshtypes/Logical.test.ts
+++ b/test/fshtypes/Logical.test.ts
@@ -1,0 +1,20 @@
+import 'jest-extended';
+import { Logical } from '../../src/fshtypes/';
+describe('Logical', () => {
+  describe('#constructor', () => {
+    it('should set the properties correctly', () => {
+      const l = new Logical('MyLogical');
+      expect(l.name).toBe('MyLogical');
+      expect(l.id).toBe('MyLogical');
+      expect(l.parent).toBeUndefined();
+      expect(l.title).toBeUndefined();
+      expect(l.description).toBeUndefined();
+      expect(l.rules).toBeEmpty();
+    });
+
+    it('should get the correct constructor name', () => {
+      const l = new Logical('MyLogical');
+      expect(l.constructorName).toBe('Logical');
+    });
+  });
+});

--- a/test/fshtypes/Resource.test.ts
+++ b/test/fshtypes/Resource.test.ts
@@ -1,0 +1,20 @@
+import 'jest-extended';
+import { Resource } from '../../src/fshtypes/';
+describe('Resource', () => {
+  describe('#constructor', () => {
+    it('should set the properties correctly', () => {
+      const r = new Resource('MyResource');
+      expect(r.name).toBe('MyResource');
+      expect(r.id).toBe('MyResource');
+      expect(r.parent).toBeUndefined();
+      expect(r.title).toBeUndefined();
+      expect(r.description).toBeUndefined();
+      expect(r.rules).toBeEmpty();
+    });
+
+    it('should get the correct constructor name', () => {
+      const r = new Resource('MyResource');
+      expect(r.constructorName).toBe('Resource');
+    });
+  });
+});

--- a/test/fshtypes/rules/AddElementRule.test.ts
+++ b/test/fshtypes/rules/AddElementRule.test.ts
@@ -1,0 +1,22 @@
+import 'jest-extended';
+import { AddElementRule } from '../../../src/fshtypes/rules/AddElementRule';
+
+describe('AddElementRule', () => {
+  describe('#constructor', () => {
+    it('should set the properties correctly', () => {
+      const r = new AddElementRule('component.code');
+      expect(r.path).toBe('component.code');
+      expect(r.min).toBeUndefined();
+      expect(r.max).toBeUndefined();
+      expect(r.types).toEqual([]);
+      expect(r.mustSupport).toBeUndefined();
+      expect(r.summary).toBeUndefined();
+      expect(r.modifier).toBeUndefined();
+      expect(r.trialUse).toBeUndefined();
+      expect(r.normative).toBeUndefined();
+      expect(r.draft).toBeUndefined();
+      expect(r.short).toBeUndefined();
+      expect(r.definition).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
This completes [CIMPL-688](https://standardhealthrecord.atlassian.net/browse/CIMPL-688) by adding an `AddElementRule` class, a `Logical` class, and a `Resource` class.

I think @cmoesel should be one of the reviewers, since he designed the syntaxes that these classes represent, and I want to make sure I didn't misunderstand any of the requirements.