### PR TITLE
Skip nonexistent files when traversing directories

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -455,8 +455,11 @@ export async function init(): Promise<void> {
 
 function getFilesRecursive(dir: string): string[] {
   if (fs.statSync(dir).isDirectory()) {
-    const ancestors = fs.readdirSync(dir, 'utf8').map(f => getFilesRecursive(path.join(dir, f)));
-    return [].concat(...ancestors);
+    const descendants = fs
+      .readdirSync(dir, 'utf8')
+      .filter(f => fs.existsSync(path.join(dir, f)))
+      .map(f => getFilesRecursive(path.join(dir, f)));
+    return [].concat(...descendants);
   } else {
     return [dir];
   }

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -432,6 +432,43 @@ describe('Processing', () => {
       }).toThrow();
       expect(loggerSpy.getLastMessage('error')).toMatch(/Invalid path to FSH definition folder\./s);
     });
+
+    describe('#symlinks', () => {
+      const linkPath = path.join(__dirname, 'fixtures', 'fsh-files', 'myLock.fsh');
+      const linkTarget = path.join(__dirname, 'fixtures', 'fsh-files', 'meaninglessTarget');
+
+      beforeAll(() => {
+        if (fs.existsSync(linkPath)) {
+          fs.removeSync(linkPath);
+        }
+        try {
+          fs.symlinkSync(linkTarget, linkPath);
+        } catch {
+          // This may fail if the user running the test doesn't have permission to create a symbolic link.
+          // On Windows systems, normal users do not have this permission.
+        }
+      });
+
+      it('should return a RawFSH for each real file in the input directory that ends with .fsh', () => {
+        const input = path.join(__dirname, 'fixtures', 'fsh-files');
+        const rawFSHes = getRawFSHes(input);
+        expect(rawFSHes.length).toBe(2);
+        expect(rawFSHes).toContainEqual({
+          content: '// Content of first file',
+          path: path.join(input, 'first.fsh')
+        });
+        expect(rawFSHes).toContainEqual({
+          content: '// Content of second file',
+          path: path.join(input, 'second.fsh')
+        });
+      });
+
+      afterAll(() => {
+        if (fs.existsSync(linkPath)) {
+          fs.removeSync(linkPath);
+        }
+      });
+    });
   });
 
   describe('#hasFshFiles()', () => {


### PR DESCRIPTION
Fixes #780 and completes task [CIMPL-708](https://standardhealthrecord.atlassian.net/browse/CIMPL-708).

- When is a door not a door?
- When it's a jar.
***
- When is a file not a file?
- When it's listed by `readdir`, but is a symbolic link with a nonexistent target.
***
A symbolic link with an invalid target will be listed when reading a directory, but it will not be possible to retrieve information about it. Therefore, it should be filtered out before continuing to traverse directories. This is primarily being done to resolve an issue with emacs lock files.

Additionally, I changed `ancestors` to `descendants` for the sake of accuracy in variable naming.

A note about the added test: I had to write the setup this way in order to get consistent behavior across systems, since non-admin Windows users can't create symbolic links. Hopefully, the test pipeline decides that what I've written is acceptable.