### PR TITLE
parseFSHPath regex fix

### DIFF
--- a/src/utils/PathUtils.ts
+++ b/src/utils/PathUtils.ts
@@ -37,7 +37,7 @@ export function parseFSHPath(fshPath: string): PathPart[] {
         pathParts.push({
           base: fhirPathBase,
           brackets: brackets,
-          slices: seenSlices
+          slices: [...seenSlices]
         });
       } else {
         pathParts.push({ base: fhirPathBase, brackets: brackets });

--- a/src/utils/PathUtils.ts
+++ b/src/utils/PathUtils.ts
@@ -11,7 +11,7 @@ import { logger } from './FSHLogger';
 export function parseFSHPath(fshPath: string): PathPart[] {
   const pathParts: PathPart[] = [];
   const seenSlices: string[] = [];
-  const indexRegex = new RegExp('^[0-9]$');
+  const indexRegex = /^[0-9]+$/;
   const splitPath = fshPath === '.' ? [fshPath] : splitOnPathPeriods(fshPath);
   for (const pathPart of splitPath) {
     const splitPathPart = pathPart.split('[');

--- a/test/utils/PathUtils.test.ts
+++ b/test/utils/PathUtils.test.ts
@@ -1,5 +1,5 @@
 import { CaretValueRule, Rule } from '../../src/fshtypes/rules';
-import { resolveSoftIndexing } from '../../src/utils';
+import { resolveSoftIndexing, parseFSHPath } from '../../src/utils';
 import '../testhelpers/loggerSpy'; // side-effect: suppresses logs
 
 describe('PathUtils', () => {
@@ -146,6 +146,58 @@ describe('PathUtils', () => {
         'name[1]',
         'name[1]'
       ]);
+    });
+  });
+
+  describe('#parseFSHPath', () => {
+    it('should properly seperate path elements into PathParts', () => {
+      const testPath = 'item1.item2.item3';
+      const pathParts = parseFSHPath(testPath);
+
+      expect(pathParts[0]).toEqual({ base: 'item1' });
+      expect(pathParts[1]).toEqual({ base: 'item2' });
+      expect(pathParts[2]).toEqual({ base: 'item3' });
+    });
+
+    it('should properly seperate path elements with brackets into PathParts', () => {
+      const testPath = 'item1[0].item2[0].item3[0]';
+      const pathParts = parseFSHPath(testPath);
+
+      expect(pathParts[0]).toEqual({ base: 'item1', brackets: ['0'] });
+      expect(pathParts[1]).toEqual({ base: 'item2', brackets: ['0'] });
+      expect(pathParts[2]).toEqual({ base: 'item3', brackets: ['0'] });
+    });
+
+    it('should properly seperate path elements with multi-digit brackets into PathParts', () => {
+      const testPath = 'item1[10].item2[11].item3[12]';
+      const pathParts = parseFSHPath(testPath);
+
+      expect(pathParts[0]).toEqual({ base: 'item1', brackets: ['10'] });
+      expect(pathParts[1]).toEqual({ base: 'item2', brackets: ['11'] });
+      expect(pathParts[2]).toEqual({ base: 'item3', brackets: ['12'] });
+    });
+
+    it('should properly seperate path elements with slice names into PathParts', () => {
+      const testPath = 'item1[10][Slice1].item2[11][Slice2].item3[12][Slice3]';
+      const pathParts = parseFSHPath(testPath);
+
+      console.log(JSON.stringify(pathParts[0]));
+
+      expect(pathParts[0]).toEqual({
+        base: 'item1',
+        brackets: ['10', 'Slice1'],
+        slices: ['Slice1']
+      });
+      expect(pathParts[1]).toEqual({
+        base: 'item2',
+        brackets: ['11', 'Slice2'],
+        slices: ['Slice1', 'Slice2']
+      });
+      expect(pathParts[2]).toEqual({
+        base: 'item3',
+        brackets: ['12', 'Slice3'],
+        slices: ['Slice1', 'Slice2', 'Slice3']
+      });
     });
   });
 });

--- a/test/utils/PathUtils.test.ts
+++ b/test/utils/PathUtils.test.ts
@@ -181,8 +181,6 @@ describe('PathUtils', () => {
       const testPath = 'item1[10][Slice1].item2[11][Slice2].item3[12][Slice3]';
       const pathParts = parseFSHPath(testPath);
 
-      console.log(JSON.stringify(pathParts[0]));
-
       expect(pathParts[0]).toEqual({
         base: 'item1',
         brackets: ['10', 'Slice1'],


### PR DESCRIPTION
This is a companion PR to [PR #106 on the GoFSH side](https://github.com/FHIR/GoFSH/pull/106). The regex expression within `parseFSHPath` is currently `^[0-9]$` when it should really be `^[0-9]+$` to take multi-digit integers into account.