### PR TITLE
Soft Indexing sequences can now being at non-zero indices

### DIFF
--- a/src/utils/PathUtils.ts
+++ b/src/utils/PathUtils.ts
@@ -77,18 +77,17 @@ function convertSoftIndexes(element: PathPart, pathMap: Map<string, number>) {
     const existingNumericBracket = element.brackets?.find(bracket => indexRegex.test(bracket));
     if (existingNumericBracket) {
       pathMap.set(mapName, parseInt(existingNumericBracket));
-      return;
     } else {
       pathMap.set(mapName, 0);
-    }
-    if (element.brackets?.includes('+')) {
-      element.brackets[element.brackets.indexOf('+')] = '0';
-    } else if (element.brackets?.includes('=')) {
-      // If a sequence begins with a '=', we log an error but assume a value of 0
-      element.brackets[element.brackets.indexOf('=')] = '0';
-      throw new Error(
-        'The first index in a Soft Indexing sequence must be "+", an actual index of "0" has been assumed'
-      );
+      if (element.brackets?.includes('+')) {
+        element.brackets[element.brackets.indexOf('+')] = '0';
+      } else if (element.brackets?.includes('=')) {
+        // If a sequence begins with a '=', we log an error but assume a value of 0
+        element.brackets[element.brackets.indexOf('=')] = '0';
+        throw new Error(
+          'The first index in a Soft Indexing sequence must be "+", an actual index of "0" has been assumed'
+        );
+      }
     }
   } else {
     element.brackets?.forEach((bracket: string, index: number) => {

--- a/src/utils/PathUtils.ts
+++ b/src/utils/PathUtils.ts
@@ -74,7 +74,13 @@ function convertSoftIndexes(element: PathPart, pathMap: Map<string, number>) {
   const mapName = `${element.prefix ?? ''}.${element.base}|${(element.slices ?? []).join('|')}`;
   const indexRegex = /^[0-9]+$/;
   if (!pathMap.has(mapName)) {
-    pathMap.set(mapName, 0);
+    const existingNumericBracket = element.brackets?.find(bracket => indexRegex.test(bracket));
+    if (existingNumericBracket) {
+      pathMap.set(mapName, parseInt(existingNumericBracket));
+      return;
+    } else {
+      pathMap.set(mapName, 0);
+    }
     if (element.brackets?.includes('+')) {
       element.brackets[element.brackets.indexOf('+')] = '0';
     } else if (element.brackets?.includes('=')) {

--- a/test/utils/PathUtils.test.ts
+++ b/test/utils/PathUtils.test.ts
@@ -147,6 +147,18 @@ describe('PathUtils', () => {
         'name[1]'
       ]);
     });
+
+    it('should resolve soft indexing beginning with a non-zero index', () => {
+      const rules = ['name[2]', 'name[=]', 'name[=]', 'name[+]', 'name[=]'].map(r => new Rule(r));
+      resolveSoftIndexing(rules);
+      expect(rules.map(r => r.path)).toEqual([
+        'name[2]',
+        'name[2]',
+        'name[2]',
+        'name[3]',
+        'name[3]'
+      ]);
+    });
   });
 
   describe('#parseFSHPath', () => {


### PR DESCRIPTION
This PR addresses another issue found in [PR #106](https://github.com/FHIR/GoFSH/pull/106) on GoFSH. When unwinding soft indexing, Sushi currently makes the assumption that the first element being assigned by an array utilizing soft indexing will always be at index 0. In the event that sushi first encounters an array as it references a non-zero element, this could result in something like the following... 
```
* effective[x] ^constraint[1].key = "us-core-1"
* effective[x] ^constraint[=].severity = #error
* effective[x] ^constraint[=].human = "Datetime must be at least to day."
```
resolving to this:
```
* effective[x] ^constraint[1].key = "us-core-1"
* effective[x] ^constraint[0].severity = #error
* effective[x] ^constraint[0].human = "Datetime must be at least to day."
```
This PR fixes this bug, taking numeric indices into account at all times. The issue can be illustrated by running the unit test included in commit `6035ded`, which should fail in that commit but pass in commit `037cd63` which adds the fix.