### PR TITLE
Loosen restrictions on constraining profiled types

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -847,11 +847,13 @@ export class ElementDefinition {
             (t2.targetProfile == null || t2.targetProfile.includes(md.url))
         );
       } else {
-        // Look for exact match on the code (w/ no profile) or a match on the same base type with
+        // Look for exact match on the code (w/ no profile) or a match on an allowed base type with
         // a matching profile
         matchedType = targetTypes.find(t2 => {
           const matchesUnprofiledResource = t2.code === md.id && isEmpty(t2.profile);
-          const matchesProfile = t2.code === md.sdType && t2.profile?.includes(md.url);
+          const matchesProfile =
+            this.getTypeLineage(md.sdType, fisher).some(ancestor => ancestor.sdType === t2.code) &&
+            t2.profile?.includes(md.url);
           // True if we match an unprofiled type that is not abstract, is a parent, and that we are
           // specializing (the type does not match the sdType of the type to match)
           specializationOfNonAbstractType =


### PR DESCRIPTION
Fixes #789 

If we have a situation like the one below:
```
Profile: MyBundle
Parent: Bundle
* entry.resource only http://hl7.org/fhir/StructureDefinition/resprate
* entry.resource ^type.code = "Resource"

Profile: MyResp
Parent: http://hl7.org/fhir/StructureDefinition/resprate

Profile: MyBundleChild
Parent: MyBundle
* entry.resource only MyResp
```
Then we get an error that looks like:
```
The type "MyResp" does not match any of the allowed types: http://hl7.org/fhir/StructureDefinition/resprate
```

This is because when we check if the `MyResp` profile can be applied as a type to `entry.resource`, we check that inherits from the current profile on `entry.resource`, and it does, since it is a child of `resprate`. But we also check that `MyResp`'s type exactly matches the `type.code` on the type constraint applied to `entry.resource`. That is not the case here, because `MyResp` is of type `Observation`, and the `type.code` is `Resource`. But, since `Observation` is a child of `Resource`, this should really still be allowed. This PR fixes this issue so that this type constraint is now allowed.

To test this, you can use the example above on `master` and observer the error, and then see that on this branch the error goes away. You can also run the tests added in 3f8bf05 and see that one fails (the other test which passes is just an implementation of an old skipped test which we had no reason to skip anymore). Then on this branch, all tests should pass.