### PR TITLE
Deprecate ValueSet expansion

### DIFF
--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -142,6 +142,9 @@ export class ValueSetExporter {
       parameter => parameter.name === 'sushi-generated' && parameter.valueBoolean === true
     );
     if (shouldExpand) {
+      logger.warn(
+        `ValueSet ${valueSet.name}: expansion is deprecated and will be removed in a future SUSHI release.`
+      );
       const errors: string[] = [];
       // the compose property must be defined
       if (!valueSet.compose) {


### PR DESCRIPTION
Addresses task [INT-999](https://standardhealthrecord.atlassian.net/browse/INT-999).

A warning is emitted when exporting a ValueSet if the ValueSet has the expansion parameters set. This function is being deprecated because it doesn't actually solve the problem it was intended to solve when sending ValueSet resources to the IG publisher. Keeping the feature in could be confusing, so it is being deprecated.