### PR TITLE
SUSHI 2.0.0 Beta 1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "1.3.2",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "1.3.2",
+  "version": "2.0.0-beta.1",
   "description": "Sushi Unshortens Short Hand Inputs (FSH Compiler)",
   "scripts": {
     "build": "del-cli dist && tsc && cpy src/utils/init-project dist/utils/init-project",

--- a/regression/repos-all.txt
+++ b/regression/repos-all.txt
@@ -40,7 +40,6 @@ hl7dk/kl-gateway#master
 costateixeira/devdays-covid19-vaccine#main
 IHE/ITI.MHD#master
 IHE/ITI_MHD_FHIR#master
-openhie/hiv-ig#master
 openhie/covid-ig#master
 DavidPyke/CEQSubscription#master
 HL7Sweden/basprofiler-r4#master


### PR DESCRIPTION
Version number has been bumped to 2.0.0-beta.1.  In addition, the regression script was updated to remove a repo branch that no longer exists.