### PR TITLE
Update sushi --help message and remove old IG Publisher hack

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -87,13 +87,6 @@ async function app() {
   }
   logger.info(`  ${path.resolve(input)}`);
 
-  // IG Publisher HACK: the IG Publisher invokes SUSHI with `/fsh` appended (even if it doesn't
-  // exist).  If we detect a direct fsh path, we need to fix it by backing up a folder, else it
-  // won't correctly detect the IG Publisher mode.
-  if (path.basename(input) === 'fsh') {
-    input = path.dirname(input);
-  }
-
   const originalInput = input;
   input = findInputDir(input);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,7 +42,7 @@ async function app() {
 
   program
     .name('sushi')
-    .usage('[path-to-fsh-defs] [options]')
+    .usage('[path-to-fsh-project] [options]')
     .option('-o, --out <out>', 'the path to the output folder')
     .option('-d, --debug', 'output extra debugging information')
     .option('-p, --preprocessed', 'output FSH produced by preprocessing steps')
@@ -52,9 +52,8 @@ async function app() {
     .on('--help', () => {
       console.log('');
       console.log('Additional information:');
-      console.log('  [path-to-fsh-defs]');
+      console.log('  [path-to-fsh-project]');
       console.log('    Default: "."');
-      console.log('    If input/fsh/ subdirectory present, it is included in [path-to-fsh-defs]');
       console.log('  -o, --out <out>');
       console.log('    Default: "fsh-generated"');
     })


### PR DESCRIPTION
This PR does two simple things:

- Updates the `sushi --help` message to clarify that the input directory to SUSHI should be the root level FSH project, which does not include a path to `input/fsh/`
- Removes a hack for the IG Publisher that is no longer required. The IG Publisher now uses `.` as the input path, which is how SUSHI is intended to run, so no special handling is needed anymore.

This can be in a beta.2 release, but it is not needed urgently.