### PR TITLE
Change HasFlags mixin to FlagCarryingRule superclass

### DIFF
--- a/src/fshtypes/common.ts
+++ b/src/fshtypes/common.ts
@@ -19,24 +19,3 @@ export function fshifyString(input: string): string {
     .replace(/\r/g, '\\r')
     .replace(/\t/g, '\\t');
 }
-
-export class HasFlags {
-  mustSupport?: boolean;
-  summary?: boolean;
-  modifier?: boolean;
-  trialUse?: boolean;
-  normative?: boolean;
-  draft?: boolean;
-
-  get flags(): string[] {
-    const flags: string[] = [];
-    if (this.mustSupport) flags.push('MS');
-    if (this.modifier) flags.push('?!');
-    if (this.summary) flags.push('SU');
-    if (this.draft) flags.push('D');
-    else if (this.trialUse) flags.push('TU');
-    else if (this.normative) flags.push('N');
-
-    return flags;
-  }
-}

--- a/src/fshtypes/rules/AddElementRule.ts
+++ b/src/fshtypes/rules/AddElementRule.ts
@@ -1,9 +1,8 @@
-import { Rule } from './Rule';
 import { OnlyRuleType } from './OnlyRule';
-import { typeString, fshifyString, HasFlags } from '../common';
-import { applyMixins } from '../../utils/Mixin';
+import { FlagCarryingRule } from './FlagCarryingRule';
+import { typeString, fshifyString } from '../common';
 
-export class AddElementRule extends Rule {
+export class AddElementRule extends FlagCarryingRule {
   min: number;
   max: string;
   types: OnlyRuleType[] = [];
@@ -28,6 +27,3 @@ export class AddElementRule extends Rule {
     return `* ${this.path} ${cardPart}${flagPart} ${typePart}${shortPart}${definitionPart}`;
   }
 }
-
-export interface AddElementRule extends Rule, HasFlags {}
-applyMixins(AddElementRule, [HasFlags]);

--- a/src/fshtypes/rules/FlagCarryingRule.ts
+++ b/src/fshtypes/rules/FlagCarryingRule.ts
@@ -1,0 +1,25 @@
+import { Rule } from './Rule';
+
+// This is a common base class for FlagRule and AddElementRule, both of which carry flags.
+// This capability was originally implemented as a mixin, but that approach was not
+// compatible w/ FSHOnline (for unknown and difficult to debug reasons).
+export abstract class FlagCarryingRule extends Rule {
+  mustSupport?: boolean;
+  summary?: boolean;
+  modifier?: boolean;
+  trialUse?: boolean;
+  normative?: boolean;
+  draft?: boolean;
+
+  get flags(): string[] {
+    const flags: string[] = [];
+    if (this.mustSupport) flags.push('MS');
+    if (this.modifier) flags.push('?!');
+    if (this.summary) flags.push('SU');
+    if (this.draft) flags.push('D');
+    else if (this.trialUse) flags.push('TU');
+    else if (this.normative) flags.push('N');
+
+    return flags;
+  }
+}

--- a/src/fshtypes/rules/FlagRule.ts
+++ b/src/fshtypes/rules/FlagRule.ts
@@ -1,8 +1,6 @@
-import { Rule } from './Rule';
-import { HasFlags } from '../common';
-import { applyMixins } from '../../utils/Mixin';
+import { FlagCarryingRule } from './FlagCarryingRule';
 
-export class FlagRule extends Rule {
+export class FlagRule extends FlagCarryingRule {
   // flags provided by HasFlags mixin
 
   constructor(path: string) {
@@ -21,6 +19,3 @@ export class FlagRule extends Rule {
     return `* ${this.path} ${this.flagsToString()}`;
   }
 }
-
-export interface FlagRule extends Rule, HasFlags {}
-applyMixins(FlagRule, [HasFlags]);


### PR DESCRIPTION
**NOTE: This is the same as #830, but into _master_ (since we don't want the version bump in the fshonline-hotfix branch)**

The HasFlags mixin causes strange errors in FSH Online that are difficult (or possibly impossible) to debug. This abandons the mixin in favor of a common superclass, which is a reasonable solution to this problem.  At least for now.