### PR TITLE
Allow CodeCaretValueRules on FSHCodeSystem and RuleSet

### DIFF
--- a/src/fshtypes/AllowedRules.ts
+++ b/src/fshtypes/AllowedRules.ts
@@ -22,7 +22,8 @@ import {
   ConceptRule,
   ValueSetComponentRule,
   MappingRule,
-  Rule
+  Rule,
+  CodeCaretValueRule
 } from './rules';
 
 const allowedRulesMap = new Map<any, any[]>([
@@ -54,7 +55,7 @@ const allowedRulesMap = new Map<any, any[]>([
   ],
   ['Instance', [AssignmentRule]],
   ['FshValueSet', [ValueSetComponentRule, CaretValueRule]],
-  ['FshCodeSystem', [ConceptRule, CaretValueRule]],
+  ['FshCodeSystem', [ConceptRule, CaretValueRule, CodeCaretValueRule]],
   ['Mapping', [MappingRule]],
   [
     'RuleSet',
@@ -70,7 +71,8 @@ const allowedRulesMap = new Map<any, any[]>([
       ObeysRule,
       OnlyRule,
       ValueSetComponentRule,
-      BindingRule
+      BindingRule,
+      CodeCaretValueRule
     ]
   ],
   [

--- a/test/fshtypes/AllowedRules.test.ts
+++ b/test/fshtypes/AllowedRules.test.ts
@@ -14,7 +14,8 @@ import {
   InsertRule,
   ValueSetComponentRule,
   ValueSetConceptComponentRule,
-  ValueSetFilterComponentRule
+  ValueSetFilterComponentRule,
+  CodeCaretValueRule
 } from '../../src/fshtypes/rules';
 import {
   isAllowedRule,
@@ -188,6 +189,7 @@ describe('isAllowedRule', () => {
     it('should allow valid rules on a FshCodeSystem', () => {
       expect(isAllowedRule(c, new CaretValueRule('foo'))).toBeTrue();
       expect(isAllowedRule(c, new ConceptRule('foo'))).toBeTrue();
+      expect(isAllowedRule(c, new CodeCaretValueRule(['foo']))).toBeTrue();
     });
 
     it('should not allow invalid rules on a FshCodeSystem', () => {
@@ -247,6 +249,7 @@ describe('isAllowedRule', () => {
       expect(isAllowedRule(r, new MappingRule('foo'))).toBeTrue();
       expect(isAllowedRule(r, new ValueSetComponentRule(true))).toBeTrue();
       expect(isAllowedRule(r, new ConceptRule('foo'))).toBeTrue();
+      expect(isAllowedRule(r, new CodeCaretValueRule(['foo']))).toBeTrue();
     });
 
     it('should not allow invalid rules on a RuleSet', () => {


### PR DESCRIPTION
This fixes #833. 

We were not allowing `CodeCaretValueRules` on `FshCodeSystems` and `RuleSets`. So something like the FSH found at this [link](https://fshschool.org/FSHOnline/#/share/3zjIdK9) would not work. This PR fixes that so that the `insert` rule can apply a `CodeCaretValueRule` to both a `FshCodeSystem` and a `RuleSet`. For testing, the linked FSH exercises both cases.