### PR TITLE
Use Version with FSH Code System

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -299,7 +299,8 @@ export function replaceReferences<T extends AssignmentRule | CaretValueRule>(
       assignedReference.sdType = instanceMeta.sdType;
     }
   } else if (value instanceof FshCode) {
-    const [system, version] = value.system?.split('|') ?? [];
+    const [system, ...versionParts] = value.system?.split('|') ?? [];
+    const version = versionParts.join('|');
     const codeSystem = tank.fish(system, Type.CodeSystem);
     const codeSystemMeta = fisher.fishForMetadata(codeSystem?.name, Type.CodeSystem);
     if (codeSystem && codeSystemMeta) {

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -299,12 +299,13 @@ export function replaceReferences<T extends AssignmentRule | CaretValueRule>(
       assignedReference.sdType = instanceMeta.sdType;
     }
   } else if (value instanceof FshCode) {
-    const codeSystem = tank.fish(value.system, Type.CodeSystem);
+    const [system, version] = value.system?.split('|') ?? [];
+    const codeSystem = tank.fish(system, Type.CodeSystem);
     const codeSystemMeta = fisher.fishForMetadata(codeSystem?.name, Type.CodeSystem);
     if (codeSystem && codeSystemMeta) {
       clone = cloneDeep(rule);
       const assignedCode = getRuleValue(clone) as FshCode;
-      assignedCode.system = codeSystemMeta.url;
+      assignedCode.system = `${codeSystemMeta.url}${version ? `|${version}` : ''}`;
     }
   }
   return clone ?? rule;

--- a/src/fshtypes/FshCode.ts
+++ b/src/fshtypes/FshCode.ts
@@ -18,7 +18,9 @@ export class FshCode extends FshEntity {
     }
     if (this.system) {
       if (this.system.indexOf('|') > -1) {
-        [coding.system, coding.version] = this.system.split('|', 2);
+        let versionParts;
+        [coding.system, ...versionParts] = this.system.split('|');
+        coding.version = versionParts.join('|');
       } else {
         coding.system = this.system;
       }

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -1679,6 +1679,26 @@ describe('InstanceExporter', () => {
       ]);
     });
 
+    it('should assign a code with a version to a top level element while replacing the local code system name with its url and use the specified version', () => {
+      const brightInstance = new Instance('BrightObservation');
+      brightInstance.instanceOf = 'Observation';
+      const assignedCodeRule = new AssignmentRule('code');
+      assignedCodeRule.value = new FshCode('bright', 'Visible|1.0.0');
+      brightInstance.rules.push(assignedCodeRule);
+      doc.instances.set(brightInstance.name, brightInstance);
+
+      const visibleSystem = new FshCodeSystem('Visible');
+      doc.codeSystems.set(visibleSystem.name, visibleSystem);
+      const exported = exportInstance(brightInstance);
+      expect(exported.code.coding).toEqual([
+        {
+          code: 'bright',
+          version: '1.0.0',
+          system: 'http://hl7.org/fhir/us/minimal/CodeSystem/Visible'
+        }
+      ]);
+    });
+
     it('should assign a code to a nested element while replacing the local code system name with its url', () => {
       const brightInstance = new Instance('BrightObservation');
       brightInstance.instanceOf = 'Observation';

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -1683,7 +1683,7 @@ describe('InstanceExporter', () => {
       const brightInstance = new Instance('BrightObservation');
       brightInstance.instanceOf = 'Observation';
       const assignedCodeRule = new AssignmentRule('code');
-      assignedCodeRule.value = new FshCode('bright', 'Visible|1.0.0');
+      assignedCodeRule.value = new FshCode('bright', 'Visible|1.0.0|a'); // Version should include anything that comes after the first |
       brightInstance.rules.push(assignedCodeRule);
       doc.instances.set(brightInstance.name, brightInstance);
 
@@ -1693,7 +1693,7 @@ describe('InstanceExporter', () => {
       expect(exported.code.coding).toEqual([
         {
           code: 'bright',
-          version: '1.0.0',
+          version: '1.0.0|a',
           system: 'http://hl7.org/fhir/us/minimal/CodeSystem/Visible'
         }
       ]);


### PR DESCRIPTION
Fixes #816 

This PR supports parsing out the CodeSystem system from the version when fishing for CodeSystems while resolving references. Previously, the full `system|version` text was used, so fishing for the code system was unsuccessful. This instead uses just the `system` portion if the version is included, and then adds the version back after the URL is resolved.