### PR TITLE
Support code values in =, in, and not-in filters

### DIFF
--- a/src/errors/ValueSetFilterValueTypeError.ts
+++ b/src/errors/ValueSetFilterValueTypeError.ts
@@ -1,12 +1,12 @@
 import { VsOperator } from '../fshtypes';
 
+type expectedType = 'string' | 'regex' | 'boolean' | 'code';
 export class ValueSetFilterValueTypeError extends Error {
-  constructor(
-    public operator: VsOperator,
-    public expectedType: 'string' | 'regex' | 'boolean' | 'code'
-  ) {
+  constructor(public operator: VsOperator, public expectedType: expectedType[]) {
     super(
-      `Not applying value set filter: operator "${operator}" requires a ${expectedType} value.`
+      `Not applying value set filter: operator "${operator}" requires a ${expectedType.join(
+        ' or '
+      )} value.`
     );
   }
 }

--- a/src/errors/ValueSetFilterValueTypeError.ts
+++ b/src/errors/ValueSetFilterValueTypeError.ts
@@ -1,12 +1,12 @@
 import { VsOperator } from '../fshtypes';
 
-type expectedType = 'string' | 'regex' | 'boolean' | 'code';
 export class ValueSetFilterValueTypeError extends Error {
-  constructor(public operator: VsOperator, public expectedType: expectedType[]) {
+  constructor(
+    public operator: VsOperator,
+    public expectedType: 'string' | 'regex' | 'boolean' | 'code'
+  ) {
     super(
-      `Not applying value set filter: operator "${operator}" requires a ${expectedType.join(
-        ' or '
-      )} value.`
+      `Not applying value set filter: operator "${operator}" requires a ${expectedType} value.`
     );
   }
 }

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1933,6 +1933,10 @@ export class FSHImporter extends FSHVisitor {
       case VsOperator.EQUALS:
       case VsOperator.IN:
       case VsOperator.NOT_IN:
+        // NOTE: We believe that =, in, and not-in operators should ONLY support code values
+        // based on the filter value documentation:
+        // http://hl7.org/fhir/R4/valueset-definitions.html#ValueSet.compose.include.filter.value
+        // Both string and code are supported for now in order to maintain backwards compatibility.
         if (typeof value !== 'string' && !(value instanceof FshCode)) {
           throw new ValueSetFilterValueTypeError(operator, ['string', 'code']);
         }

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1940,11 +1940,12 @@ export class FSHImporter extends FSHVisitor {
         if (typeof value === 'string') {
           logger.warn(
             `The match value of filter operator "${operator}" must be a code. ` +
-              'Support for string values has been deprecated and will be removed in a future release.'
+              'For string valued properties, use the regex filter operator with a regular expression value. ' +
+              'Support for using strings as filter values has been deprecated and will be removed in a future release.'
           );
         }
         if (typeof value !== 'string' && !(value instanceof FshCode)) {
-          throw new ValueSetFilterValueTypeError(operator, ['string', 'code']);
+          throw new ValueSetFilterValueTypeError(operator, 'code');
         }
         break;
       case VsOperator.IS_A:
@@ -1952,17 +1953,17 @@ export class FSHImporter extends FSHVisitor {
       case VsOperator.IS_NOT_A:
       case VsOperator.GENERALIZES:
         if (!(value instanceof FshCode)) {
-          throw new ValueSetFilterValueTypeError(operator, ['code']);
+          throw new ValueSetFilterValueTypeError(operator, 'code');
         }
         break;
       case VsOperator.REGEX:
         if (!(value instanceof RegExp)) {
-          throw new ValueSetFilterValueTypeError(operator, ['regex']);
+          throw new ValueSetFilterValueTypeError(operator, 'regex');
         }
         break;
       case VsOperator.EXISTS:
         if (typeof value !== 'boolean') {
-          throw new ValueSetFilterValueTypeError(operator, ['boolean']);
+          throw new ValueSetFilterValueTypeError(operator, 'boolean');
         }
         break;
       default:

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1933,8 +1933,8 @@ export class FSHImporter extends FSHVisitor {
       case VsOperator.EQUALS:
       case VsOperator.IN:
       case VsOperator.NOT_IN:
-        if (typeof value !== 'string') {
-          throw new ValueSetFilterValueTypeError(operator, 'string');
+        if (typeof value !== 'string' && !(value instanceof FshCode)) {
+          throw new ValueSetFilterValueTypeError(operator, ['string', 'code']);
         }
         break;
       case VsOperator.IS_A:
@@ -1942,17 +1942,17 @@ export class FSHImporter extends FSHVisitor {
       case VsOperator.IS_NOT_A:
       case VsOperator.GENERALIZES:
         if (!(value instanceof FshCode)) {
-          throw new ValueSetFilterValueTypeError(operator, 'code');
+          throw new ValueSetFilterValueTypeError(operator, ['code']);
         }
         break;
       case VsOperator.REGEX:
         if (!(value instanceof RegExp)) {
-          throw new ValueSetFilterValueTypeError(operator, 'regex');
+          throw new ValueSetFilterValueTypeError(operator, ['regex']);
         }
         break;
       case VsOperator.EXISTS:
         if (typeof value !== 'boolean') {
-          throw new ValueSetFilterValueTypeError(operator, 'boolean');
+          throw new ValueSetFilterValueTypeError(operator, ['boolean']);
         }
         break;
       default:

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1937,6 +1937,12 @@ export class FSHImporter extends FSHVisitor {
         // based on the filter value documentation:
         // http://hl7.org/fhir/R4/valueset-definitions.html#ValueSet.compose.include.filter.value
         // Both string and code are supported for now in order to maintain backwards compatibility.
+        if (typeof value === 'string') {
+          logger.warn(
+            `The match value of filter operator "${operator}" must be a code. ` +
+              'Support for string values has been deprecated and will be removed in a future release.'
+          );
+        }
         if (typeof value !== 'string' && !(value instanceof FshCode)) {
           throw new ValueSetFilterValueTypeError(operator, ['string', 'code']);
         }

--- a/test/import/FSHImporter.ValueSet.test.ts
+++ b/test/import/FSHImporter.ValueSet.test.ts
@@ -720,7 +720,7 @@ describe('FSHImporter', () => {
         expect(loggerSpy.getLastMessage('error')).toMatch(/File: MostlyDogs\.fsh.*Line: 3\D*/s);
       });
 
-      it('should parse a value set that uses filter operator in', () => {
+      it('should parse a value set that uses filter operator in with a string value', () => {
         const input = `
         ValueSet: CatAndDogVS
         * codes from system ZOO where concept in "#cat, #dog"
@@ -738,10 +738,28 @@ describe('FSHImporter', () => {
         ]);
       });
 
-      it('should log an error when the in filter has a non-string value', () => {
+      it('should parse a value set that use filter operator in with a code value', () => {
         const input = `
         ValueSet: CatAndDogVS
         * codes from system ZOO where concept in ZOO#cat
+        `;
+        const result = importSingleText(input, 'CatDog.fsh');
+        expect(result.valueSets.size).toBe(1);
+        const valueSet = result.valueSets.get('CatAndDogVS');
+        expect(valueSet.rules.length).toBe(1);
+        assertValueSetFilterComponent(valueSet.rules[0], 'ZOO', undefined, [
+          {
+            property: 'concept',
+            operator: VsOperator.IN,
+            value: new FshCode('cat', 'ZOO').withLocation([3, 50, 3, 56]).withFile('CatDog.fsh')
+          }
+        ]);
+      });
+
+      it('should log an error when the in filter has a non-string or non-code value', () => {
+        const input = `
+        ValueSet: CatAndDogVS
+        * codes from system ZOO where concept in true
         `;
         const result = importSingleText(input, 'CatDog.fsh');
         expect(result.valueSets.size).toBe(1);

--- a/test/import/FSHImporter.ValueSet.test.ts
+++ b/test/import/FSHImporter.ValueSet.test.ts
@@ -532,6 +532,9 @@ describe('FSHImporter', () => {
             value: '2.0'
           }
         ]);
+        expect(loggerSpy.getLastMessage('warn')).toMatch(
+          /match value of filter operator "=" must be a code/
+        );
       });
 
       it('should parse a value set that uses filter operator = with code value', () => {
@@ -754,6 +757,9 @@ describe('FSHImporter', () => {
             value: '#cat, #dog'
           }
         ]);
+        expect(loggerSpy.getLastMessage('warn')).toMatch(
+          /match value of filter operator "in" must be a code/
+        );
       });
 
       it('should parse a value set that use filter operator in with a code value', () => {
@@ -804,6 +810,9 @@ describe('FSHImporter', () => {
             value: '#goose'
           }
         ]);
+        expect(loggerSpy.getLastMessage('warn')).toMatch(
+          /match value of filter operator "not-in" must be a code/
+        );
       });
 
       it('should parse a value set that uses filter operator not-in with a code value', () => {

--- a/test/import/FSHImporter.ValueSet.test.ts
+++ b/test/import/FSHImporter.ValueSet.test.ts
@@ -583,7 +583,7 @@ describe('FSHImporter', () => {
         const valueSet = result.valueSets.get('ZooVS');
         expect(valueSet.rules.length).toBe(1);
         assertValueSetFilterComponent(valueSet.rules[0], 'ZOO', undefined, []);
-        expect(loggerSpy.getLastMessage('error')).toMatch(/"=".*string/);
+        expect(loggerSpy.getLastMessage('error')).toMatch(/"=".*code/);
         expect(loggerSpy.getLastMessage('error')).toMatch(/File: Zoo\.fsh.*Line: 3\D*/s);
       });
 
@@ -790,7 +790,7 @@ describe('FSHImporter', () => {
         const valueSet = result.valueSets.get('CatAndDogVS');
         expect(valueSet.rules.length).toBe(1);
         assertValueSetFilterComponent(valueSet.rules[0], 'ZOO', undefined, []);
-        expect(loggerSpy.getLastMessage('error')).toMatch(/"in".*string/);
+        expect(loggerSpy.getLastMessage('error')).toMatch(/"in".*code/);
         expect(loggerSpy.getLastMessage('error')).toMatch(/File: CatDog\.fsh.*Line: 3\D*/s);
       });
 
@@ -843,7 +843,7 @@ describe('FSHImporter', () => {
         const valueSet = result.valueSets.get('NoGooseVS');
         expect(valueSet.rules.length).toBe(1);
         assertValueSetFilterComponent(valueSet.rules[0], 'ZOO', undefined, []);
-        expect(loggerSpy.getLastMessage('error')).toMatch(/"not-in".*string/);
+        expect(loggerSpy.getLastMessage('error')).toMatch(/"not-in".*code/);
         expect(loggerSpy.getLastMessage('error')).toMatch(/File: NoGoose\.fsh.*Line: 3\D*/s);
       });
 


### PR DESCRIPTION
This PR fixes #812 by adding support for code values in the `=`, `in`, and `not-in` filter operators. Based on the [documentation](http://hl7.org/fhir/R4/valueset-definitions.html#ValueSet.compose.include.filter.value) and discussion, we believe these filter operators should _only_ accept code values. We will continue support string values for backwards compatibility, but we will officially deprecate support for strings and log a warning. There are multiple projects, including mCODE, that use string values for these filters which would break if we removed string values immediately. The `is-a`, `is-not-a`, `descendent-of` and `generalizes` remain supporting only code values since we believe that is the correct interpretation of the documentation.