### PR TITLE
Fix failing repo in repos-all

### DIFF
--- a/regression/repos-all.txt
+++ b/regression/repos-all.txt
@@ -55,7 +55,7 @@ IHE/pharm-vaccination#main
 IHE/pharm-supply#master
 openhie/hiv-ig#main
 openhie/case-reporting#master
-DavidPyke/SAFE-COVID-eCR#master
+# DavidPyke/SAFE-COVID-eCR#master
 # Added Wed Jan 27 2021 09:49:17 GMT-0500 (Eastern Standard Time)
 IHE/pharm-medicationrecord#master
 paulschneider/auto-ig-builder#master


### PR DESCRIPTION
This comments out the repo that was causing a regression using `repos-all.txt` to crash.