### PR TITLE
Include hierarchy in FSH for ConceptRule

### DIFF
--- a/src/fshtypes/rules/ConceptRule.ts
+++ b/src/fshtypes/rules/ConceptRule.ts
@@ -17,7 +17,10 @@ export class ConceptRule extends Rule {
   }
 
   toFSH(): string {
-    let line = `* #${/\s/.test(this.code) ? `"${this.code}"` : this.code}`;
+    const quotedCodes = [...this.hierarchy, this.code].map(code =>
+      /\s/.test(code) ? `#"${code}"` : `#${code}`
+    );
+    let line = `* ${quotedCodes.join(' ')}`;
     if (this.display) {
       line += ` "${fshifyString(this.display)}"`;
     }

--- a/test/fshtypes/rules/ConceptRule.test.ts
+++ b/test/fshtypes/rules/ConceptRule.test.ts
@@ -80,5 +80,28 @@ describe('ConceptRule', () => {
       const result = rule.toFSH();
       expect(result).toBe(expectedResult);
     });
+
+    it('should produce FSH for a ConceptRule with one code in its hierarchy', () => {
+      const rule = new ConceptRule('platinum');
+      rule.display = 'platinum';
+      rule.definition = 'element with atomic number 78';
+      rule.hierarchy = ['metal'];
+
+      const expectedResult = '* #metal #platinum "platinum" "element with atomic number 78"';
+      const result = rule.toFSH();
+      expect(result).toBe(expectedResult);
+    });
+
+    it('should produce FSH for a ConceptRule with multiple codes in its hierarchy', () => {
+      const rule = new ConceptRule('platinum');
+      rule.display = 'platinum';
+      rule.definition = 'element with atomic number 78';
+      rule.hierarchy = ['physical', 'solid phase', 'metal'];
+
+      const expectedResult =
+        '* #physical #"solid phase" #metal #platinum "platinum" "element with atomic number 78"';
+      const result = rule.toFSH();
+      expect(result).toBe(expectedResult);
+    });
   });
 });


### PR DESCRIPTION
Completes task [CIMPL-785](https://standardhealthrecord.atlassian.net/browse/CIMPL-785).

The hierarchy on a `ConceptRule` is now used in the `toFSH()` method. Previously, hierarchy information was ignored by this method, which meant that incorrect FSH would be produced for any concept with a hierarchy. If a code in the hierarchy contains spaces, it is quoted so that the syntax is valid.