### PR TITLE
Load predefined resources in nested folders

### DIFF
--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -7,7 +7,7 @@ import tar from 'tar';
 import axios from 'axios';
 import junk from 'junk';
 import temp from 'temp';
-import { logger } from '../utils';
+import { logger, getFilesRecursive } from '../utils';
 import { Fhir as FHIRConverter } from 'fhir/fhir';
 
 /**
@@ -210,7 +210,7 @@ export function loadCustomResources(resourceDir: string, defs: FHIRDefinitions):
     let foundSpreadsheets = false;
     const dirPath = path.join(resourceDir, pathEnd);
     if (fs.existsSync(dirPath)) {
-      const files = fs.readdirSync(dirPath);
+      const files = getFilesRecursive(dirPath);
       for (const file of files) {
         let resourceJSON: any;
         try {
@@ -218,12 +218,12 @@ export function loadCustomResources(resourceDir: string, defs: FHIRDefinitions):
             // Ignore "junk" files created by the OS, like .DS_Store on macOS and Thumbs.db on Windows
             continue;
           } else if (file.endsWith('.json')) {
-            resourceJSON = fs.readJSONSync(path.join(dirPath, file));
+            resourceJSON = fs.readJSONSync(file);
           } else if (file.endsWith('-spreadsheet.xml')) {
             foundSpreadsheets = true;
             continue;
           } else if (file.endsWith('xml')) {
-            const xml = fs.readFileSync(path.join(dirPath, file)).toString();
+            const xml = fs.readFileSync(file).toString();
             if (/<\?mso-application progid="Excel\.Sheet"\?>/m.test(xml)) {
               foundSpreadsheets = true;
               continue;

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -505,15 +505,17 @@ export async function init(): Promise<void> {
   );
 }
 
-function getFilesRecursive(dir: string): string[] {
+export function getFilesRecursive(dir: string): string[] {
+  // always return absolute paths
+  const absPath = path.resolve(dir);
   try {
-    if (fs.statSync(dir).isDirectory()) {
+    if (fs.statSync(absPath).isDirectory()) {
       const descendants = fs
-        .readdirSync(dir, 'utf8')
-        .map(f => getFilesRecursive(path.join(dir, f)));
+        .readdirSync(absPath, 'utf8')
+        .map(f => getFilesRecursive(path.join(absPath, f)));
       return [].concat(...descendants);
     } else {
-      return [dir];
+      return [absPath];
     }
   } catch {
     return [];

--- a/test/fhirdefs/fixtures/customized-ig-with-resources/ig-data/input/resources/nested/StructureDefinition-MyNestedPatient.json
+++ b/test/fhirdefs/fixtures/customized-ig-with-resources/ig-data/input/resources/nested/StructureDefinition-MyNestedPatient.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "MyNestedPatient",
+  "kind": "resource",
+  "derivation": "constraint"
+}

--- a/test/fhirdefs/load.test.ts
+++ b/test/fhirdefs/load.test.ts
@@ -392,17 +392,18 @@ describe('#loadDependency()', () => {
 
 describe('#loadCustomResources', () => {
   let defs: FHIRDefinitions;
+  let pathToInput: string;
   beforeAll(() => {
     loggerSpy.reset();
     defs = new FHIRDefinitions();
-    const fixtures = path.join(
+    pathToInput = path.join(
       __dirname,
       'fixtures',
       'customized-ig-with-resources',
       'ig-data',
       'input'
     );
-    loadCustomResources(fixtures, defs);
+    loadCustomResources(pathToInput, defs);
   });
 
   it('should load custom JSON and XML resources', () => {
@@ -410,7 +411,7 @@ describe('#loadCustomResources', () => {
     const profiles = defs.allProfiles();
     const valueSets = defs.allValueSets();
     const extensions = defs.allExtensions();
-    expect(profiles).toHaveLength(1);
+    expect(profiles).toHaveLength(2);
     expect(profiles[0].id).toBe('MyPatient');
     expect(valueSets).toHaveLength(1);
     expect(valueSets[0].id).toBe('MyVS');
@@ -430,19 +431,51 @@ describe('#loadCustomResources', () => {
   });
 
   it('should add all predefined resources to the FHIRDefs with file information', () => {
-    expect(defs.getPredefinedResource('CapabilityStatement-MyCS.json').id).toBe('MyCS');
-    expect(defs.getPredefinedResource('Patient-MyPatient.json').id).toBe('MyPatient');
-    expect(defs.getPredefinedResource('StructureDefinition-patient-birthPlace.json').id).toBe(
-      'patient-birthPlace'
-    );
-    expect(defs.getPredefinedResource('StructureDefinition-patient-birthPlaceXML.xml').id).toBe(
-      'patient-birthPlaceXML'
-    );
-    expect(defs.getPredefinedResource('StructureDefinition-MyLM.json').id).toBe('MyLM');
-    expect(defs.getPredefinedResource('OperationDefinition-MyOD.json').id).toBe('MyOD');
-    expect(defs.getPredefinedResource('StructureDefinition-MyPatient.json').id).toBe('MyPatient');
-    expect(defs.getPredefinedResource('Patient-BazPatient.json').id).toBe('BazPatient');
-    expect(defs.getPredefinedResource('ValueSet-MyVS.json').id).toBe('MyVS');
+    expect(
+      defs.getPredefinedResource(
+        path.join(pathToInput, 'capabilities', 'CapabilityStatement-MyCS.json')
+      ).id
+    ).toBe('MyCS');
+    expect(
+      defs.getPredefinedResource(path.join(pathToInput, 'examples', 'Patient-MyPatient.json')).id
+    ).toBe('MyPatient');
+    expect(
+      defs.getPredefinedResource(
+        path.join(pathToInput, 'extensions', 'StructureDefinition-patient-birthPlace.json')
+      ).id
+    ).toBe('patient-birthPlace');
+    expect(
+      defs.getPredefinedResource(
+        path.join(pathToInput, 'extensions', 'StructureDefinition-patient-birthPlaceXML.xml')
+      ).id
+    ).toBe('patient-birthPlaceXML');
+    expect(
+      defs.getPredefinedResource(path.join(pathToInput, 'models', 'StructureDefinition-MyLM.json'))
+        .id
+    ).toBe('MyLM');
+    expect(
+      defs.getPredefinedResource(
+        path.join(pathToInput, 'operations', 'OperationDefinition-MyOD.json')
+      ).id
+    ).toBe('MyOD');
+    expect(
+      defs.getPredefinedResource(
+        path.join(pathToInput, 'profiles', 'StructureDefinition-MyPatient.json')
+      ).id
+    ).toBe('MyPatient');
+    expect(
+      defs.getPredefinedResource(path.join(pathToInput, 'resources', 'Patient-BazPatient.json')).id
+    ).toBe('BazPatient');
+    // NOTE: It loads nested predefined resources even thought the IG Publisher doesn't handle them well
+    expect(
+      defs.getPredefinedResource(
+        path.join(pathToInput, 'resources', 'nested', 'StructureDefinition-MyNestedPatient.json')
+      ).id
+    ).toBe('MyNestedPatient');
+
+    expect(
+      defs.getPredefinedResource(path.join(pathToInput, 'vocabulary', 'ValueSet-MyVS.json')).id
+    ).toBe('MyVS');
   });
 
   it('should log an info message for non JSON or XML input files', () => {
@@ -453,7 +486,7 @@ describe('#loadCustomResources', () => {
 
   it('should log an error for invalid XML files', () => {
     expect(loggerSpy.getLastMessage('error')).toMatch(
-      /Loading InvalidFile.xml failed with the following error:/
+      /Loading .*InvalidFile.xml failed with the following error:/
     );
   });
 
@@ -477,7 +510,7 @@ describe('#loadCustomResources', () => {
 
   it('should log an error for invalid JSON files', () => {
     expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(
-      /Loading InvalidFile.json failed with the following error:/
+      /Loading .*InvalidFile.json failed with the following error:/
     );
   });
 });

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -1579,8 +1579,8 @@ describe('IGExporter', () => {
       expect(warning).toInclude(
         'The following files were not added to the ImplementationGuide JSON'
       );
-      expect(warning).toInclude('nested1/StructureDefinition-MyTitlePatient.json');
-      expect(warning).toInclude('nested2/ValueSet-MyVS.json');
+      expect(warning).toInclude(path.join('nested1', 'StructureDefinition-MyTitlePatient.json'));
+      expect(warning).toInclude(path.join('nested2', 'ValueSet-MyVS.json'));
       expect(warning).not.toInclude('Patient-BarPatient.json');
       expect(warning).not.toInclude('StructureDefinition-MyPatient.json');
     });

--- a/test/ig/fixtures/customized-ig-with-nested-resources/input/examples/Patient-BarPatient.json
+++ b/test/ig/fixtures/customized-ig-with-nested-resources/input/examples/Patient-BarPatient.json
@@ -1,0 +1,8 @@
+{
+  "resourceType": "Patient",
+  "id": "BarPatient",
+  "meta": {
+    "profile": ["http://hl7.org/fhir/sushi-test/StructureDefinition/MyPatient"]
+  },
+  "name": [{ "family": "Bar" }]
+}

--- a/test/ig/fixtures/customized-ig-with-nested-resources/input/resources/StructureDefinition-MyPatient.json
+++ b/test/ig/fixtures/customized-ig-with-nested-resources/input/resources/StructureDefinition-MyPatient.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "MyPatient",
+  "url": "http://hl7.org/fhir/sushi-test/StructureDefinition/MyPatient",
+  "name": "MyPatient",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient.deceased[x]",
+        "path": "Patient.deceased[x]",
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/ig/fixtures/customized-ig-with-nested-resources/input/resources/nested1/StructureDefinition-MyTitlePatient.json
+++ b/test/ig/fixtures/customized-ig-with-nested-resources/input/resources/nested1/StructureDefinition-MyTitlePatient.json
@@ -1,0 +1,26 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "MyTitlePatient",
+  "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/MyTitlePatient",
+  "title": "This patient has a title",
+  "name": "MyTitlePatient",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient.deceased[x]",
+        "path": "Patient.deceased[x]",
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/ig/fixtures/customized-ig-with-nested-resources/input/resources/nested2/ValueSet-MyVS.json
+++ b/test/ig/fixtures/customized-ig-with-nested-resources/input/resources/nested2/ValueSet-MyVS.json
@@ -1,0 +1,59 @@
+{
+  "resourceType": "ValueSet",
+  "id": "MyVS",
+  "meta": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+        "valueMarkdown": "Ignored Description"
+      },
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+        "valueString": "Ignored Name"
+      }
+    ]
+  },
+  "url": "http://hl7.org/fhir/ValueSet/MyVS",
+  "version": "4.0.1",
+  "name": "Yes/No/Don't Know",
+  "status": "draft",
+  "compose": {
+    "include": [
+      {
+        "valueSet": [
+          "http://terminology.hl7.org/ValueSet/v2-0136"
+        ]
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+        "concept": [
+          {
+            "code": "asked-unknown",
+            "display": "Don't know"
+          }
+        ]
+      }
+    ]
+  },
+  "expansion": {
+    "identifier": "urn:uuid:bf99fe50-2c2b-41ad-bd63-bee6919810b4",
+    "timestamp": "2015-07-14T10:00:00Z",
+    "contains": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+        "code": "Y",
+        "display": "Yes"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+        "code": "N",
+        "display": "No"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+        "code": "asked-unknown",
+        "display": "Don't know"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The IG templates define a set of supported input folders (e.g., input/profiles, input/resources, etc.). If an author creates further subfolders (e.g., input/resources/nested), SUSHI will now load resources from them as well.  Since the IG publisher doesn't support those paths, however, it will emit a warning and exclude them from the IG JSON.

You can manually test w/ the attached project: [RecursiveInput.zip](https://github.com/FHIR/sushi/files/6785975/RecursiveInput.zip).

Fixes #786 