### PR TITLE
Add support for type checking when fixing Canonical types

### DIFF
--- a/src/errors/InvalidTypeError.ts
+++ b/src/errors/InvalidTypeError.ts
@@ -31,6 +31,8 @@ function allowedTypesToString(types: ElementDefinitionType[]): string {
   types.forEach(t => {
     if (isReferenceType(t.code)) {
       strings.push(`Reference(${(t.targetProfile ?? []).join(' | ')})`);
+    } else if (t.code === 'canonical') {
+      strings.push(`Canonical(${(t.targetProfile ?? []).join(' | ')})`);
     } else if (t.profile?.length > 0) {
       strings.push(...t.profile);
     } else {

--- a/src/export/Package.ts
+++ b/src/export/Package.ts
@@ -77,7 +77,7 @@ export class Package implements Fishable {
         instanceUsage:
           result instanceof InstanceDefinition ? result._instanceMeta.usage : undefined,
         url: result.url,
-        ancestor: result.resourceType
+        resourceType: result.resourceType
       };
       if (result instanceof StructureDefinition) {
         metadata.sdType = result.type;

--- a/src/export/Package.ts
+++ b/src/export/Package.ts
@@ -76,7 +76,8 @@ export class Package implements Fishable {
         name: result instanceof InstanceDefinition ? result._instanceMeta.name : result.name,
         instanceUsage:
           result instanceof InstanceDefinition ? result._instanceMeta.usage : undefined,
-        url: result.url
+        url: result.url,
+        ancestor: result.resourceType
       };
       if (result instanceof StructureDefinition) {
         metadata.sdType = result.type;

--- a/src/fhirdefs/FHIRDefinitions.ts
+++ b/src/fhirdefs/FHIRDefinitions.ts
@@ -176,7 +176,7 @@ export class FHIRDefinitions implements Fishable {
         url: resource.url as string,
         parent: resource.baseDefinition as string,
         abstract: resource.abstract as boolean,
-        ancestor: resource.resourceType as string
+        resourceType: resource.resourceType as string
       };
     }
   }
@@ -243,7 +243,7 @@ export class FHIRDefinitions implements Fishable {
         url: result.url as string,
         parent: result.baseDefinition as string,
         abstract: result.abstract as boolean,
-        ancestor: result.resourceType as string
+        resourceType: result.resourceType as string
       };
     }
   }

--- a/src/fhirdefs/FHIRDefinitions.ts
+++ b/src/fhirdefs/FHIRDefinitions.ts
@@ -166,7 +166,7 @@ export class FHIRDefinitions implements Fishable {
     }
   }
 
-  fishForPredefinedResourceMetadata(item: string, ...types: Type[]): any | undefined {
+  fishForPredefinedResourceMetadata(item: string, ...types: Type[]): Metadata | undefined {
     const resource = this.fishForPredefinedResource(item, ...types);
     if (resource) {
       return {
@@ -175,7 +175,8 @@ export class FHIRDefinitions implements Fishable {
         sdType: resource.type as string,
         url: resource.url as string,
         parent: resource.baseDefinition as string,
-        abstract: resource.abstract as boolean
+        abstract: resource.abstract as boolean,
+        ancestor: resource.resourceType as string
       };
     }
   }
@@ -241,7 +242,8 @@ export class FHIRDefinitions implements Fishable {
         sdType: result.type as string,
         url: result.url as string,
         parent: result.baseDefinition as string,
-        abstract: result.abstract as boolean
+        abstract: result.abstract as boolean,
+        ancestor: result.resourceType as string
       };
     }
   }

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1469,8 +1469,8 @@ export class ElementDefinition {
           Type.Instance
         );
         let canonicalUrl: string;
-        if (!this.typeSatisfiesTargetProfile(canonicalDefinition?.sdType, fisher)) {
-          throw new InvalidTypeError(`Canonical(${canonicalDefinition.sdType})`, this.type);
+        if (!this.typeSatisfiesTargetProfile(canonicalDefinition?.ancestor, fisher)) {
+          throw new InvalidTypeError(`Canonical(${canonicalDefinition.ancestor})`, this.type);
         }
         if (canonicalDefinition?.url) {
           canonicalUrl = canonicalDefinition.url;

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1469,8 +1469,8 @@ export class ElementDefinition {
           Type.Instance
         );
         let canonicalUrl: string;
-        if (!this.typeSatisfiesTargetProfile(canonicalDefinition?.ancestor, fisher)) {
-          throw new InvalidTypeError(`Canonical(${canonicalDefinition.ancestor})`, this.type);
+        if (!this.typeSatisfiesTargetProfile(canonicalDefinition?.resourceType, fisher)) {
+          throw new InvalidTypeError(`Canonical(${canonicalDefinition.resourceType})`, this.type);
         }
         if (canonicalDefinition?.url) {
           canonicalUrl = canonicalDefinition.url;

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -261,7 +261,7 @@ export class FSHTank implements Fishable {
       ) {
         meta.url = getUrlFromFshDefinition(result, this.config.canonical);
         meta.parent = result.parent;
-        meta.ancestor = 'StructureDefinition';
+        meta.resourceType = 'StructureDefinition';
         if (result instanceof Logical) {
           // Logical models should always use an absolute URL as their StructureDefinition.type
           // unless HL7 published them. In that case, the URL is relative to
@@ -273,9 +273,9 @@ export class FSHTank implements Fishable {
       } else if (result instanceof FshValueSet || result instanceof FshCodeSystem) {
         meta.url = getUrlFromFshDefinition(result, this.config.canonical);
         if (result instanceof FshValueSet) {
-          meta.ancestor = 'ValueSet';
+          meta.resourceType = 'ValueSet';
         } else {
-          meta.ancestor = 'CodeSystem';
+          meta.resourceType = 'CodeSystem';
         }
       } else if (result instanceof Instance) {
         result.rules?.forEach(r => {
@@ -285,7 +285,6 @@ export class FSHTank implements Fishable {
           }
         });
         meta.instanceUsage = result.usage;
-        meta.ancestor = result.instanceOf;
       }
       return meta;
     }

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -261,6 +261,7 @@ export class FSHTank implements Fishable {
       ) {
         meta.url = getUrlFromFshDefinition(result, this.config.canonical);
         meta.parent = result.parent;
+        meta.ancestor = 'StructureDefinition';
         if (result instanceof Logical) {
           // Logical models should always use an absolute URL as their StructureDefinition.type
           // unless HL7 published them. In that case, the URL is relative to
@@ -271,6 +272,11 @@ export class FSHTank implements Fishable {
         }
       } else if (result instanceof FshValueSet || result instanceof FshCodeSystem) {
         meta.url = getUrlFromFshDefinition(result, this.config.canonical);
+        if (result instanceof FshValueSet) {
+          meta.ancestor = 'ValueSet';
+        } else {
+          meta.ancestor = 'CodeSystem';
+        }
       } else if (result instanceof Instance) {
         result.rules?.forEach(r => {
           if (r.path === 'url' && r instanceof AssignmentRule && typeof r.value === 'string') {
@@ -279,6 +285,7 @@ export class FSHTank implements Fishable {
           }
         });
         meta.instanceUsage = result.usage;
+        meta.ancestor = result.instanceOf;
       }
       return meta;
     }

--- a/src/utils/Fishable.ts
+++ b/src/utils/Fishable.ts
@@ -18,6 +18,7 @@ export interface Metadata {
   id: string;
   name: string;
   sdType?: string;
+  ancestor?: string;
   url?: string;
   parent?: string;
   abstract?: boolean;

--- a/src/utils/Fishable.ts
+++ b/src/utils/Fishable.ts
@@ -18,7 +18,7 @@ export interface Metadata {
   id: string;
   name: string;
   sdType?: string;
-  ancestor?: string;
+  resourceType?: string;
   url?: string;
   parent?: string;
   abstract?: boolean;

--- a/src/utils/MasterFisher.ts
+++ b/src/utils/MasterFisher.ts
@@ -3,6 +3,7 @@ import { FSHTank } from '../import';
 import { FHIRDefinitions } from '../fhirdefs';
 import { Package } from '../export';
 import { logger } from './FSHLogger';
+import { Instance } from '../fshtypes';
 
 /**
  * The MasterFisher can fish from the tank, the FHIR definitions, and the package that is currently
@@ -69,6 +70,11 @@ export class MasterFisher implements Fishable {
         // If it came from the tank, we need to get the sdType because the tank doesn't know.
         if (fishable instanceof FSHTank) {
           result.sdType = this.findSdType(result, types, fishables);
+        }
+        if (fishable instanceof FSHTank && !result.resourceType) {
+          result.resourceType = this.fishForMetadata(
+            (fishable.fish(item, Type.Instance) as Instance)?.instanceOf
+          )?.sdType;
         }
         return result;
       }

--- a/src/utils/MasterFisher.ts
+++ b/src/utils/MasterFisher.ts
@@ -71,6 +71,9 @@ export class MasterFisher implements Fishable {
         if (fishable instanceof FSHTank) {
           result.sdType = this.findSdType(result, types, fishables);
         }
+        // When an Instance comes from the FSHTank, the FSHTank doesn't know its resourceType,
+        // only its InstanceOf. But here we have access to the other fishers, so we can try
+        // to figure that resourceType out here
         if (fishable instanceof FSHTank && !result.resourceType) {
           result.resourceType = this.fishForMetadata(
             (fishable.fish(item, Type.Instance) as Instance)?.instanceOf

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -139,6 +139,7 @@ describe('InstanceExporter', () => {
     let valueSetInstance: Instance;
     let respRateInstance: Instance;
     let bundleInstance: Instance;
+    let carePlanInstance: Instance;
     beforeEach(() => {
       questionnaire = new Profile('TestQuestionnaire');
       questionnaire.parent = 'Questionnaire';
@@ -163,6 +164,9 @@ describe('InstanceExporter', () => {
       patientProfInstance = new Instance('Baz');
       patientProfInstance.instanceOf = 'TestPatientProf';
       doc.instances.set(patientProfInstance.name, patientProfInstance);
+      carePlanInstance = new Instance('C');
+      carePlanInstance.instanceOf = 'CarePlan';
+      doc.instances.set(carePlanInstance.name, carePlanInstance);
       lipidInstance = new Instance('Bam')
         .withFile('LipidInstance.fsh')
         .withLocation([10, 1, 20, 30]);
@@ -1693,6 +1697,19 @@ describe('InstanceExporter', () => {
       expect(exported.code).toEqual(undefined);
       expect(loggerSpy.getFirstMessage('error')).toMatch(
         /Cannot use canonical URL of FakeCodeSystem because it does not exist.\D*/s
+      );
+    });
+
+    it('should log an error when an invalid canonical is assigned', () => {
+      const assignedRefRule = new AssignmentRule('instantiatesCanonical');
+      assignedRefRule.value = new FshCanonical('Observation');
+      // * instantiatesCanonical = Canonical(TestObservation)
+      carePlanInstance.rules.push(assignedRefRule);
+
+      const exported = exportInstance(carePlanInstance);
+      expect(exported.instantiatesCanonical).toEqual(undefined); // instantiatesCanonical is not set with invalid type
+      expect(loggerSpy.getFirstMessage('error')).toMatch(
+        /The type "Canonical\(Observation\)" does not match any of the allowed types\D*/s
       );
     });
 

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -1700,16 +1700,72 @@ describe('InstanceExporter', () => {
       );
     });
 
+    it('should assign a Canonical that is one of the valid types', () => {
+      const assignedRefRule = new AssignmentRule('instantiatesCanonical');
+      const pdInstance = new Instance('TestPD');
+      pdInstance.instanceOf = 'PlanDefinition';
+      const urlRule = new AssignmentRule('url');
+      urlRule.value = 'http://example.org/PlanDefition/1';
+      pdInstance.rules.push(urlRule);
+      doc.instances.set(pdInstance.name, pdInstance);
+      assignedRefRule.value = new FshCanonical('TestPD');
+      // * instantiatesCanonical = Canonical(TestPD)
+      carePlanInstance.rules.push(assignedRefRule);
+
+      const exported = exportInstance(carePlanInstance);
+      expect(exported.instantiatesCanonical).toEqual(['http://example.org/PlanDefition/1']); // instantiatesCanonical is set
+    });
+
+    it('should assign a Canonical that is a child of the valid types', () => {
+      const assignedRefRule = new AssignmentRule('instantiatesCanonical');
+      const pdProfile = new Profile('PlanDefProfile');
+      pdProfile.parent = 'PlanDefinition';
+      doc.profiles.set(pdProfile.name, pdProfile);
+      const pdInstance = new Instance('PlanDefInstance');
+      pdInstance.instanceOf = 'PlanDefProfile';
+      const urlRule = new AssignmentRule('url');
+      urlRule.value = 'http://example.org/PlanDefition/1';
+      pdInstance.rules.push(urlRule);
+      doc.instances.set(pdInstance.name, pdInstance);
+      assignedRefRule.value = new FshCanonical('PlanDefInstance');
+      // * instantiatesCanonical = Canonical(PlanDefInstance)
+      carePlanInstance.rules.push(assignedRefRule);
+
+      const exported = exportInstance(carePlanInstance);
+      expect(exported.instantiatesCanonical).toEqual(['http://example.org/PlanDefition/1']); // instantiatesCanonical is set
+    });
+
     it('should log an error when an invalid canonical is assigned', () => {
       const assignedRefRule = new AssignmentRule('instantiatesCanonical');
-      assignedRefRule.value = new FshCanonical('Observation');
-      // * instantiatesCanonical = Canonical(TestObservation)
+      const vsInstance = new Instance('TestVS');
+      vsInstance.instanceOf = 'ValueSet';
+      doc.instances.set(vsInstance.name, vsInstance);
+      assignedRefRule.value = new FshCanonical('TestVS');
+      // * instantiatesCanonical = Canonical(TestVS)
       carePlanInstance.rules.push(assignedRefRule);
 
       const exported = exportInstance(carePlanInstance);
       expect(exported.instantiatesCanonical).toEqual(undefined); // instantiatesCanonical is not set with invalid type
       expect(loggerSpy.getFirstMessage('error')).toMatch(
-        /The type "Canonical\(Observation\)" does not match any of the allowed types\D*/s
+        /The type "Canonical\(ValueSet\)" does not match any of the allowed types\D*/s
+      );
+    });
+
+    it('should log an error when an already exported invalid canonical is assigned', () => {
+      const assignedRefRule = new AssignmentRule('instantiatesCanonical');
+      const vsInstance = new Instance('TestVS');
+      vsInstance.instanceOf = 'ValueSet';
+      doc.instances.set(vsInstance.name, vsInstance);
+      // First export the VS so that it is fished from  the package instead of FSHTank
+      exportInstance(vsInstance);
+      assignedRefRule.value = new FshCanonical('TestVS');
+      // * instantiatesCanonical = Canonical(TestVS)
+      carePlanInstance.rules.push(assignedRefRule);
+
+      const exported = exportInstance(carePlanInstance);
+      expect(exported.instantiatesCanonical).toEqual(undefined); // instantiatesCanonical is not set with invalid type
+      expect(loggerSpy.getMessageAtIndex(1, 'error')).toMatch(
+        /The type "Canonical\(ValueSet\)" does not match any of the allowed types\D*/s
       );
     });
 

--- a/test/export/Package.test.ts
+++ b/test/export/Package.test.ts
@@ -361,7 +361,8 @@ describe('Package', () => {
         name: 'Funny',
         sdType: 'Condition',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/fun-ny',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Condition'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Condition',
+        ancestor: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('Funny', Type.Profile)).toEqual(funnyProfile);
       expect(
@@ -379,7 +380,8 @@ describe('Package', () => {
         name: 'PoorTaste',
         sdType: 'Extension',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/poor-taste',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Extension'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Extension',
+        ancestor: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('PoorTaste', Type.Extension)).toEqual(poorTasteExtensionByID);
       expect(
@@ -397,7 +399,8 @@ describe('Package', () => {
         name: 'WheatBeer',
         sdType: 'wheat-beer',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/wheat-beer',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Element'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Element',
+        ancestor: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('WheatBeer', Type.Logical)).toEqual(wheatBeerLogicalByID);
       expect(
@@ -415,7 +418,8 @@ describe('Package', () => {
         name: 'Destination',
         sdType: 'Destination',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/Destination',
-        parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource'
+        parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
+        ancestor: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('Destination', Type.Resource)).toEqual(destinationResourceByID);
       expect(
@@ -431,7 +435,8 @@ describe('Package', () => {
       expect(soupsValueSetByID).toEqual({
         id: 'soup-flavors',
         name: 'Soups',
-        url: 'http://hl7.org/fhir/us/minimal/ValueSet/soup-flavors'
+        url: 'http://hl7.org/fhir/us/minimal/ValueSet/soup-flavors',
+        ancestor: 'ValueSet'
       });
       expect(pkg.fishForMetadata('Soups', Type.ValueSet)).toEqual(soupsValueSetByID);
       expect(
@@ -444,7 +449,8 @@ describe('Package', () => {
       expect(numericsCodeSystemByID).toEqual({
         id: 'numerics',
         name: 'Numbers',
-        url: 'http://hl7.org/fhir/us/minimal/CodeSystem/numerics'
+        url: 'http://hl7.org/fhir/us/minimal/CodeSystem/numerics',
+        ancestor: 'CodeSystem'
       });
       expect(pkg.fishForMetadata('Numbers', Type.CodeSystem)).toEqual(numericsCodeSystemByID);
       expect(
@@ -456,7 +462,8 @@ describe('Package', () => {
       const drSueInstanceById = pkg.fishForMetadata('dr-sue', Type.Instance);
       expect(drSueInstanceById).toEqual({
         id: 'dr-sue',
-        name: 'DrSue'
+        name: 'DrSue',
+        ancestor: 'Practitioner'
       });
       expect(pkg.fishForMetadata('DrSue', Type.Instance)).toEqual(drSueInstanceById);
     });
@@ -554,7 +561,8 @@ describe('Package', () => {
         name: 'Funny',
         sdType: 'Condition',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/fun-ny',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Condition'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Condition',
+        ancestor: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('Funny')).toEqual(funnyProfileByID);
       expect(
@@ -567,7 +575,8 @@ describe('Package', () => {
         name: 'PoorTaste',
         sdType: 'Extension',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/poor-taste',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Extension'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Extension',
+        ancestor: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('PoorTaste')).toEqual(poorTasteExtensionByID);
       expect(
@@ -580,7 +589,8 @@ describe('Package', () => {
         name: 'WheatBeer',
         sdType: 'wheat-beer',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/wheat-beer',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Element'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Element',
+        ancestor: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('WheatBeer')).toEqual(wheatBeerLogicalByID);
       expect(
@@ -593,7 +603,8 @@ describe('Package', () => {
         name: 'Destination',
         sdType: 'Destination',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/Destination',
-        parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource'
+        parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
+        ancestor: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('Destination')).toEqual(destinationResourceByID);
       expect(
@@ -604,7 +615,8 @@ describe('Package', () => {
       expect(soupsValueSetByID).toEqual({
         id: 'soup-flavors',
         name: 'Soups',
-        url: 'http://hl7.org/fhir/us/minimal/ValueSet/soup-flavors'
+        url: 'http://hl7.org/fhir/us/minimal/ValueSet/soup-flavors',
+        ancestor: 'ValueSet'
       });
       expect(pkg.fishForMetadata('Soups')).toEqual(soupsValueSetByID);
       expect(pkg.fishForMetadata('http://hl7.org/fhir/us/minimal/ValueSet/soup-flavors')).toEqual(
@@ -615,7 +627,8 @@ describe('Package', () => {
       expect(numericsCodeSystemByID).toEqual({
         id: 'numerics',
         name: 'Numbers',
-        url: 'http://hl7.org/fhir/us/minimal/CodeSystem/numerics'
+        url: 'http://hl7.org/fhir/us/minimal/CodeSystem/numerics',
+        ancestor: 'CodeSystem'
       });
       expect(pkg.fishForMetadata('Numbers')).toEqual(numericsCodeSystemByID);
       expect(pkg.fishForMetadata('http://hl7.org/fhir/us/minimal/CodeSystem/numerics')).toEqual(
@@ -625,7 +638,8 @@ describe('Package', () => {
       const drSueInstanceByID = pkg.fishForMetadata('dr-sue');
       expect(drSueInstanceByID).toEqual({
         id: 'dr-sue',
-        name: 'DrSue'
+        name: 'DrSue',
+        ancestor: 'Practitioner'
       });
 
       expect(pkg.fishForMetadata('DrSue')).toEqual(drSueInstanceByID);

--- a/test/export/Package.test.ts
+++ b/test/export/Package.test.ts
@@ -362,7 +362,7 @@ describe('Package', () => {
         sdType: 'Condition',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/fun-ny',
         parent: 'http://hl7.org/fhir/StructureDefinition/Condition',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('Funny', Type.Profile)).toEqual(funnyProfile);
       expect(
@@ -381,7 +381,7 @@ describe('Package', () => {
         sdType: 'Extension',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/poor-taste',
         parent: 'http://hl7.org/fhir/StructureDefinition/Extension',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('PoorTaste', Type.Extension)).toEqual(poorTasteExtensionByID);
       expect(
@@ -400,7 +400,7 @@ describe('Package', () => {
         sdType: 'wheat-beer',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/wheat-beer',
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('WheatBeer', Type.Logical)).toEqual(wheatBeerLogicalByID);
       expect(
@@ -419,7 +419,7 @@ describe('Package', () => {
         sdType: 'Destination',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/Destination',
         parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('Destination', Type.Resource)).toEqual(destinationResourceByID);
       expect(
@@ -436,7 +436,7 @@ describe('Package', () => {
         id: 'soup-flavors',
         name: 'Soups',
         url: 'http://hl7.org/fhir/us/minimal/ValueSet/soup-flavors',
-        ancestor: 'ValueSet'
+        resourceType: 'ValueSet'
       });
       expect(pkg.fishForMetadata('Soups', Type.ValueSet)).toEqual(soupsValueSetByID);
       expect(
@@ -450,7 +450,7 @@ describe('Package', () => {
         id: 'numerics',
         name: 'Numbers',
         url: 'http://hl7.org/fhir/us/minimal/CodeSystem/numerics',
-        ancestor: 'CodeSystem'
+        resourceType: 'CodeSystem'
       });
       expect(pkg.fishForMetadata('Numbers', Type.CodeSystem)).toEqual(numericsCodeSystemByID);
       expect(
@@ -463,7 +463,7 @@ describe('Package', () => {
       expect(drSueInstanceById).toEqual({
         id: 'dr-sue',
         name: 'DrSue',
-        ancestor: 'Practitioner'
+        resourceType: 'Practitioner'
       });
       expect(pkg.fishForMetadata('DrSue', Type.Instance)).toEqual(drSueInstanceById);
     });
@@ -562,7 +562,7 @@ describe('Package', () => {
         sdType: 'Condition',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/fun-ny',
         parent: 'http://hl7.org/fhir/StructureDefinition/Condition',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('Funny')).toEqual(funnyProfileByID);
       expect(
@@ -576,7 +576,7 @@ describe('Package', () => {
         sdType: 'Extension',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/poor-taste',
         parent: 'http://hl7.org/fhir/StructureDefinition/Extension',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('PoorTaste')).toEqual(poorTasteExtensionByID);
       expect(
@@ -590,7 +590,7 @@ describe('Package', () => {
         sdType: 'wheat-beer',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/wheat-beer',
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('WheatBeer')).toEqual(wheatBeerLogicalByID);
       expect(
@@ -604,7 +604,7 @@ describe('Package', () => {
         sdType: 'Destination',
         url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/Destination',
         parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(pkg.fishForMetadata('Destination')).toEqual(destinationResourceByID);
       expect(
@@ -616,7 +616,7 @@ describe('Package', () => {
         id: 'soup-flavors',
         name: 'Soups',
         url: 'http://hl7.org/fhir/us/minimal/ValueSet/soup-flavors',
-        ancestor: 'ValueSet'
+        resourceType: 'ValueSet'
       });
       expect(pkg.fishForMetadata('Soups')).toEqual(soupsValueSetByID);
       expect(pkg.fishForMetadata('http://hl7.org/fhir/us/minimal/ValueSet/soup-flavors')).toEqual(
@@ -628,7 +628,7 @@ describe('Package', () => {
         id: 'numerics',
         name: 'Numbers',
         url: 'http://hl7.org/fhir/us/minimal/CodeSystem/numerics',
-        ancestor: 'CodeSystem'
+        resourceType: 'CodeSystem'
       });
       expect(pkg.fishForMetadata('Numbers')).toEqual(numericsCodeSystemByID);
       expect(pkg.fishForMetadata('http://hl7.org/fhir/us/minimal/CodeSystem/numerics')).toEqual(
@@ -639,7 +639,7 @@ describe('Package', () => {
       expect(drSueInstanceByID).toEqual({
         id: 'dr-sue',
         name: 'DrSue',
-        ancestor: 'Practitioner'
+        resourceType: 'Practitioner'
       });
 
       expect(pkg.fishForMetadata('DrSue')).toEqual(drSueInstanceByID);

--- a/test/fhirdefs/FHIRDefinitions.test.ts
+++ b/test/fhirdefs/FHIRDefinitions.test.ts
@@ -379,7 +379,8 @@ describe('FHIRDefinitions', () => {
         name: 'Condition',
         sdType: 'Condition',
         url: 'http://hl7.org/fhir/StructureDefinition/Condition',
-        parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource'
+        parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
+        ancestor: 'StructureDefinition'
       });
       expect(
         defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/Condition', Type.Resource)
@@ -394,7 +395,8 @@ describe('FHIRDefinitions', () => {
         name: 'ELTSSServiceModel',
         sdType: 'eLTSSServiceModel',
         url: 'http://hl7.org/fhir/us/eltss/StructureDefinition/eLTSSServiceModel',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Element'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Element',
+        ancestor: 'StructureDefinition'
       });
       expect(
         defs.fishForMetadata(
@@ -412,7 +414,8 @@ describe('FHIRDefinitions', () => {
         name: 'boolean',
         sdType: 'boolean',
         url: 'http://hl7.org/fhir/StructureDefinition/boolean',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Element'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Element',
+        ancestor: 'StructureDefinition'
       });
       expect(
         defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/boolean', Type.Type)
@@ -427,7 +430,8 @@ describe('FHIRDefinitions', () => {
         name: 'Address',
         sdType: 'Address',
         url: 'http://hl7.org/fhir/StructureDefinition/Address',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Element'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Element',
+        ancestor: 'StructureDefinition'
       });
       expect(
         defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/Address', Type.Type)
@@ -442,7 +446,8 @@ describe('FHIRDefinitions', () => {
         name: 'observation-vitalsigns',
         sdType: 'Observation',
         url: 'http://hl7.org/fhir/StructureDefinition/vitalsigns',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Observation'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Observation',
+        ancestor: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('observation-vitalsigns', Type.Profile)).toEqual(vitalSignsByID);
       expect(
@@ -461,7 +466,8 @@ describe('FHIRDefinitions', () => {
         name: 'mothersMaidenName',
         sdType: 'Extension',
         url: 'http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Extension'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Extension',
+        ancestor: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('mothersMaidenName', Type.Extension)).toEqual(
         maidenNameExtensionByID
@@ -482,7 +488,8 @@ describe('FHIRDefinitions', () => {
       expect(allergyStatusValueSetByID).toEqual({
         id: 'allergyintolerance-clinical',
         name: 'AllergyIntoleranceClinicalStatusCodes',
-        url: 'http://hl7.org/fhir/ValueSet/allergyintolerance-clinical'
+        url: 'http://hl7.org/fhir/ValueSet/allergyintolerance-clinical',
+        ancestor: 'ValueSet'
       });
       expect(defs.fishForMetadata('AllergyIntoleranceClinicalStatusCodes', Type.ValueSet)).toEqual(
         allergyStatusValueSetByID
@@ -503,7 +510,8 @@ describe('FHIRDefinitions', () => {
       expect(allergyStatusCodeSystemByID).toEqual({
         id: 'allergyintolerance-clinical',
         name: 'AllergyIntoleranceClinicalStatusCodes',
-        url: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical'
+        url: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
+        ancestor: 'CodeSystem'
       });
       expect(
         defs.fishForMetadata('AllergyIntoleranceClinicalStatusCodes', Type.CodeSystem)
@@ -642,7 +650,8 @@ describe('FHIRDefinitions', () => {
         name: 'Condition',
         sdType: 'Condition',
         url: 'http://hl7.org/fhir/StructureDefinition/Condition',
-        parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource'
+        parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
+        ancestor: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/Condition')).toEqual(
         conditionByID
@@ -655,7 +664,8 @@ describe('FHIRDefinitions', () => {
         name: 'boolean',
         sdType: 'boolean',
         url: 'http://hl7.org/fhir/StructureDefinition/boolean',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Element'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Element',
+        ancestor: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/boolean')).toEqual(
         booleanByID
@@ -668,7 +678,8 @@ describe('FHIRDefinitions', () => {
         name: 'Address',
         sdType: 'Address',
         url: 'http://hl7.org/fhir/StructureDefinition/Address',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Element'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Element',
+        ancestor: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/Address')).toEqual(
         addressByID
@@ -681,7 +692,8 @@ describe('FHIRDefinitions', () => {
         name: 'observation-vitalsigns',
         sdType: 'Observation',
         url: 'http://hl7.org/fhir/StructureDefinition/vitalsigns',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Observation'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Observation',
+        ancestor: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('observation-vitalsigns')).toEqual(vitalSignsProfileByID);
       expect(defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/vitalsigns')).toEqual(
@@ -695,7 +707,8 @@ describe('FHIRDefinitions', () => {
         name: 'mothersMaidenName',
         sdType: 'Extension',
         url: 'http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName',
-        parent: 'http://hl7.org/fhir/StructureDefinition/Extension'
+        parent: 'http://hl7.org/fhir/StructureDefinition/Extension',
+        ancestor: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('mothersMaidenName')).toEqual(maidenNameExtensionByID);
       expect(
@@ -708,7 +721,8 @@ describe('FHIRDefinitions', () => {
       expect(allergyStatusValueSetByID).toEqual({
         id: 'allergyintolerance-clinical',
         name: 'AllergyIntoleranceClinicalStatusCodes',
-        url: 'http://hl7.org/fhir/ValueSet/allergyintolerance-clinical'
+        url: 'http://hl7.org/fhir/ValueSet/allergyintolerance-clinical',
+        ancestor: 'ValueSet'
       });
       expect(defs.fishForMetadata('AllergyIntoleranceClinicalStatusCodes')).toEqual(
         allergyStatusValueSetByID
@@ -721,7 +735,8 @@ describe('FHIRDefinitions', () => {
       expect(w3cProvenanceCodeSystemByID).toEqual({
         id: 'w3c-provenance-activity-type',
         name: 'W3cProvenanceActivityType',
-        url: 'http://hl7.org/fhir/w3c-provenance-activity-type'
+        url: 'http://hl7.org/fhir/w3c-provenance-activity-type',
+        ancestor: 'CodeSystem'
       });
       expect(defs.fishForMetadata('W3cProvenanceActivityType')).toEqual(
         w3cProvenanceCodeSystemByID
@@ -737,7 +752,8 @@ describe('FHIRDefinitions', () => {
         name: 'ELTSSServiceModel',
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
         sdType: 'eLTSSServiceModel',
-        url: 'http://hl7.org/fhir/us/eltss/StructureDefinition/eLTSSServiceModel'
+        url: 'http://hl7.org/fhir/us/eltss/StructureDefinition/eLTSSServiceModel',
+        ancestor: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('ELTSSServiceModel')).toEqual(eLTSSServiceModelByID);
       expect(

--- a/test/fhirdefs/FHIRDefinitions.test.ts
+++ b/test/fhirdefs/FHIRDefinitions.test.ts
@@ -380,7 +380,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'Condition',
         url: 'http://hl7.org/fhir/StructureDefinition/Condition',
         parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(
         defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/Condition', Type.Resource)
@@ -396,7 +396,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'eLTSSServiceModel',
         url: 'http://hl7.org/fhir/us/eltss/StructureDefinition/eLTSSServiceModel',
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(
         defs.fishForMetadata(
@@ -415,7 +415,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'boolean',
         url: 'http://hl7.org/fhir/StructureDefinition/boolean',
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(
         defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/boolean', Type.Type)
@@ -431,7 +431,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'Address',
         url: 'http://hl7.org/fhir/StructureDefinition/Address',
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(
         defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/Address', Type.Type)
@@ -447,7 +447,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'Observation',
         url: 'http://hl7.org/fhir/StructureDefinition/vitalsigns',
         parent: 'http://hl7.org/fhir/StructureDefinition/Observation',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('observation-vitalsigns', Type.Profile)).toEqual(vitalSignsByID);
       expect(
@@ -467,7 +467,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'Extension',
         url: 'http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName',
         parent: 'http://hl7.org/fhir/StructureDefinition/Extension',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('mothersMaidenName', Type.Extension)).toEqual(
         maidenNameExtensionByID
@@ -489,7 +489,7 @@ describe('FHIRDefinitions', () => {
         id: 'allergyintolerance-clinical',
         name: 'AllergyIntoleranceClinicalStatusCodes',
         url: 'http://hl7.org/fhir/ValueSet/allergyintolerance-clinical',
-        ancestor: 'ValueSet'
+        resourceType: 'ValueSet'
       });
       expect(defs.fishForMetadata('AllergyIntoleranceClinicalStatusCodes', Type.ValueSet)).toEqual(
         allergyStatusValueSetByID
@@ -511,7 +511,7 @@ describe('FHIRDefinitions', () => {
         id: 'allergyintolerance-clinical',
         name: 'AllergyIntoleranceClinicalStatusCodes',
         url: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
-        ancestor: 'CodeSystem'
+        resourceType: 'CodeSystem'
       });
       expect(
         defs.fishForMetadata('AllergyIntoleranceClinicalStatusCodes', Type.CodeSystem)
@@ -651,7 +651,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'Condition',
         url: 'http://hl7.org/fhir/StructureDefinition/Condition',
         parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/Condition')).toEqual(
         conditionByID
@@ -665,7 +665,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'boolean',
         url: 'http://hl7.org/fhir/StructureDefinition/boolean',
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/boolean')).toEqual(
         booleanByID
@@ -679,7 +679,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'Address',
         url: 'http://hl7.org/fhir/StructureDefinition/Address',
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/Address')).toEqual(
         addressByID
@@ -693,7 +693,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'Observation',
         url: 'http://hl7.org/fhir/StructureDefinition/vitalsigns',
         parent: 'http://hl7.org/fhir/StructureDefinition/Observation',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('observation-vitalsigns')).toEqual(vitalSignsProfileByID);
       expect(defs.fishForMetadata('http://hl7.org/fhir/StructureDefinition/vitalsigns')).toEqual(
@@ -708,7 +708,7 @@ describe('FHIRDefinitions', () => {
         sdType: 'Extension',
         url: 'http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName',
         parent: 'http://hl7.org/fhir/StructureDefinition/Extension',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('mothersMaidenName')).toEqual(maidenNameExtensionByID);
       expect(
@@ -722,7 +722,7 @@ describe('FHIRDefinitions', () => {
         id: 'allergyintolerance-clinical',
         name: 'AllergyIntoleranceClinicalStatusCodes',
         url: 'http://hl7.org/fhir/ValueSet/allergyintolerance-clinical',
-        ancestor: 'ValueSet'
+        resourceType: 'ValueSet'
       });
       expect(defs.fishForMetadata('AllergyIntoleranceClinicalStatusCodes')).toEqual(
         allergyStatusValueSetByID
@@ -736,7 +736,7 @@ describe('FHIRDefinitions', () => {
         id: 'w3c-provenance-activity-type',
         name: 'W3cProvenanceActivityType',
         url: 'http://hl7.org/fhir/w3c-provenance-activity-type',
-        ancestor: 'CodeSystem'
+        resourceType: 'CodeSystem'
       });
       expect(defs.fishForMetadata('W3cProvenanceActivityType')).toEqual(
         w3cProvenanceCodeSystemByID
@@ -753,7 +753,7 @@ describe('FHIRDefinitions', () => {
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
         sdType: 'eLTSSServiceModel',
         url: 'http://hl7.org/fhir/us/eltss/StructureDefinition/eLTSSServiceModel',
-        ancestor: 'StructureDefinition'
+        resourceType: 'StructureDefinition'
       });
       expect(defs.fishForMetadata('ELTSSServiceModel')).toEqual(eLTSSServiceModelByID);
       expect(

--- a/test/import/FSHTank.test.ts
+++ b/test/import/FSHTank.test.ts
@@ -309,41 +309,48 @@ describe('FSHTank', () => {
       id: 'prf1',
       name: 'Profile1',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/prf1',
-      parent: 'Observation'
+      parent: 'Observation',
+      ancestor: 'StructureDefinition'
     };
     const ext1MD: Metadata = {
       id: 'ext1',
       name: 'Extension1',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/ext1',
-      parent: 'Extension2'
+      parent: 'Extension2',
+      ancestor: 'StructureDefinition'
     };
     const log1MD: Metadata = {
       id: 'log1',
       name: 'Logical1',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/log1',
       sdType: 'http://hl7.org/fhir/us/minimal/StructureDefinition/log1',
-      parent: 'Element'
+      parent: 'Element',
+      ancestor: 'StructureDefinition'
     };
     const res1MD: Metadata = {
       id: 'res1',
       name: 'Resource1',
       parent: 'DomainResource',
-      url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/res1'
+      url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/res1',
+      ancestor: 'StructureDefinition'
     };
     const vs1MD: Metadata = {
       id: 'vs1',
       name: 'ValueSet1',
-      url: 'http://hl7.org/fhir/us/minimal/ValueSet/vs1'
+      url: 'http://hl7.org/fhir/us/minimal/ValueSet/vs1',
+      ancestor: 'ValueSet'
     };
     const cs1MD: Metadata = {
       id: 'cs1',
       name: 'CodeSystem1',
-      url: 'http://hl7.org/fhir/us/minimal/CodeSystem/cs1'
+      url: 'http://hl7.org/fhir/us/minimal/CodeSystem/cs1',
+      ancestor: 'CodeSystem'
     };
     const inst1MD: Metadata = {
       id: 'inst1',
       name: 'Instance1',
-      instanceUsage: 'Example'
+      instanceUsage: 'Example',
+      ancestor: 'Condition'
     };
     const inv1MD: Metadata = {
       id: 'Invariant1', // id will always be name on Invariants
@@ -671,7 +678,8 @@ describe('FSHTank for HL7', () => {
       name: 'HL7Logical',
       url: 'http://hl7.org/fhir/StructureDefinition/hl7-log',
       sdType: 'hl7-log',
-      parent: 'Element'
+      parent: 'Element',
+      ancestor: 'StructureDefinition'
     };
 
     it('should find valid HL7 fish metadata when fishing by id for logical models', () => {

--- a/test/import/FSHTank.test.ts
+++ b/test/import/FSHTank.test.ts
@@ -310,14 +310,14 @@ describe('FSHTank', () => {
       name: 'Profile1',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/prf1',
       parent: 'Observation',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     };
     const ext1MD: Metadata = {
       id: 'ext1',
       name: 'Extension1',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/ext1',
       parent: 'Extension2',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     };
     const log1MD: Metadata = {
       id: 'log1',
@@ -325,32 +325,31 @@ describe('FSHTank', () => {
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/log1',
       sdType: 'http://hl7.org/fhir/us/minimal/StructureDefinition/log1',
       parent: 'Element',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     };
     const res1MD: Metadata = {
       id: 'res1',
       name: 'Resource1',
       parent: 'DomainResource',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/res1',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     };
     const vs1MD: Metadata = {
       id: 'vs1',
       name: 'ValueSet1',
       url: 'http://hl7.org/fhir/us/minimal/ValueSet/vs1',
-      ancestor: 'ValueSet'
+      resourceType: 'ValueSet'
     };
     const cs1MD: Metadata = {
       id: 'cs1',
       name: 'CodeSystem1',
       url: 'http://hl7.org/fhir/us/minimal/CodeSystem/cs1',
-      ancestor: 'CodeSystem'
+      resourceType: 'CodeSystem'
     };
     const inst1MD: Metadata = {
       id: 'inst1',
       name: 'Instance1',
-      instanceUsage: 'Example',
-      ancestor: 'Condition'
+      instanceUsage: 'Example'
     };
     const inv1MD: Metadata = {
       id: 'Invariant1', // id will always be name on Invariants
@@ -679,7 +678,7 @@ describe('FSHTank for HL7', () => {
       url: 'http://hl7.org/fhir/StructureDefinition/hl7-log',
       sdType: 'hl7-log',
       parent: 'Element',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     };
 
     it('should find valid HL7 fish metadata when fishing by id for logical models', () => {

--- a/test/utils/MasterFisher.test.ts
+++ b/test/utils/MasterFisher.test.ts
@@ -71,7 +71,7 @@ describe('MasterFisher', () => {
       sdType: 'Procedure',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/prf1',
       parent: 'Procedure',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     });
   });
 
@@ -86,7 +86,7 @@ describe('MasterFisher', () => {
       sdType: 'Observation',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/Profile2',
       parent: 'bp',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     });
   });
 
@@ -107,7 +107,7 @@ describe('MasterFisher', () => {
       sdType: undefined,
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/my-dr',
       parent: 'Practitioner',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     });
   });
 
@@ -123,7 +123,7 @@ describe('MasterFisher', () => {
       sdType: 'Condition',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/profile3',
       parent: 'http://hl7.org/fhir/StructureDefinition/Condition',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     });
   });
 
@@ -140,7 +140,7 @@ describe('MasterFisher', () => {
       sdType: 'Patient',
       url: 'http://hl7.org/fhir/StructureDefinition/Patient',
       parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     });
   });
 
@@ -156,7 +156,7 @@ describe('MasterFisher', () => {
       sdType: 'Observation',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/vitalsigns',
       parent: 'http://hl7.org/fhir/StructureDefinition/Observation',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     });
   });
 
@@ -177,7 +177,7 @@ describe('MasterFisher', () => {
       sdType: fhirDefinedVitalSigns.type,
       url: fhirDefinedVitalSigns.url,
       parent: fhirDefinedVitalSigns.baseDefinition,
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     });
     defs.resetPredefinedResources();
   });
@@ -193,7 +193,7 @@ describe('MasterFisher', () => {
       sdType: 'Organization',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/my-org',
       parent: 'http://hl7.org/fhir/StructureDefinition/Organization',
-      ancestor: 'StructureDefinition'
+      resourceType: 'StructureDefinition'
     });
   });
 

--- a/test/utils/MasterFisher.test.ts
+++ b/test/utils/MasterFisher.test.ts
@@ -70,7 +70,8 @@ describe('MasterFisher', () => {
       name: 'Profile1',
       sdType: 'Procedure',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/prf1',
-      parent: 'Procedure'
+      parent: 'Procedure',
+      ancestor: 'StructureDefinition'
     });
   });
 
@@ -84,7 +85,8 @@ describe('MasterFisher', () => {
       name: 'Profile2',
       sdType: 'Observation',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/Profile2',
-      parent: 'bp'
+      parent: 'bp',
+      ancestor: 'StructureDefinition'
     });
   });
 
@@ -104,7 +106,8 @@ describe('MasterFisher', () => {
       name: 'Practitioner',
       sdType: undefined,
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/my-dr',
-      parent: 'Practitioner'
+      parent: 'Practitioner',
+      ancestor: 'StructureDefinition'
     });
   });
 
@@ -119,7 +122,8 @@ describe('MasterFisher', () => {
       name: 'Profile3',
       sdType: 'Condition',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/profile3',
-      parent: 'http://hl7.org/fhir/StructureDefinition/Condition'
+      parent: 'http://hl7.org/fhir/StructureDefinition/Condition',
+      ancestor: 'StructureDefinition'
     });
   });
 
@@ -135,7 +139,8 @@ describe('MasterFisher', () => {
       name: 'Patient',
       sdType: 'Patient',
       url: 'http://hl7.org/fhir/StructureDefinition/Patient',
-      parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource'
+      parent: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
+      ancestor: 'StructureDefinition'
     });
   });
 
@@ -150,7 +155,8 @@ describe('MasterFisher', () => {
       name: 'MyVitalSigns',
       sdType: 'Observation',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/vitalsigns',
-      parent: 'http://hl7.org/fhir/StructureDefinition/Observation'
+      parent: 'http://hl7.org/fhir/StructureDefinition/Observation',
+      ancestor: 'StructureDefinition'
     });
   });
 
@@ -170,7 +176,8 @@ describe('MasterFisher', () => {
       name: fhirDefinedVitalSigns.name,
       sdType: fhirDefinedVitalSigns.type,
       url: fhirDefinedVitalSigns.url,
-      parent: fhirDefinedVitalSigns.baseDefinition
+      parent: fhirDefinedVitalSigns.baseDefinition,
+      ancestor: 'StructureDefinition'
     });
     defs.resetPredefinedResources();
   });
@@ -185,7 +192,8 @@ describe('MasterFisher', () => {
       name: 'Organization',
       sdType: 'Organization',
       url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/my-org',
-      parent: 'http://hl7.org/fhir/StructureDefinition/Organization'
+      parent: 'http://hl7.org/fhir/StructureDefinition/Organization',
+      ancestor: 'StructureDefinition'
     });
   });
 


### PR DESCRIPTION
This addresses [CIMPL-783](https://standardhealthrecord.atlassian.net/browse/CIMPL-783) by adding support for type checking when fixing `Canonical` values. The type checking checks the type of the SD pointed to by the `Canonical` keyword against the `targetProfile` on the element being assigned to. If the type of the SD pointed to is not a child of one of the options listed in the `targetProfile`, then an error is logged. Otherwise, no error is logged.

If the type of the SD pointed to cannot be determined, no type checking is done, and the assignment is just allowed. Generally this is set up to mimic how things work for `Reference`.