### PR TITLE
Support code systems with fragments

### DIFF
--- a/src/import/parseCodeLexeme.ts
+++ b/src/import/parseCodeLexeme.ts
@@ -9,10 +9,15 @@ import { FshCode } from '../fshtypes';
  * @returns {FshCode} the parse FshCode
  */
 export function parseCodeLexeme(conceptText: string): FshCode {
-  const allSplitPoints = [...conceptText.matchAll(/(^|[^\\])(\\\\)*#/g)];
-  const allSplitPointsArray = allSplitPoints.map(p => p);
+  const codeRegex = new RegExp(/(^|[^\\])(\\\\)*#/g);
+  const allSplitPointsArray = [];
+  let currentMatch = codeRegex.exec(conceptText);
+  while (currentMatch !== null) {
+    allSplitPointsArray.push(currentMatch);
+    currentMatch = codeRegex.exec(conceptText);
+  }
   let splitIndex = allSplitPointsArray.length - 1;
-  let splitPoint = allSplitPointsArray[splitIndex];
+  let splitPoint: any = allSplitPointsArray[splitIndex];
   let system: string, code: string;
   if (splitPoint == null) {
     system = '';

--- a/src/import/parseCodeLexeme.ts
+++ b/src/import/parseCodeLexeme.ts
@@ -9,7 +9,10 @@ import { FshCode } from '../fshtypes';
  * @returns {FshCode} the parse FshCode
  */
 export function parseCodeLexeme(conceptText: string): FshCode {
-  const splitPoint = conceptText.match(/(^|[^\\])(\\\\)*#/);
+  const allSplitPoints = [...conceptText.matchAll(/(^|[^\\])(\\\\)*#/g)];
+  const allSplitPointsArray = allSplitPoints.map(p => p);
+  let splitIndex = allSplitPointsArray.length - 1;
+  let splitPoint = allSplitPointsArray[splitIndex];
   let system: string, code: string;
   if (splitPoint == null) {
     system = '';
@@ -18,13 +21,22 @@ export function parseCodeLexeme(conceptText: string): FshCode {
     system = conceptText.slice(0, splitPoint.index) + splitPoint[0].slice(0, -1);
     code = conceptText.slice(splitPoint.index + splitPoint[0].length);
   }
-  system = system.replace(/\\\\/g, '\\').replace(/\\#/g, '#');
+  if (code.endsWith('"') && !code.startsWith('"')) {
+    // We matched on a # that is within a "quoted" code and we need to get an earlier #
+    while (!code.startsWith('"') && splitIndex >= 0) {
+      splitIndex = splitIndex - 1;
+      splitPoint = allSplitPointsArray[splitIndex];
+      system = conceptText.slice(0, splitPoint.index) + splitPoint[0].slice(0, -1);
+      code = conceptText.slice(splitPoint.index + splitPoint[0].length);
+    }
+  }
   if (code.startsWith('"')) {
     code = code
       .slice(1, code.length - 1)
       .replace(/\\\\/g, '\\')
       .replace(/\\"/g, '"');
   }
+  system = system.replace(/\\\\/g, '\\').replace(/\\#/g, '#');
   const concept = new FshCode(code);
   if (system.length > 0) {
     concept.system = system;

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -68,7 +68,7 @@ describe('FSHImporter', () => {
     `;
     const result = importSingleText(input, 'HashBrowns.fsh');
     const profile = result.profiles.get('HashBrowns');
-    const expectedCode = new FshCode('hash#browns', 'https://breakfast.com/good\\food#potatoes')
+    const expectedCode = new FshCode('browns', 'https://breakfast.com/good\\food#potatoes#hash')
       .withLocation([4, 14, 4, 67])
       .withFile('HashBrowns.fsh');
     const expectedExtraCode = new FshCode('last', 'https://lastly.com/backslash\\')
@@ -81,6 +81,36 @@ describe('FSHImporter', () => {
     assertAssignmentRule(profile.rules[0], 'code', expectedCode);
     assertAssignmentRule(profile.rules[1], 'extraCode', expectedExtraCode);
     assertAssignmentRule(profile.rules[2], 'bonusCode', expectedBonusCode);
+  });
+
+  it('should parse a code with a system that has a fragment', () => {
+    const input = `
+    Profile: PotatoFragment
+    Parent: Observation
+    * code = https://breakfast.com/goodfood#potatoes#hashbrowns
+    `;
+    const result = importSingleText(input, 'PotatoFragment.fsh');
+    const profile = result.profiles.get('PotatoFragment');
+    const expectedCode = new FshCode('hashbrowns', 'https://breakfast.com/goodfood#potatoes')
+      .withLocation([4, 14, 4, 63])
+      .withFile('PotatoFragment.fsh');
+    expect(profile.rules).toHaveLength(1);
+    assertAssignmentRule(profile.rules[0], 'code', expectedCode);
+  });
+
+  it('should parse a code with a system that has a fragment and not use a # within a quoted code', () => {
+    const input = `
+    Profile: PotatoFragment
+    Parent: Observation
+    * code = https://breakfast.com/goodfood#potatoes#"hash#browns"
+    `;
+    const result = importSingleText(input, 'PotatoFragment.fsh');
+    const profile = result.profiles.get('PotatoFragment');
+    const expectedCode = new FshCode('hash#browns', 'https://breakfast.com/goodfood#potatoes')
+      .withLocation([4, 14, 4, 66])
+      .withFile('PotatoFragment.fsh');
+    expect(profile.rules).toHaveLength(1);
+    assertAssignmentRule(profile.rules[0], 'code', expectedCode);
   });
 
   it('should parse a rule that uses non-breaking spaces in a concept string', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es2020"],                        /* Specify library files to be included in the compilation. */
+    // "lib": ["es6"],                        /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": ["es6"],                        /* Specify library files to be included in the compilation. */
+    "lib": ["es2020"],                        /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
This PR fixes #873 by updating how we split a system and code apart. Instead of splitting the system and the code on the first `#`, this PR now makes it so we do that split on the last unescaped and unquoted `#`. Finding the last match was harder than I expected using regular expressions, although I'm very willing to believe I missed some clever and simple regular expression trick. In order to get around this, I found all matches using `exec`, which will give the capture groups and index of the matched unescaped `#`, and then worked my way backwards through that list to find the unquoted `#`.

I added two tests that check the new functionality this adds. I also updated an existing test that I think is incompatible with also supporting system fragments.

If anyone has ideas to explore that would make this operation simpler, please let me know.