### PR TITLE
Set . path as context

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -2064,7 +2064,6 @@ export class FSHImporter extends FSHVisitor {
       return path;
     }
 
-    // Otherwise, get the context based on the indent level.
     if (path.length === 1 && path[0] === '.') {
       logger.error(
         "The special '.' path is only allowed in top-level rules. The rule will be processed as if it is not indented.",
@@ -2076,6 +2075,7 @@ export class FSHImporter extends FSHVisitor {
       return path;
     }
 
+    // Otherwise, get the context based on the indent level.
     const currentContext = this.pathContext[contextIndex - 1];
     if (currentContext.length === 0) {
       logger.error(

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1130,10 +1130,8 @@ export class FSHImporter extends FSHVisitor {
   }
 
   getPathWithContext(path: string, parentCtx: ParserRuleContext): string {
-    return this.getArrayPathWithContext(
-      splitOnPathPeriods(path).filter(p => p),
-      parentCtx
-    ).join('.');
+    const splitPath = path === '.' ? [path] : splitOnPathPeriods(path).filter(p => p);
+    return this.getArrayPathWithContext(splitPath, parentCtx).join('.');
   }
 
   getArrayPathWithContext(pathArray: string[], parentCtx: ParserRuleContext): string[] {
@@ -2051,17 +2049,6 @@ export class FSHImporter extends FSHVisitor {
     const currentIndent = location.startColumn - this.baseIndent;
     const contextIndex = currentIndent / INDENT_WIDTH;
 
-    if (this.pathContext.length && path.length === 1 && path[0] === '.') {
-      logger.error(
-        "The special '.' path is only allowed in top-level rules. The rule will be processed as if it is not indented.",
-        {
-          location,
-          file: this.currentFile
-        }
-      );
-      return path;
-    }
-
     if (!this.isValidContext(location, currentIndent, this.pathContext)) {
       return path;
     }
@@ -2078,6 +2065,17 @@ export class FSHImporter extends FSHVisitor {
     }
 
     // Otherwise, get the context based on the indent level.
+    if (path.length === 1 && path[0] === '.') {
+      logger.error(
+        "The special '.' path is only allowed in top-level rules. The rule will be processed as if it is not indented.",
+        {
+          location,
+          file: this.currentFile
+        }
+      );
+      return path;
+    }
+
     const currentContext = this.pathContext[contextIndex - 1];
     if (currentContext.length === 0) {
       logger.error(

--- a/test/import/FSHImporter.context.test.ts
+++ b/test/import/FSHImporter.context.test.ts
@@ -9,7 +9,8 @@ import {
   assertObeysRule,
   assertValueSetConceptComponent,
   assertValueSetFilterComponent,
-  assertAddElementRule
+  assertAddElementRule,
+  assertOnlyRule
 } from '../testhelpers/asserts';
 import { FshCode } from '../../src/fshtypes';
 
@@ -338,6 +339,35 @@ describe('FSHImporter', () => {
         types: [{ type: 'string' }],
         defs: { short: 'Father' }
       });
+    });
+
+    it('should set the context correctly when a rule with . path is followed by a caret rule with no path', () => {
+      const input = `
+      Extension: TestExtension
+      * value[x] only boolean
+      * . 0..1
+        * ^short = "A test extension."
+        * ^definition = "Yep.  It is a test extension."
+      * ^context.expression = "Patient"
+      `;
+      const result = importSingleText(input, 'Context.fsh');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+      expect(result.extensions.size).toBe(1);
+      const extension = result.extensions.get('TestExtension');
+      expect(extension.rules).toHaveLength(5);
+      assertOnlyRule(extension.rules[0], 'value[x]', { type: 'boolean' });
+      assertCardRule(extension.rules[1], '.', 0, '1');
+      assertCaretValueRule(extension.rules[2], '.', 'short', 'A test extension.', false, ['.']);
+      assertCaretValueRule(
+        extension.rules[3],
+        '.',
+        'definition',
+        'Yep.  It is a test extension.',
+        false,
+        ['.']
+      );
+      assertCaretValueRule(extension.rules[4], '', 'context.expression', 'Patient', false, []);
     });
 
     it('should log an error when a . rule is indented', () => {


### PR DESCRIPTION
Fixes #887.

When a rule's path is ".", the rule applies to the root element. Allow these rules to set a context so that they may be followed by an indented caret rule with no path.

Basically, the check for "did we indent a rule with a . path" was happening a bit too early. Now, when we have a . path on a rule with no indent, we'll first check that we're not indented, and therefore everything is fine.