### PR TITLE
Context setting rules now required to begin at column 1

### DIFF
--- a/test/import/FSHErrorListener.test.ts
+++ b/test/import/FSHErrorListener.test.ts
@@ -1,33 +1,36 @@
 import { loggerSpy } from '../testhelpers/loggerSpy';
 import { importSingleText } from '../testhelpers/importSingleText';
+import { leftAlign } from '../utils/leftAlign';
 
 describe('FSHErrorListener', () => {
   beforeEach(() => loggerSpy.reset());
 
   it('should not log any errors for valid FSH', () => {
-    const input = `
+    const input = leftAlign(`
     Profile: MyPatient
     Parent: Patient
     * active = true
-    `;
+    `);
     importSingleText(input, 'MyPatient.fsh');
     expect(loggerSpy.getAllMessages('error')).toBeEmpty();
   });
 
   it('should report mismatched input errors from antlr', () => {
-    const input = `
+    const input = leftAlign(
+      leftAlign(`
     Profile: MismatchedPizza
     Pizza: Large
-    `;
+    `)
+    );
     importSingleText(input, 'Pizza.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(/File: Pizza\.fsh.*Line: 3\D*/s);
   });
 
   it('should report extraneous input errors from antlr', () => {
-    const input = `
+    const input = leftAlign(`
     Profile: Something Spaced
     Parent: Spacious
-    `;
+    `);
     importSingleText(input, 'Space.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(/File: Space\.fsh.*Line: 2\D*/s);
   });
@@ -37,9 +40,9 @@ describe('FSHErrorListener', () => {
   // ########################################################################
 
   it('should make sense of errors due to no space before = in an Alias definition', () => {
-    const input = `
+    const input = leftAlign(`
     Alias: $OrgType= http://terminology.hl7.org/CodeSystem/organization-type
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Alias declarations must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 2\D*/s
@@ -47,9 +50,9 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space after = in an Alias definition', () => {
-    const input = `
+    const input = leftAlign(`
     Alias: $OrgType =http://terminology.hl7.org/CodeSystem/organization-type
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Alias declarations must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 2\D*/s
@@ -57,9 +60,9 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space around = in an Alias definition', () => {
-    const input = `
+    const input = leftAlign(`
     Alias: $OrgType=http://terminology.hl7.org/CodeSystem/organization-type
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Alias declarations must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 2\D*/s
@@ -67,11 +70,11 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space before = in an assignment rule', () => {
-    const input = `
+    const input = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * component= FOO#bar
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -79,11 +82,11 @@ describe('FSHErrorListener', () => {
 
     // Test with a multi-word string as well since sometimes that results in a different error
     loggerSpy.reset();
-    const input2 = `
+    const input2 = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * valueString= "My Value"
-    `;
+    `);
     importSingleText(input2, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -91,11 +94,11 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space after = in an assignment rule', () => {
-    const input = `
+    const input = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * component =FOO#bar
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -103,11 +106,11 @@ describe('FSHErrorListener', () => {
 
     // Test with a multi-word string as well since sometimes that results in a different error
     loggerSpy.reset();
-    const input2 = `
+    const input2 = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * valueString ="My Value"
-    `;
+    `);
     importSingleText(input2, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -115,11 +118,13 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space around = in an assignment rule', () => {
-    const input = `
+    const input = leftAlign(
+      leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * component=FOO#bar
-    `;
+    `)
+    );
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -127,11 +132,11 @@ describe('FSHErrorListener', () => {
 
     // Test with a multi-word string as well since sometimes that results in a different error
     loggerSpy.reset();
-    const input2 = `
+    const input2 = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * valueString="My Value"
-    `;
+    `);
     importSingleText(input2, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -139,11 +144,11 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space before = in a caret rule', () => {
-    const input = `
+    const input = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * component ^short= "Component1"
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -151,11 +156,11 @@ describe('FSHErrorListener', () => {
 
     // Test with a multi-word string as well since sometimes that results in a different error
     loggerSpy.reset();
-    const input2 = `
+    const input2 = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * component ^short= "A component"
-    `;
+    `);
     importSingleText(input2, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -163,11 +168,11 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space after = in a caret rule', () => {
-    const input = `
+    const input = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * component ^short ="Component1"
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -175,11 +180,11 @@ describe('FSHErrorListener', () => {
 
     // Test with a multi-word string as well since sometimes that results in a different error
     loggerSpy.reset();
-    const input2 = `
+    const input2 = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * component ^short ="A component"
-    `;
+    `);
     importSingleText(input2, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -187,11 +192,11 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space around = in a caret rule', () => {
-    const input = `
+    const input = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * component ^short="Component1"
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -199,11 +204,11 @@ describe('FSHErrorListener', () => {
 
     // Test with a multi-word string as well since sometimes that results in a different error
     loggerSpy.reset();
-    const input2 = `
+    const input2 = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * component ^short="A component"
-    `;
+    `);
     importSingleText(input2, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s
@@ -215,14 +220,14 @@ describe('FSHErrorListener', () => {
   // ########################################################################
 
   it('should make sense of errors due to no space after -> in a mapping rule', () => {
-    const input = `
+    const input = leftAlign(`
     Mapping:  USCorePatientToArgonaut
     Source:   USCorePatient
     Target:   "http://unknown.org/Argonaut-DQ-DSTU2"
     Title:    "Argonaut DSTU2"
     Id:       argonaut-dq-dstu2
     * identifier ->"Patient.identifier"
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Mapping rules must include at least one space both before and after the '->' operator.*File: Invalid\.fsh.*Line: 7\D*/s
@@ -230,14 +235,14 @@ describe('FSHErrorListener', () => {
 
     // Test with a multi-word string as well since sometimes that results in a different error
     loggerSpy.reset();
-    const input2 = `
+    const input2 = leftAlign(`
     Mapping:  USCorePatientToArgonaut
     Source:   USCorePatient
     Target:   "http://unknown.org/Argonaut-DQ-DSTU2"
     Title:    "Argonaut DSTU2"
     Id:       argonaut-dq-dstu2
     * identifier ->"Patient identifier"
-    `;
+    `);
     importSingleText(input2, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Mapping rules must include at least one space both before and after the '->' operator.*File: Invalid\.fsh.*Line: 7\D*/s
@@ -245,14 +250,14 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space before -> in a mapping rule', () => {
-    const input = `
+    const input = leftAlign(`
     Mapping:  USCorePatientToArgonaut
     Source:   USCorePatient
     Target:   "http://unknown.org/Argonaut-DQ-DSTU2"
     Title:    "Argonaut DSTU2"
     Id:       argonaut-dq-dstu2
     * identifier-> "Patient.identifier"
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Mapping rules must include at least one space both before and after the '->' operator.*File: Invalid\.fsh.*Line: 7\D*/s
@@ -260,14 +265,14 @@ describe('FSHErrorListener', () => {
 
     // Test with a multi-word string as well since sometimes that results in a different error
     loggerSpy.reset();
-    const input2 = `
+    const input2 = leftAlign(`
     Mapping:  USCorePatientToArgonaut
     Source:   USCorePatient
     Target:   "http://unknown.org/Argonaut-DQ-DSTU2"
     Title:    "Argonaut DSTU2"
     Id:       argonaut-dq-dstu2
     * identifier-> "Patient identifier"
-    `;
+    `);
     importSingleText(input2, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Mapping rules must include at least one space both before and after the '->' operator.*File: Invalid\.fsh.*Line: 7\D*/s
@@ -275,14 +280,14 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space around -> in a mapping rule', () => {
-    const input = `
+    const input = leftAlign(`
     Mapping:  USCorePatientToArgonaut
     Source:   USCorePatient
     Target:   "http://unknown.org/Argonaut-DQ-DSTU2"
     Title:    "Argonaut DSTU2"
     Id:       argonaut-dq-dstu2
     * identifier->"Patient.identifier"
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Mapping rules must include at least one space both before and after the '->' operator.*File: Invalid\.fsh.*Line: 7\D*/s
@@ -290,14 +295,14 @@ describe('FSHErrorListener', () => {
 
     // Test with a multi-word string as well since sometimes that results in a different error
     loggerSpy.reset();
-    const input2 = `
+    const input2 = leftAlign(`
     Mapping:  USCorePatientToArgonaut
     Source:   USCorePatient
     Target:   "http://unknown.org/Argonaut-DQ-DSTU2"
     Title:    "Argonaut DSTU2"
     Id:       argonaut-dq-dstu2
     * identifier->"Patient identifier"
-    `;
+    `);
     importSingleText(input2, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Mapping rules must include at least one space both before and after the '->' operator.*File: Invalid\.fsh.*Line: 7\D*/s
@@ -309,11 +314,11 @@ describe('FSHErrorListener', () => {
   // ########################################################################
 
   it('should make sense of errors due to no space after * in a rule', () => {
-    const input = `
+    const input = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     *component = FOO#bar
-    `;
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Rules must start with a '\*' symbol followed by at least one space.*File: Invalid\.fsh.*Line: 4\D*/s

--- a/test/import/FSHErrorListener.test.ts
+++ b/test/import/FSHErrorListener.test.ts
@@ -16,12 +16,10 @@ describe('FSHErrorListener', () => {
   });
 
   it('should report mismatched input errors from antlr', () => {
-    const input = leftAlign(
-      leftAlign(`
+    const input = leftAlign(`
     Profile: MismatchedPizza
     Pizza: Large
-    `)
-    );
+    `);
     importSingleText(input, 'Pizza.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(/File: Pizza\.fsh.*Line: 3\D*/s);
   });
@@ -118,13 +116,11 @@ describe('FSHErrorListener', () => {
   });
 
   it('should make sense of errors due to no space around = in an assignment rule', () => {
-    const input = leftAlign(
-      leftAlign(`
+    const input = leftAlign(`
     Profile: SampleObservation
     Parent: Observation
     * component=FOO#bar
-    `)
-    );
+    `);
     importSingleText(input, 'Invalid.fsh');
     expect(loggerSpy.getLastMessage('error')).toMatch(
       /Assignment rules must include at least one space both before and after the '=' sign.*File: Invalid\.fsh.*Line: 4\D*/s

--- a/test/import/FSHImporter.Alias.test.ts
+++ b/test/import/FSHImporter.Alias.test.ts
@@ -3,6 +3,7 @@ import { AssignmentRule, BindingRule } from '../../src/fshtypes/rules';
 import { FshCode } from '../../src/fshtypes';
 import { importSingleText } from '../testhelpers/importSingleText';
 import { loggerSpy } from '../testhelpers';
+import { leftAlign } from '../utils/leftAlign';
 
 // Aliases are tested as part of the other entity tests where aliases are allowed
 // but these tests ensure that aliases work generally and can be in any order
@@ -12,7 +13,7 @@ describe('FSHImporter', () => {
 
   describe('Alias', () => {
     it('should collect and return aliases in result', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: LOINC = http://loinc.org
       Alias: SCT = http://snomed.info/sct
 
@@ -25,7 +26,7 @@ describe('FSHImporter', () => {
       Parent: Observation
 
       Alias: UCUM = http://unitsofmeasure.org
-      `;
+      `);
 
       const result = importSingleText(input);
       expect(result.aliases.size).toBe(4);
@@ -36,9 +37,9 @@ describe('FSHImporter', () => {
     });
 
     it('should parse aliases that replicate the syntax of a code', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: LOINC = http://loinc.org#1234
-      `;
+      `);
 
       const result = importSingleText(input);
       expect(result.aliases.size).toBe(1);
@@ -46,10 +47,10 @@ describe('FSHImporter', () => {
     });
 
     it('should report when the same alias is defined twice w/ different values in the same file', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: USCoreRace = http://hl7.org/fhir/us/core/ValueSet/omb-race-category
       Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
-      `;
+      `);
 
       const result = importSingleText(input);
       expect(result.aliases.size).toBe(1);
@@ -62,12 +63,12 @@ describe('FSHImporter', () => {
     });
 
     it('should report when the same alias is defined twice w/ different values in different files', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: USCoreRace = http://hl7.org/fhir/us/core/ValueSet/omb-race-category
-      `;
-      const input2 = `
+      `);
+      const input2 = leftAlign(`
       Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
-      `;
+      `);
 
       const results = importText([
         new RawFSH(input, 'Alias1.fsh'),
@@ -85,13 +86,13 @@ describe('FSHImporter', () => {
     });
 
     it('should not report an error when the same alias is defined multiple times w/ the same values', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
       Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
-      `;
-      const input2 = `
+      `);
+      const input2 = leftAlign(`
       Alias: USCoreRace = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
-      `;
+      `);
 
       const results = importText([
         new RawFSH(input, 'Alias1.fsh'),
@@ -110,13 +111,13 @@ describe('FSHImporter', () => {
     });
 
     it('should translate an alias when the alias is defined before its use', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: LOINC = http://loinc.org
 
       Profile: ObservationProfile
       Parent: Observation
       * code from LOINC
-      `;
+      `);
 
       const result = importSingleText(input);
       const rule = result.profiles.get('ObservationProfile').rules[0] as BindingRule;
@@ -124,13 +125,13 @@ describe('FSHImporter', () => {
     });
 
     it('should translate an alias when the alias is defined after its use', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: ObservationProfile
       Parent: Observation
       * code from LOINC
 
       Alias: LOINC = http://loinc.org
-      `;
+      `);
 
       const result = importSingleText(input);
       const rule = result.profiles.get('ObservationProfile').rules[0] as BindingRule;
@@ -138,13 +139,13 @@ describe('FSHImporter', () => {
     });
 
     it('should not translate an alias when the alias does not match', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: LOINC = http://loinc.org
 
       Profile: ObservationProfile
       Parent: Observation
       * code from LAINC
-      `;
+      `);
 
       const result = importSingleText(input);
       const rule = result.profiles.get('ObservationProfile').rules[0] as BindingRule;
@@ -152,14 +153,14 @@ describe('FSHImporter', () => {
     });
 
     it('should translate an alias from any input file', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: ObservationProfile
       Parent: Observation
       * code from LOINC
-      `;
-      const input2 = `
+      `);
+      const input2 = leftAlign(`
       Alias: LOINC = http://loinc.org
-      `;
+      `);
 
       const results = importText([new RawFSH(input), new RawFSH(input2)]);
       expect(results.length).toBe(2);
@@ -168,13 +169,13 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when an aliased code prefixed with $ does not resolve', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: $LOINC = http://loinc.org
 
       Profile: ObservationProfile
       Parent: Observation
       * code = $LOINCZ#foo
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'Loinc.fsh')]);
       expect(results.length).toBe(1);
@@ -183,13 +184,13 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when an aliased value set rule prefixed with $ does not resolve', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: $LOINC = http://loinc.org
 
       Profile: ObservationProfile
       Parent: Observation
       * code from $LOINCZ
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'Loinc.fsh')]);
       expect(results.length).toBe(1);
@@ -198,13 +199,13 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when an aliased reference prefixed with $ does not resolve', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: $MYPATIENT = http://hl7.org/fhir/StructureDefinition/mypatient.html
 
       Profile: ObservationProfile
       Parent: Observation
       * subject only Reference($MYPATIENTZ)
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'MyPatient.fsh')]);
       expect(results.length).toBe(1);
@@ -213,13 +214,13 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when an assignment rule aliased reference prefixed with $ does not resolve', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: $MYPATIENT = http://hl7.org/fhir/StructureDefinition/mypatient.html
 
       Profile: ObservationProfile
       Parent: Observation
       * subject = Reference($MYPATIENTZ)
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'MyPatient.fsh')]);
       expect(results.length).toBe(1);
@@ -228,13 +229,13 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when an only rule aliased reference prefixed with $ does not resolve', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: $MYPATIENT = http://hl7.org/fhir/StructureDefinition/mypatient.html
 
       Profile: ObservationProfile
       Parent: Observation
       * subject only Reference($MYPATIENTZ)
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'MyPatient.fsh')]);
       expect(results.length).toBe(1);
@@ -244,13 +245,13 @@ describe('FSHImporter', () => {
 
     it('should not log an error when a contains rule aliased extension prefixed with $ does not resolve', () => {
       loggerSpy.reset();
-      const input = `
+      const input = leftAlign(`
       Alias: $MYEXTENSION = http://hl7.org/fhir/StructureDefinition/mypatient-extension.html
 
       Profile: ObservationProfile
       Parent: Observation
       * extension contains $TYPO 1..1
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'MyExtension.fsh')]);
       expect(results.length).toBe(1);
@@ -258,13 +259,13 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when an aliased contains rule type prefixed with $ does not resolve', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: $EXT = http://fhir.org/extension
 
       Profile: MyObservation
       Parent: Observation
       * extension contains $EXTZ named ext
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'Ext.fsh')]);
       expect(results.length).toBe(1);
@@ -273,12 +274,12 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when an aliased value set system prefixed with $ does not resolve', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: $LOINC = http://loinc.org
 
       ValueSet: MySet
       * codes from system $LOINCZ
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'Loinc.fsh')]);
       expect(results.length).toBe(1);
@@ -287,12 +288,12 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when an aliased value set prefixed with $ does not resolve', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: $LOINC = http://loinc.org
 
       ValueSet: MySet
       * codes from valueset $LOINCZ
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'Loinc.fsh')]);
       expect(results.length).toBe(1);
@@ -301,13 +302,13 @@ describe('FSHImporter', () => {
     });
 
     it('should resolve an alias while accounting for a version', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: LOINC = http://loinc.org
 
       Profile: ObservationProfile
       Parent: Observation
       * code = LOINC|123#foo
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'Loinc.fsh')]);
       expect(results.length).toBe(1);
@@ -315,44 +316,44 @@ describe('FSHImporter', () => {
       expect(rule.value).toEqual(
         new FshCode('foo', 'http://loinc.org|123')
           .withFile('Loinc.fsh')
-          .withLocation([6, 16, 6, 28])
+          .withLocation([6, 10, 6, 22])
       );
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
 
     it('should resolve an alias while ignoring an empty version', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: LOINC = http://loinc.org
 
       Profile: ObservationProfile
       Parent: Observation
       * code = LOINC|#foo
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'Loinc.fsh')]);
       expect(results.length).toBe(1);
       const rule = results[0].profiles.get('ObservationProfile').rules[0] as AssignmentRule;
       expect(rule.value).toEqual(
-        new FshCode('foo', 'http://loinc.org').withFile('Loinc.fsh').withLocation([6, 16, 6, 25])
+        new FshCode('foo', 'http://loinc.org').withFile('Loinc.fsh').withLocation([6, 10, 6, 19])
       );
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
 
     it('should log an error when an alias contains reserved characters', () => {
-      const input = `
+      const input = leftAlign(`
       Alias: BAD|LOINC = http://loinc.org
 
       Profile: ObservationProfile
       Parent: Observation
       * code = BAD|LOINC#foo
-      `;
+      `);
 
       const results = importText([new RawFSH(input, 'Loinc.fsh')]);
       expect(results.length).toBe(1);
       const rule = results[0].profiles.get('ObservationProfile').rules[0] as AssignmentRule;
       // The BAD|LOINC alias does not resolve, since it is not created
       expect(rule.value).toEqual(
-        new FshCode('foo', 'BAD|LOINC').withFile('Loinc.fsh').withLocation([6, 16, 6, 28])
+        new FshCode('foo', 'BAD|LOINC').withFile('Loinc.fsh').withLocation([6, 10, 6, 22])
       );
       expect(loggerSpy.getLastMessage('error')).toMatch(/BAD\|LOINC cannot include "\|"/);
     });

--- a/test/import/FSHImporter.CodeSystem.test.ts
+++ b/test/import/FSHImporter.CodeSystem.test.ts
@@ -2,6 +2,7 @@ import { importSingleText } from '../testhelpers/importSingleText';
 import { assertConceptRule, assertInsertRule, assertCaretValueRule } from '../testhelpers/asserts';
 import { loggerSpy } from '../testhelpers/loggerSpy';
 import { Rule, CaretValueRule, InsertRule, ConceptRule } from '../../src/fshtypes/rules';
+import { leftAlign } from '../utils/leftAlign';
 
 describe('FSHImporter', () => {
   describe('CodeSystem', () => {
@@ -11,9 +12,9 @@ describe('FSHImporter', () => {
 
     describe('#csMetadata', () => {
       it('should parse the simplest possible code system', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -22,20 +23,20 @@ describe('FSHImporter', () => {
         expect(codeSystem.rules).toEqual([]);
         expect(codeSystem.sourceInfo.location).toEqual({
           startLine: 2,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 2,
-          endColumn: 23
+          endColumn: 15
         });
         expect(codeSystem.sourceInfo.file).toBe('Zoo.fsh');
       });
 
       it('should parse a code system with additional metadata', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         Id: zoo-codes
         Title: "Zoo Animals"
         Description: "Animals and cryptids that may be at a zoo."
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -46,18 +47,18 @@ describe('FSHImporter', () => {
         expect(codeSystem.rules).toEqual([]);
         expect(codeSystem.sourceInfo.location).toEqual({
           startLine: 2,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 5,
-          endColumn: 65
+          endColumn: 57
         });
       });
 
       it('should parse numeric code system name and id', () => {
         // NOT recommended, but possible
-        const input = `
+        const input = leftAlign(`
         CodeSystem: 123
         Id: 456
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('123');
@@ -66,7 +67,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse a code system with a multi-line description', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         Id: zoo-codes
         Title: "Zoo Animals"
@@ -81,7 +82,7 @@ describe('FSHImporter', () => {
           * swamp ape
           * hopkinsville goblin
         """
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -104,7 +105,7 @@ describe('FSHImporter', () => {
       });
 
       it('should only apply each metadata attribute the first time it is declared', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         Id: zoo-codes
         Title: "Zoo Animals"
@@ -112,7 +113,7 @@ describe('FSHImporter', () => {
         Title: "Duplicate Animals"
         Id: zoo-codes-again
         Description: "Lions and tigers and bears!"
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -123,14 +124,14 @@ describe('FSHImporter', () => {
         expect(codeSystem.rules).toEqual([]);
         expect(codeSystem.sourceInfo.location).toEqual({
           startLine: 2,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 8,
-          endColumn: 50
+          endColumn: 42
         });
       });
 
       it('should log an error when encountering a duplicate metadata attribute', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         Id: zoo-codes
         Title: "Zoo Animals"
@@ -138,7 +139,7 @@ describe('FSHImporter', () => {
         Title: "Duplicate Animals"
         Id: zoo-codes-again
         Description: "Lions and tigers and bears!"
-        `;
+        `);
         importSingleText(input, 'Zoo.fsh');
         expect(loggerSpy.getMessageAtIndex(-3, 'error')).toMatch(/File: Zoo\.fsh.*Line: 6\D*/s);
         expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(/File: Zoo\.fsh.*Line: 7\D*/s);
@@ -146,13 +147,13 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error and skip the code system when encountering a code system with a name used by another code system', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: BREAD
         Title: "Known Bread"
 
         CodeSystem: BREAD
         Title: "Unknown Bread"
-        `;
+        `);
         const result = importSingleText(input, 'Bread.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('BREAD');
@@ -166,10 +167,10 @@ describe('FSHImporter', () => {
 
     describe('#concept', () => {
       it('should parse a code system with one concept', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #lion
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -178,19 +179,19 @@ describe('FSHImporter', () => {
         assertConceptRule(codeSystem.rules[0], 'lion', undefined, undefined, []);
         expect(codeSystem.rules[0].sourceInfo.location).toEqual({
           startLine: 3,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 3,
-          endColumn: 15
+          endColumn: 7
         });
         expect(codeSystem.rules[0].sourceInfo.file).toBe('Zoo.fsh');
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       });
 
       it('should parse a code system with one concept with a display string', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #tiger "Tiger"
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -199,19 +200,19 @@ describe('FSHImporter', () => {
         assertConceptRule(codeSystem.rules[0], 'tiger', 'Tiger', undefined, []);
         expect(codeSystem.rules[0].sourceInfo.location).toEqual({
           startLine: 3,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 3,
-          endColumn: 24
+          endColumn: 16
         });
         expect(codeSystem.rules[0].sourceInfo.file).toBe('Zoo.fsh');
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       });
 
       it('should parse a code system with one concept with display and definition strings', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #bear "Bear" "A member of family Ursidae."
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -220,22 +221,22 @@ describe('FSHImporter', () => {
         assertConceptRule(codeSystem.rules[0], 'bear', 'Bear', 'A member of family Ursidae.', []);
         expect(codeSystem.rules[0].sourceInfo.location).toEqual({
           startLine: 3,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 3,
-          endColumn: 52
+          endColumn: 44
         });
         expect(codeSystem.rules[0].sourceInfo.file).toBe('Zoo.fsh');
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       });
 
       it('should parse a concept with a multi-line definition string', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #gorilla "Gorilla" """
         Let there be no mistake
         about the greatest ape of all.
         """
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -248,21 +249,21 @@ describe('FSHImporter', () => {
         assertConceptRule(codeSystem.rules[0], 'gorilla', 'Gorilla', expectedDefinition, []);
         expect(codeSystem.rules[0].sourceInfo.location).toEqual({
           startLine: 3,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 3,
-          endColumn: 115
+          endColumn: 83
         });
         expect(codeSystem.rules[0].sourceInfo.file).toBe('Zoo.fsh');
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       });
 
       it('should parse a code system with more than one concept', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #lion
         * #tiger "Tiger"
         * #bear "Bear" "A member of family Ursidae."
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -271,37 +272,37 @@ describe('FSHImporter', () => {
         assertConceptRule(codeSystem.rules[0], 'lion', undefined, undefined, []);
         expect(codeSystem.rules[0].sourceInfo.location).toEqual({
           startLine: 3,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 3,
-          endColumn: 15
+          endColumn: 7
         });
         expect(codeSystem.rules[0].sourceInfo.file).toBe('Zoo.fsh');
         assertConceptRule(codeSystem.rules[1], 'tiger', 'Tiger', undefined, []);
         expect(codeSystem.rules[1].sourceInfo.location).toEqual({
           startLine: 4,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 4,
-          endColumn: 24
+          endColumn: 16
         });
         expect(codeSystem.rules[1].sourceInfo.file).toBe('Zoo.fsh');
         assertConceptRule(codeSystem.rules[2], 'bear', 'Bear', 'A member of family Ursidae.', []);
         expect(codeSystem.rules[2].sourceInfo.location).toEqual({
           startLine: 5,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 5,
-          endColumn: 52
+          endColumn: 44
         });
         expect(codeSystem.rules[2].sourceInfo.file).toBe('Zoo.fsh');
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       });
 
       it('should parse a code system with hierarchical codes', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #bear "Bear" "A member of family Ursidae."
         * #bear #sunbear "Sun bear" "Helarctos malayanus"
         * #bear #sunbear #ursula "Ursula the sun bear"
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -310,18 +311,18 @@ describe('FSHImporter', () => {
         assertConceptRule(codeSystem.rules[0], 'bear', 'Bear', 'A member of family Ursidae.', []);
         expect(codeSystem.rules[0].sourceInfo.location).toEqual({
           startLine: 3,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 3,
-          endColumn: 52
+          endColumn: 44
         });
         assertConceptRule(codeSystem.rules[1], 'sunbear', 'Sun bear', 'Helarctos malayanus', [
           'bear'
         ]);
         expect(codeSystem.rules[1].sourceInfo.location).toEqual({
           startLine: 4,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 4,
-          endColumn: 57
+          endColumn: 49
         });
         assertConceptRule(codeSystem.rules[2], 'ursula', 'Ursula the sun bear', undefined, [
           'bear',
@@ -329,19 +330,19 @@ describe('FSHImporter', () => {
         ]);
         expect(codeSystem.rules[2].sourceInfo.location).toEqual({
           startLine: 5,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 5,
-          endColumn: 54
+          endColumn: 46
         });
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       });
 
       it('should log an error when encountering a duplicate code', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #goat "A goat"
         * #goat "Another goat?"
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -351,11 +352,11 @@ describe('FSHImporter', () => {
       });
 
       it('should not log an error when encountering a duplicate code if the new code has no display or definition', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #goat "A goat"
         * #goat
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -365,11 +366,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when encountering a code with an incorrectly defined hierarchy', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #bear "Bear" "A member of family Ursidae."
         * #bear #sunbear #ursula "Ursula the sun bear"
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -379,13 +380,13 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when a concept includes a system declaration', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #goat
         * ZOO#bat
         * CRYPTID#jackalope
         * ZOO#goat #mountaingoat
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         expect(result.codeSystems.size).toBe(1);
         const codeSystem = result.codeSystems.get('ZOO');
@@ -403,10 +404,10 @@ describe('FSHImporter', () => {
 
     describe('#CaretValueRule', () => {
       it('should log an error when a CaretValueRule contains a path before ^', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * somepath ^publisher = "Marky Mark"
-        `;
+        `);
         const result = importSingleText(input, 'Simple.fsh');
         const codeSystem = result.codeSystems.get('ZOO');
         expect(codeSystem.rules).toHaveLength(1);
@@ -414,10 +415,10 @@ describe('FSHImporter', () => {
       });
 
       it('should parse a code system that uses a CaretValueRule with no codes', () => {
-        const input = `
+        const input = leftAlign(`
           CodeSystem: ZOO
           * ^publisher = "Matt"
-          `;
+          `);
         const result = importSingleText(input);
         const codeSystem = result.codeSystems.get('ZOO');
         assertCaretValueRule(codeSystem.rules[0] as Rule, '', 'publisher', 'Matt', false, []);
@@ -425,11 +426,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse a code system that uses CaretValueRules with no codes alongside rules', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #lion
         * ^publisher = "Damon"
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         const codeSystem = result.codeSystems.get('ZOO');
         assertConceptRule(codeSystem.rules[0], 'lion', undefined, undefined, []);
@@ -446,11 +447,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse a code system that uses a CaretValueRule on a top-level concept', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #anteater "Anteater"
         * #anteater ^property[0].valueString = "Their threat pose is really cute."
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         const codeSystem = result.codeSystems.get('ZOO');
         assertConceptRule(codeSystem.rules[0], 'anteater', 'Anteater', undefined, []);
@@ -468,12 +469,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse a code system that uses a CaretValueRule on a nested concept', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: ZOO
         * #anteater "Anteater"
         * #anteater #northern "Northern tamandua"
         * #anteater #northern ^property[0].valueString = "They are strong climbers."
-        `;
+        `);
         const result = importSingleText(input, 'Zoo.fsh');
         const codeSystem = result.codeSystems.get('ZOO');
         assertConceptRule(codeSystem.rules[0], 'anteater', 'Anteater', undefined, []);
@@ -497,10 +498,10 @@ describe('FSHImporter', () => {
 
     describe('#insertRule', () => {
       it('should parse an insert rule with a single RuleSet', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: MyCS
         * insert MyRuleSet
-        `;
+        `);
         const result = importSingleText(input, 'Insert.fsh');
         const cs = result.codeSystems.get('MyCS');
         expect(cs.rules).toHaveLength(1);

--- a/test/import/FSHImporter.Logical.test.ts
+++ b/test/import/FSHImporter.Logical.test.ts
@@ -13,6 +13,7 @@ import {
   assertOnlyRule
 } from '../testhelpers';
 import { FshCode } from '../../src/fshtypes';
+import { leftAlign } from '../utils/leftAlign';
 
 describe('FSHImporter', () => {
   beforeEach(() => loggerSpy.reset());
@@ -46,11 +47,11 @@ describe('FSHImporter', () => {
 
         // Since we'll do the same thing over and over (and over), create a function for it
         const testToken = (token: string) => {
-          const input = `
+          const input = leftAlign(`
           Logical: ${token}
           Parent: BaseObservationModel
           * value[x] only boolean
-          `;
+          `);
           const result = importSingleText(input);
           expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
           expect(result).toBeDefined();

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -22,15 +22,16 @@ import { stats } from '../../src/utils/FSHLogger';
 import { importSingleText } from '../testhelpers/importSingleText';
 import { FSHImporter, RawFSH } from '../../src/import';
 import { EOL } from 'os';
+import { leftAlign } from '../utils/leftAlign';
 
 describe('FSHImporter', () => {
   describe('Profile', () => {
     describe('#sdMetadata', () => {
       it('should parse the simplest possible profile', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
-        `;
+        `);
 
         const result = importSingleText(input, 'Simple.fsh');
         expect(result.profiles.size).toBe(1);
@@ -41,9 +42,9 @@ describe('FSHImporter', () => {
         expect(profile.id).toBe('ObservationProfile');
         expect(profile.sourceInfo.location).toEqual({
           startLine: 2,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 3,
-          endColumn: 27
+          endColumn: 19
         });
         expect(profile.sourceInfo.file).toBe('Simple.fsh');
       });
@@ -54,11 +55,11 @@ describe('FSHImporter', () => {
 
         // Since we'll do the same thing over and over (and over), create a function for it
         const testToken = (token: string) => {
-          const input = `
+          const input = leftAlign(`
           Profile: ${token}
           Parent: Observation
           * value[x] only boolean
-          `;
+          `);
           const result = importSingleText(input);
           expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
           expect(result).toBeDefined();
@@ -81,13 +82,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse profile with additional metadata properties', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         Id: observation-profile
         Title: "An Observation Profile"
         Description: "A profile on Observation"
-        `;
+        `);
 
         const result = importSingleText(input);
         expect(result.profiles.size).toBe(1);
@@ -99,18 +100,18 @@ describe('FSHImporter', () => {
         expect(profile.description).toBe('A profile on Observation');
         expect(profile.sourceInfo.location).toEqual({
           startLine: 2,
-          startColumn: 9,
+          startColumn: 1,
           endLine: 6,
-          endColumn: 47
+          endColumn: 39
         });
       });
 
       it('should parse profile with numeric name, parent, and id', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: 123
         Parent: 456
         Id: 789
-        `;
+        `);
 
         const result = importSingleText(input);
         expect(result.profiles.size).toBe(1);
@@ -121,7 +122,7 @@ describe('FSHImporter', () => {
       });
 
       it('should properly parse a multi-string description', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         Description:
@@ -138,7 +139,7 @@ describe('FSHImporter', () => {
             * Bullet C
           * Bullet 2
           """
-        `;
+        `);
 
         const result = importSingleText(input);
         expect(result.profiles.size).toBe(1);
@@ -160,12 +161,12 @@ describe('FSHImporter', () => {
       });
 
       it('should accept and translate an alias for the parent', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: OBS = http://hl7.org/fhir/StructureDefinition/Observation
 
         Profile: ObservationProfile
         Parent: OBS
-        `;
+        `);
 
         const result = importSingleText(input);
         expect(result.profiles.size).toBe(1);
@@ -175,7 +176,7 @@ describe('FSHImporter', () => {
       });
 
       it('should only apply each metadata attribute the first time it is declared', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         Id: observation-profile
@@ -185,7 +186,7 @@ describe('FSHImporter', () => {
         Id: duplicate-observation-profile
         Title: "Duplicate Observation Profile"
         Description: "A duplicated profile on Observation"
-        `;
+        `);
 
         const result = importSingleText(input);
         expect(result.profiles.size).toBe(1);
@@ -197,7 +198,7 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when encountering a duplicate metadata attribute', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         Id: observation-profile
@@ -205,7 +206,7 @@ describe('FSHImporter', () => {
         Description: "A profile on Observation"
         Title: "Duplicate Observation Profile"
         Description: "A duplicated profile on Observation"
-        `;
+        `);
 
         importSingleText(input, 'Dupe.fsh');
         expect(loggerSpy.getMessageAtIndex(-2, 'error')).toMatch(/File: Dupe\.fsh.*Line: 7\D*/s);
@@ -213,7 +214,7 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error and skip the profile when encountering a profile with a name used by another profile', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         Title: "First Observation Profile"
@@ -221,7 +222,7 @@ describe('FSHImporter', () => {
         Profile: ObservationProfile
         Parent: Observation
         Title: "Second Observation Profile"
-        `;
+        `);
         const result = importSingleText(input, 'SameName.fsh');
         expect(result.profiles.size).toBe(1);
         const profile = result.profiles.get('ObservationProfile');
@@ -233,11 +234,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when the deprecated Mixins keyword is used', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: SomeProfile
         Parent: Observation
         Mixins: RuleSet1 and RuleSet2
-        `;
+        `);
 
         const result = importSingleText(input, 'Deprecated.fsh');
         expect(result.profiles.size).toBe(1);
@@ -252,13 +253,13 @@ describe('FSHImporter', () => {
 
     describe('#cardRule', () => {
       it('should parse simple card rules', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category 1..5
         * value[x] 1..1
         * component 2..*
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -269,11 +270,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse card rule with only min', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category 1..
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -282,11 +283,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse card rule with only max', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category ..5
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -295,11 +296,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error if neither side is specified', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category ..
-        `;
+        `);
 
         const result = importSingleText(input, 'BadCard.fsh');
         const profile = result.profiles.get('ObservationProfile');
@@ -311,7 +312,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse card rules w/ flags', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category 1..5 MS
@@ -320,7 +321,7 @@ describe('FSHImporter', () => {
         * interpretation 1..* TU
         * note 0..11 N
         * bodySite 1..1 D
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -394,13 +395,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse card rules w/ multiple flags', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category 1..5 MS ?! TU
         * value[x] 1..1 ?! SU N
         * component 2..* SU MS D
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -443,7 +444,7 @@ describe('FSHImporter', () => {
 
     describe('#flagRule', () => {
       it('should parse single-path single-value flag rules', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category MS
@@ -452,7 +453,7 @@ describe('FSHImporter', () => {
         * interpretation TU
         * note N
         * bodySite D
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -520,13 +521,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse single-path multi-value flag rules', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category MS ?! N
         * value[x] ?! SU D
         * component MS SU ?! TU
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -555,13 +556,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse multi-path single-value flag rules', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category and value[x] and component MS
         * subject and focus ?!
         * interpretation and note N
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -639,12 +640,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse multi-path multi-value flag rules', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category and value[x] and component MS SU N
         * subject and focus ?! SU TU
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -702,11 +703,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when paths are listed with commas', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category, value[x] , component MS SU N
-        `;
+        `);
 
         const result = importSingleText(input, 'Deprecated.fsh');
         const profile = result.profiles.get('ObservationProfile');
@@ -720,14 +721,14 @@ describe('FSHImporter', () => {
 
     describe('#BindingRule', () => {
       it('should parse value set rules w/ names and strengths', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category from CategoryValueSet (required)
         * code from CodeValueSet (extensible)
         * valueCodeableConcept from ValueValueSet (preferred)
         * component.code from ComponentCodeValueSet (example)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -739,14 +740,14 @@ describe('FSHImporter', () => {
       });
 
       it('should parse value set rules w/ urls and strengths', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category from http://example.org/fhir/ValueSet/CategoryValueSet (required)
         * code from http://example.org/fhir/ValueSet/CodeValueSet (extensible)
         * valueCodeableConcept from http://example.org/fhir/ValueSet/ValueValueSet (preferred)
         * component.code from http://example.org/fhir/ValueSet/ComponentCodeValueSet (example)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -778,7 +779,7 @@ describe('FSHImporter', () => {
       });
 
       it('should accept and translate aliases for value set URLs', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: CAT = http://example.org/fhir/ValueSet/CategoryValueSet
         Alias: CODE = http://example.org/fhir/ValueSet/CodeValueSet
         Alias: VALUE = http://example.org/fhir/ValueSet/ValueValueSet
@@ -790,7 +791,7 @@ describe('FSHImporter', () => {
         * code from CODE (extensible)
         * valueCodeableConcept from VALUE (preferred)
         * component.code from COMP (example)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -822,12 +823,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse value set rules w/ numeric names', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category from 123 (required)
         * code from 456 (extensible)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -837,12 +838,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse value set rules w/ no strength and default to required', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category from CategoryValueSet
         * code from http://example.org/fhir/ValueSet/CodeValueSet
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -857,11 +858,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse value set rules on Quantity', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueQuantity from http://unitsofmeasure.org
-        `;
+        `);
 
         const result = importSingleText(input, 'UselessQuant.fsh');
         const profile = result.profiles.get('ObservationProfile');
@@ -875,11 +876,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when parsing value set rules using the unit keyword', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueQuantity units from http://unitsofmeasure.org
-        `;
+        `);
 
         const result = importSingleText(input, 'Deprecated.fsh');
         const profile = result.profiles.get('ObservationProfile');
@@ -892,11 +893,11 @@ describe('FSHImporter', () => {
 
     describe('#assignmentRule', () => {
       it('should parse assigned value boolean rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueBoolean = true
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -905,11 +906,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value boolean rule with (exactly) modifier', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueBoolean = true (exactly)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -918,11 +919,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value number (decimal) rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueDecimal = 1.23
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -931,11 +932,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value number (integer) rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueInteger = 123
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -944,11 +945,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value string rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueString = "hello world"
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -957,14 +958,14 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value multi-line string rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueString = """
             hello
             world
             """
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -973,11 +974,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value date rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueDateTime = 2019-11-01T12:30:01.999Z
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -987,11 +988,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value time rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueTime = 12:30:01.999-05:00
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1001,29 +1002,29 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value code rule', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: LOINC = http://loinc.org
 
         Profile: ObservationProfile
         Parent: Observation
         * status = #final
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
-        const expectedCode = new FshCode('final').withLocation([6, 20, 6, 25]).withFile('');
+        const expectedCode = new FshCode('final').withLocation([6, 12, 6, 17]).withFile('');
         assertAssignmentRule(profile.rules[0], 'status', expectedCode);
       });
 
       it('should parse assigned value CodeableConcept rule', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: LOINC = http://loinc.org
 
         Profile: ObservationProfile
         Parent: Observation
         * valueCodeableConcept = LOINC#718-7 "Hemoglobin [Mass/volume] in Blood"
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1033,19 +1034,19 @@ describe('FSHImporter', () => {
           'http://loinc.org',
           'Hemoglobin [Mass/volume] in Blood'
         )
-          .withLocation([6, 34, 6, 80])
+          .withLocation([6, 26, 6, 72])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueCodeableConcept', expectedCode);
       });
 
       it('should parse assigned value CodeableConcept rule with (exactly) modifier', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: LOINC = http://loinc.org
 
         Profile: ObservationProfile
         Parent: Observation
         * valueCodeableConcept = LOINC#718-7 "Hemoglobin [Mass/volume] in Blood" (exactly)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1055,33 +1056,33 @@ describe('FSHImporter', () => {
           'http://loinc.org',
           'Hemoglobin [Mass/volume] in Blood'
         )
-          .withLocation([6, 34, 6, 80])
+          .withLocation([6, 26, 6, 72])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueCodeableConcept', expectedCode, true);
       });
 
       it('should parse an assigned value FSHCode rule with units on Quantity', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueQuantity = http://unitsofmeasure.org#cGy
-        `;
+        `);
 
         const result = importSingleText(input, 'UselessUnits.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
         const expectedCode = new FshCode('cGy', 'http://unitsofmeasure.org')
-          .withLocation([4, 27, 4, 55])
+          .withLocation([4, 19, 4, 47])
           .withFile('UselessUnits.fsh');
         assertAssignmentRule(profile.rules[0], 'valueQuantity', expectedCode);
       });
 
       it('should log an error when parsing an assigned value FSHCode rule using the unit keyword', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueQuantity units = http://unitsofmeasure.org#cGy
-        `;
+        `);
 
         const result = importSingleText(input, 'Deprecated.fsh');
         const profile = result.profiles.get('ObservationProfile');
@@ -1092,32 +1093,32 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value Quantity rule', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueQuantity = 1.5 'mm'
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
         const expectedQuantity = new FshQuantity(
           1.5,
-          new FshCode('mm', 'http://unitsofmeasure.org').withLocation([5, 31, 5, 34]).withFile('')
+          new FshCode('mm', 'http://unitsofmeasure.org').withLocation([5, 23, 5, 26]).withFile('')
         )
-          .withLocation([5, 27, 5, 34])
+          .withLocation([5, 19, 5, 26])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueQuantity', expectedQuantity);
       });
 
       it('should parse assigned value Quantity rule with unit display', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueQuantity = 155.0 '[lb_av]' "lb"
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1125,21 +1126,21 @@ describe('FSHImporter', () => {
         const expectedQuantity = new FshQuantity(
           155.0,
           new FshCode('[lb_av]', 'http://unitsofmeasure.org', 'lb')
-            .withLocation([5, 33, 5, 41])
+            .withLocation([5, 25, 5, 33])
             .withFile('')
         )
-          .withLocation([5, 27, 5, 46])
+          .withLocation([5, 19, 5, 38])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueQuantity', expectedQuantity);
       });
 
       it('should parse assigned value Ratio rule', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueRatio = 130 'mg' : 1 'dL'
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1147,54 +1148,54 @@ describe('FSHImporter', () => {
         const expectedRatio = new FshRatio(
           new FshQuantity(
             130,
-            new FshCode('mg', 'http://unitsofmeasure.org').withLocation([5, 28, 5, 31]).withFile('')
+            new FshCode('mg', 'http://unitsofmeasure.org').withLocation([5, 20, 5, 23]).withFile('')
           )
-            .withLocation([5, 24, 5, 31])
+            .withLocation([5, 16, 5, 23])
             .withFile(''),
           new FshQuantity(
             1,
-            new FshCode('dL', 'http://unitsofmeasure.org').withLocation([5, 37, 5, 40]).withFile('')
+            new FshCode('dL', 'http://unitsofmeasure.org').withLocation([5, 29, 5, 32]).withFile('')
           )
-            .withLocation([5, 35, 5, 40])
+            .withLocation([5, 27, 5, 32])
             .withFile('')
         )
-          .withLocation([5, 24, 5, 40])
+          .withLocation([5, 16, 5, 32])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse assigned value Ratio rule w/ numeric numerator', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueRatio = 130 : 1 'dL'
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
         const expectedRatio = new FshRatio(
-          new FshQuantity(130).withLocation([5, 24, 5, 26]).withFile(''),
+          new FshQuantity(130).withLocation([5, 16, 5, 18]).withFile(''),
           new FshQuantity(
             1,
-            new FshCode('dL', 'http://unitsofmeasure.org').withLocation([5, 32, 5, 35]).withFile('')
+            new FshCode('dL', 'http://unitsofmeasure.org').withLocation([5, 24, 5, 27]).withFile('')
           )
-            .withLocation([5, 30, 5, 35])
+            .withLocation([5, 22, 5, 27])
             .withFile('')
         )
-          .withLocation([5, 24, 5, 35])
+          .withLocation([5, 16, 5, 27])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse assigned value Ratio rule w/ numeric denominator', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueRatio = 130 'mg' : 1
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1202,63 +1203,63 @@ describe('FSHImporter', () => {
         const expectedRatio = new FshRatio(
           new FshQuantity(
             130,
-            new FshCode('mg', 'http://unitsofmeasure.org').withLocation([5, 28, 5, 31]).withFile('')
+            new FshCode('mg', 'http://unitsofmeasure.org').withLocation([5, 20, 5, 23]).withFile('')
           )
-            .withLocation([5, 24, 5, 31])
+            .withLocation([5, 16, 5, 23])
             .withFile(''),
-          new FshQuantity(1).withLocation([5, 35, 5, 35]).withFile('')
+          new FshQuantity(1).withLocation([5, 27, 5, 27]).withFile('')
         )
-          .withLocation([5, 24, 5, 35])
+          .withLocation([5, 16, 5, 27])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse assigned value Ratio rule w/ numeric numerator and denominator', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueRatio = 130 : 1
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
         const expectedRatio = new FshRatio(
-          new FshQuantity(130).withLocation([5, 24, 5, 26]).withFile(''),
-          new FshQuantity(1).withLocation([5, 30, 5, 30]).withFile('')
+          new FshQuantity(130).withLocation([5, 16, 5, 18]).withFile(''),
+          new FshQuantity(1).withLocation([5, 22, 5, 22]).withFile('')
         )
-          .withLocation([5, 24, 5, 30])
+          .withLocation([5, 16, 5, 22])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse assigned value Reference rule', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * basedOn = Reference(fooProfile)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedReference = new FshReference('fooProfile')
-          .withLocation([5, 21, 5, 41])
+          .withLocation([5, 13, 5, 33])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'basedOn', expectedReference);
       });
 
       it('should parse assigned value Reference rules while allowing and translating aliases', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: FOO = http://hl7.org/fhir/StructureDefinition/Foo
 
         Profile: ObservationProfile
         Parent: Observation
         * basedOn = Reference(FOO) "bar"
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1268,61 +1269,61 @@ describe('FSHImporter', () => {
           'http://hl7.org/fhir/StructureDefinition/Foo',
           'bar'
         )
-          .withLocation([6, 21, 6, 40])
+          .withLocation([6, 13, 6, 32])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'basedOn', expectedReference);
       });
 
       it('should parse assigned value Reference rule with a display string', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * basedOn = Reference(fooProfile) "bar"
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedReference = new FshReference('fooProfile', 'bar')
-          .withLocation([5, 21, 5, 47])
+          .withLocation([5, 13, 5, 39])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'basedOn', expectedReference);
       });
 
       it('should parse assigned value Reference rule with whitespace', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * basedOn = Reference(   fooProfile   )
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedReference = new FshReference('fooProfile')
-          .withLocation([5, 21, 5, 47])
+          .withLocation([5, 13, 5, 39])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'basedOn', expectedReference);
       });
 
       it('should log an error when an assigned value Reference rule has a choice of references', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * basedOn = Reference(cakeProfile or pieProfile)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedReference = new FshReference('cakeProfile')
-          .withLocation([5, 21, 5, 56])
+          .withLocation([5, 13, 5, 48])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'basedOn', expectedReference);
         expect(loggerSpy.getLastMessage('error')).toMatch(
@@ -1331,7 +1332,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value using Canonical', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: Example
         * #first
         * #second
@@ -1339,20 +1340,20 @@ describe('FSHImporter', () => {
         Profile: ObservationProfile
         Parent: Observation
         * code.coding.system = Canonical(Example)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedCanonical = new FshCanonical('Example')
-          .withLocation([8, 32, 8, 49])
+          .withLocation([8, 24, 8, 41])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'code.coding.system', expectedCanonical);
       });
 
       it('should parse assigned value using Canonical with spaces around entity name', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: SpaceyExample
         * #first
         * #second
@@ -1360,20 +1361,20 @@ describe('FSHImporter', () => {
         Profile: ObservationProfile
         Parent: Observation
         * code.coding.system = Canonical(   SpaceyExample )
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedCanonical = new FshCanonical('SpaceyExample') // No spaces are included in the entityName
-          .withLocation([8, 32, 8, 59])
+          .withLocation([8, 24, 8, 51])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'code.coding.system', expectedCanonical);
       });
 
       it('should parse assigned value using Canonical with a version', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: Example
         * #first
         * #second
@@ -1381,21 +1382,21 @@ describe('FSHImporter', () => {
         Profile: ObservationProfile
         Parent: Observation
         * code.coding.system = Canonical(Example|1.2.3)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedCanonical = new FshCanonical('Example')
-          .withLocation([8, 32, 8, 55])
+          .withLocation([8, 24, 8, 47])
           .withFile('');
         expectedCanonical.version = '1.2.3';
         assertAssignmentRule(profile.rules[0], 'code.coding.system', expectedCanonical);
       });
 
       it('should parse assigned value using Canonical with a version which contains a |', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: Example
         * #first
         * #second
@@ -1403,21 +1404,21 @@ describe('FSHImporter', () => {
         Profile: ObservationProfile
         Parent: Observation
         * code.coding.system = Canonical(  Example|1.2.3|aWeirdVersion  )
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedCanonical = new FshCanonical('Example')
-          .withLocation([8, 32, 8, 73])
+          .withLocation([8, 24, 8, 65])
           .withFile('');
         expectedCanonical.version = '1.2.3|aWeirdVersion';
         assertAssignmentRule(profile.rules[0], 'code.coding.system', expectedCanonical);
       });
 
       it('should log an error when an assigned value Canonical rule has a choice of canonicals', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: Example
         * #first
         * #second
@@ -1425,14 +1426,14 @@ describe('FSHImporter', () => {
         Profile: ObservationProfile
         Parent: Observation
         * code.coding.system = Canonical(Example or OtherExample)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedCanonical = new FshCanonical('Example')
-          .withLocation([8, 32, 8, 65])
+          .withLocation([8, 24, 8, 57])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'code.coding.system', expectedCanonical);
         expect(loggerSpy.getLastMessage('error')).toMatch(
@@ -1441,13 +1442,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned values that are an alias', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: EXAMPLE = http://example.org
 
         Profile: PatientProfile
         Parent: Patient
         * identifier.system = EXAMPLE
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('PatientProfile');
@@ -1456,12 +1457,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an assigned value Resource rule', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * contained[0] = SomeInstance
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1472,11 +1473,11 @@ describe('FSHImporter', () => {
 
     describe('#onlyRule', () => {
       it('should parse an only rule with one type', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * value[x] only Quantity
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1485,11 +1486,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with multiple types', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * value[x] only Quantity or CodeableConcept or string
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1504,11 +1505,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with one numeric type name', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * value[x] only 123
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1517,11 +1518,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with multiple numeric type names', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * value[x] only 123 or 456 or 789
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1536,11 +1537,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with a reference to one type', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * performer only Reference(Practitioner)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1549,11 +1550,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with a reference to multiple types', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * performer only Reference(Organization or CareTeam)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1567,11 +1568,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with a reference to multiple types with whitespace', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * performer only Reference(   Organization    or  CareTeam)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1585,11 +1586,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with a canonical to one type', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: PlanDefinitionProfile
         Parent: PlanDefinition
         * action.definition[x] only Canonical(ActivityDefinition)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('PlanDefinitionProfile');
@@ -1601,11 +1602,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with a canonical to multiple types', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: PlanDefinitionProfile
         Parent: PlanDefinition
         * action.definition[x] only Canonical(ActivityDefinition or PlanDefinition)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('PlanDefinitionProfile');
@@ -1619,11 +1620,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with a canonical to multiple types with whitespace', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: PlanDefinitionProfile
         Parent: PlanDefinition
         * action.definition[x] only Canonical(     ActivityDefinition   or    PlanDefinition    )
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('PlanDefinitionProfile');
@@ -1637,11 +1638,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with a canonical to multiple types with versions', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: PlanDefinitionProfile
         Parent: PlanDefinition
         * action.definition[x] only Canonical(ActivityDefinition|4.0.1 or PlanDefinition|4.0.1)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('PlanDefinitionProfile');
@@ -1655,14 +1656,14 @@ describe('FSHImporter', () => {
       });
 
       it('should allow and translate aliases for only types', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: QUANTITY = http://hl7.org/fhir/StructureDefinition/Quantity
         Alias: CODING = http://hl7.org/fhir/StructureDefinition/Coding
 
         Profile: ObservationProfile
         Parent: Observation
         * value[x] only CodeableConcept or CODING or string or QUANTITY
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1678,11 +1679,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when references are listed with pipes', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * performer only Reference(Organization | CareTeam)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1693,11 +1694,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when references are listed with pipes with whitespace', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * performer only Reference(   Organization  |   CareTeam)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1710,11 +1711,11 @@ describe('FSHImporter', () => {
 
     describe('#containsRule', () => {
       it('should parse contains rule with one item', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * component contains SystolicBP 1..1
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1724,12 +1725,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rule with one item declaring an aliased type', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: OffsetExtension = http://hl7.org/fhir/StructureDefinition/observation-timeOffset
         Profile: ObservationProfile
         Parent: Observation
         * component.extension contains OffsetExtension named offset 0..1
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1742,7 +1743,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rule with one item declaring an FSH extension type', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * component.extension contains ComponentExtension named compext 0..1
@@ -1750,7 +1751,7 @@ describe('FSHImporter', () => {
         Extension: ComponentExtension
         Id: component-extension
         * value[x] only CodeableConcept
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1763,11 +1764,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rules with multiple items', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * component contains SystolicBP 1..1 and DiastolicBP 2..*
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1778,7 +1779,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rule with mutliple items, some declaring types', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: FocusCodeExtension = http://hl7.org/fhir/StructureDefinition/observation-focusCode
         Alias: PreconditionExtension = http://hl7.org/fhir/StructureDefinition/observation-precondition
         Profile: ObservationProfile
@@ -1788,7 +1789,7 @@ describe('FSHImporter', () => {
             FocusCodeExtension named focus 1..1 and
             bar 0..* and
             PreconditionExtension named pc 1..*
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1814,11 +1815,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rules with flags', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * component contains SystolicBP 1..1 MS D and DiastolicBP 2..* MS SU
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1849,12 +1850,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rule with item declaring a type and flags', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: OffsetExtension = http://hl7.org/fhir/StructureDefinition/observation-timeOffset
         Profile: ObservationProfile
         Parent: Observation
         * component.extension contains OffsetExtension named offset 0..1 MS TU
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1879,13 +1880,13 @@ describe('FSHImporter', () => {
 
     describe('#caretValueRule', () => {
       it('should parse caret value rules with no path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * ^description = "foo"
         * ^experimental = false
         * ^keyword[0] = foo#bar "baz"
-        `;
+        `);
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         assertCaretValueRule(profile.rules[0], '', 'description', 'foo', false);
@@ -1894,30 +1895,30 @@ describe('FSHImporter', () => {
           profile.rules[2],
           '',
           'keyword[0]',
-          new FshCode('bar', 'foo', 'baz').withLocation([6, 25, 6, 37]).withFile(''),
+          new FshCode('bar', 'foo', 'baz').withLocation([6, 17, 6, 29]).withFile(''),
           false
         );
       });
 
       it('should parse caret value rules with a . path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * . ^definition = "foo"
-        `;
+        `);
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         assertCaretValueRule(profile.rules[0], '.', 'definition', 'foo', false, ['.']);
       });
 
       it('should parse caret value rules with a path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * status ^short = "foo"
         * status ^sliceIsConstraining = false
         * status ^code[0] = foo#bar "baz"
-        `;
+        `);
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         assertCaretValueRule(profile.rules[0], 'status', 'short', 'foo', false);
@@ -1926,28 +1927,28 @@ describe('FSHImporter', () => {
           profile.rules[2],
           'status',
           'code[0]',
-          new FshCode('bar', 'foo', 'baz').withLocation([6, 29, 6, 41]).withFile(''),
+          new FshCode('bar', 'foo', 'baz').withLocation([6, 21, 6, 33]).withFile(''),
           false
         );
       });
 
       it('should not include non-breaking spaces as part of the caret path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * status ^short\u00A0= "Non-breaking"
-        `;
+        `);
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         assertCaretValueRule(profile.rules[0], 'status', 'short', 'Non-breaking', false);
       });
 
       it('should add resources to the contained array using a CaretValueRule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * ^contained = myResource
-        `;
+        `);
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         assertCaretValueRule(profile.rules[0], '', 'contained', 'myResource', true);
@@ -1956,11 +1957,11 @@ describe('FSHImporter', () => {
 
     describe('#obeysRule', () => {
       it('should parse an obeys rule with one invariant and no path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * obeys SomeInvariant
-        `;
+        `);
         const result = importSingleText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
@@ -1968,11 +1969,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an obeys rule with one invariant and a path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category obeys SomeInvariant
-        `;
+        `);
         const result = importSingleText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
@@ -1980,11 +1981,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an obeys rule with multiple invariants and no path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * obeys SomeInvariant and ThisInvariant and ThatInvariant
-        `;
+        `);
         const result = importSingleText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(3);
@@ -1994,11 +1995,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an obeys rule with multiple invariants and a path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category obeys SomeInvariant and ThisInvariant and ThatInvariant
-        `;
+        `);
         const result = importSingleText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(3);
@@ -2008,11 +2009,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an obeys rule with a numeric invariant name', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * obeys 123
-        `;
+        `);
         const result = importSingleText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
@@ -2022,11 +2023,11 @@ describe('FSHImporter', () => {
 
     describe('#pathRule', () => {
       it('should parse a pathRule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: PatientProfile
         Parent: Patient
         * name
-        `;
+        `);
         const result = importSingleText(input, 'Path.fsh');
         const profile = result.profiles.get('PatientProfile');
         expect(profile.rules).toHaveLength(0);
@@ -2141,11 +2142,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with a single RuleSet', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MyRuleSet
-        `;
+        `);
         const result = importSingleText(input, 'Insert.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
@@ -2153,11 +2154,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with a single RuleSet and a path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * code insert MyRuleSet
-        `;
+        `);
         const result = importSingleText(input, 'Insert.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
@@ -2165,11 +2166,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with a RuleSet with one parameter', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert OneParamRuleSet (#final)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -2202,11 +2203,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with a RuleSet with one parameter and a path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * code insert OneParamRuleSet (#final)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -2239,11 +2240,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with a RuleSet with multiple parameters', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MultiParamRuleSet (#preliminary, "this is a string value\\, right?", 4)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -2301,11 +2302,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with a parameter that contains right parenthesis', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert OneParamRuleSet (#final "(Final\\)")
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -2339,11 +2340,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with parameters that contain newline, tab, or backslash characters', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MultiParamRuleSet (#final, "very\\nstrange\\rvalue\\\\\\tindeed", 1)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -2392,7 +2393,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule that separates its parameters onto multiple lines', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MultiParamRuleSet (
@@ -2400,7 +2401,7 @@ describe('FSHImporter', () => {
           "string value",
           7
         )
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -2438,12 +2439,12 @@ describe('FSHImporter', () => {
       });
 
       it('should generate a RuleSet only once when inserted with the same parameters multiple times in the same document', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MultiParamRuleSet (#preliminary, "something", 3)
         * insert MultiParamRuleSet (#preliminary, "something", 3)
-        `;
+        `);
         const visitDocSpy = jest.spyOn(importer, 'visitDoc');
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -2469,11 +2470,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with parameters that will use the same RuleSet more than once with different parameters each time', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert EntryRules (Recursive)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -2542,11 +2543,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error and not add a rule when an insert rule has the wrong number of parameters', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert OneParamRuleSet (#final, "Final")
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         const doc = allDocs[0];
         const profile = doc.profiles.get('ObservationProfile');
@@ -2558,11 +2559,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error and not add a rule when an insert rule with parameters refers to an undefined parameterized RuleSet', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MysteriousRuleSet ("mystery")
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         const doc = allDocs[0];
         const profile = doc.profiles.get('ObservationProfile');
@@ -2574,11 +2575,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when an insert rule with parameters results in a parser error in the generated RuleSet', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: MyObservation
         Parent: Observation
         * insert CardRuleSet(path with spaces, 1, *)
-        `;
+        `);
         importer.import([new RawFSH(input, 'Insert.fsh')]);
 
         expect(stats.numError).toBe(1);
@@ -2589,12 +2590,12 @@ describe('FSHImporter', () => {
       });
 
       it('should log one error when nested insert rules with parameters result in multiple parser errors in the generated RuleSets', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: MyObservation
         Parent: Observation
         * note 0..1
         * insert FirstRiskyRuleSet("Observation.id")
-        `;
+        `);
         importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(stats.numError).toBe(1);
         expect(loggerSpy.getLastMessage('error')).toMatch(
@@ -2604,11 +2605,11 @@ describe('FSHImporter', () => {
       });
 
       it('should not log an error when an insert rule with parameters results in rules that are syntactically correct but semantically invalid', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: MyObservation
         Parent: Observation
         * insert CardRuleSet(nonExistentPath, 7, 4)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(allDocs).toHaveLength(1);
         const doc = allDocs[0];
@@ -2637,11 +2638,11 @@ describe('FSHImporter', () => {
       // All deprecated syntaxes are now errors (not warnings).  We can re-enable if/when the importer
       // produces warnings on rules.
       it.skip('should log one warning when an insert rule with parameters results in warnings', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: MyObservation
         Parent: Observation
         * insert WarningRuleSet(Device)
-        `;
+        `);
         importer.import([new RawFSH(input, 'Insert.fsh')]);
 
         expect(stats.numWarn).toBe(1);
@@ -2652,11 +2653,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log one error when an insert rule with parameters results in non-parser errors', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: MyObservation
         Parent: Observation
         * insert CardRuleSet(nonExistentPath, , )
-        `;
+        `);
         importer.import([new RawFSH(input, 'Insert.fsh')]);
 
         expect(stats.numError).toBe(1);

--- a/test/import/FSHImporter.Resource.test.ts
+++ b/test/import/FSHImporter.Resource.test.ts
@@ -13,6 +13,7 @@ import {
   assertOnlyRule
 } from '../testhelpers';
 import { FshCode } from '../../src/fshtypes';
+import { leftAlign } from '../utils/leftAlign';
 
 describe('FSHImporter', () => {
   describe('Resource', () => {
@@ -44,10 +45,10 @@ describe('FSHImporter', () => {
 
         // Since we'll do the same thing over and over (and over), create a function for it
         const testToken = (token: string) => {
-          const input = `
+          const input = leftAlign(`
           Resource: ${token}
           * value[x] only boolean
-          `;
+          `);
           const result = importSingleText(input);
           expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
           expect(result).toBeDefined();

--- a/test/import/FSHImporter.RuleSet.test.ts
+++ b/test/import/FSHImporter.RuleSet.test.ts
@@ -12,6 +12,7 @@ import {
 import { loggerSpy } from '../testhelpers/loggerSpy';
 import { Rule, ConceptRule } from '../../src/fshtypes/rules';
 import { FshCode } from '../../src/fshtypes';
+import { leftAlign } from '../utils/leftAlign';
 
 describe('FSHImporter', () => {
   beforeEach(() => {
@@ -219,11 +220,11 @@ describe('FSHImporter', () => {
     });
 
     it('should not log an error when the ConceptRule has one code with a system, no definition, and no hierarchy', () => {
-      const input = `
+      const input = leftAlign(`
       RuleSet: VSRuleSet
       * ZOO#bear
       * ZOO#gator "Alligator"
-      `;
+      `);
       const result = importSingleText(input, 'VSRules.fsh');
       expect(result.ruleSets.size).toBe(1);
       const ruleSet = result.ruleSets.get('VSRuleSet');

--- a/test/import/FSHImporter.SDRules.test.ts
+++ b/test/import/FSHImporter.SDRules.test.ts
@@ -23,6 +23,7 @@ import { stats } from '../../src/utils/FSHLogger';
 import { importSingleText } from '../testhelpers/importSingleText';
 import { FSHImporter, RawFSH } from '../../src/import';
 import { EOL } from 'os';
+import { leftAlign } from '../utils/leftAlign';
 
 describe('FSHImporter', () => {
   beforeEach(() => loggerSpy.reset());
@@ -35,13 +36,13 @@ describe('FSHImporter', () => {
     // smoke tests.
     describe('#cardRule', () => {
       it('should parse simple card rules', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category 1..5
         * value[x] 1..1
         * component 2..*
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -52,11 +53,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse card rule with only min', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category 1..
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -65,11 +66,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse card rule with only max', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category ..5
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -78,11 +79,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error if neither side is specified', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category ..
-        `;
+        `);
 
         const result = importSingleText(input, 'BadCard.fsh');
         const profile = result.profiles.get('ObservationProfile');
@@ -94,7 +95,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse card rules w/ flags', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category 1..5 MS
@@ -103,7 +104,7 @@ describe('FSHImporter', () => {
         * interpretation 1..* TU
         * note 0..11 N
         * bodySite 1..1 D
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -177,13 +178,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse card rules w/ multiple flags', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category 1..5 MS ?! TU
         * value[x] 1..1 ?! SU N
         * component 2..* SU MS D
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -226,7 +227,7 @@ describe('FSHImporter', () => {
 
     describe('#flagRule', () => {
       it('should parse single-path single-value flag rules', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category MS
@@ -235,7 +236,7 @@ describe('FSHImporter', () => {
         * interpretation TU
         * note N
         * bodySite D
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -303,13 +304,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse single-path multi-value flag rules', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category MS ?! N
         * value[x] ?! SU D
         * component MS SU ?! TU
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -338,13 +339,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse multi-path single-value flag rules', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category and value[x] and component MS
         * subject and focus ?!
         * interpretation and note N
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -422,12 +423,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse multi-path multi-value flag rules', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category and value[x] and component MS SU N
         * subject and focus ?! SU TU
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -485,11 +486,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when paths are listed with commas', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category, value[x] , component MS SU N
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -503,14 +504,14 @@ describe('FSHImporter', () => {
 
     describe('#BindingRule', () => {
       it('should parse value set rules w/ names and strengths', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category from CategoryValueSet (required)
         * code from CodeValueSet (extensible)
         * valueCodeableConcept from ValueValueSet (preferred)
         * component.code from ComponentCodeValueSet (example)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -522,14 +523,14 @@ describe('FSHImporter', () => {
       });
 
       it('should parse value set rules w/ urls and strengths', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category from http://example.org/fhir/ValueSet/CategoryValueSet (required)
         * code from http://example.org/fhir/ValueSet/CodeValueSet (extensible)
         * valueCodeableConcept from http://example.org/fhir/ValueSet/ValueValueSet (preferred)
         * component.code from http://example.org/fhir/ValueSet/ComponentCodeValueSet (example)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -561,7 +562,7 @@ describe('FSHImporter', () => {
       });
 
       it('should accept and translate aliases for value set URLs', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: CAT = http://example.org/fhir/ValueSet/CategoryValueSet
         Alias: CODE = http://example.org/fhir/ValueSet/CodeValueSet
         Alias: VALUE = http://example.org/fhir/ValueSet/ValueValueSet
@@ -573,7 +574,7 @@ describe('FSHImporter', () => {
         * code from CODE (extensible)
         * valueCodeableConcept from VALUE (preferred)
         * component.code from COMP (example)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -605,12 +606,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse value set rules w/ numeric names', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category from 123 (required)
         * code from 456 (extensible)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -620,12 +621,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse value set rules w/ no strength and default to required', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category from CategoryValueSet
         * code from http://example.org/fhir/ValueSet/CodeValueSet
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -640,11 +641,11 @@ describe('FSHImporter', () => {
       });
 
       it('should ignore the units keyword and log an error when parsing value set rules on Quantity', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueQuantity units from http://unitsofmeasure.org
-        `;
+        `);
 
         const result = importSingleText(input, 'UselessQuant.fsh');
         const profile = result.profiles.get('ObservationProfile');
@@ -658,11 +659,11 @@ describe('FSHImporter', () => {
 
     describe('#assignmentRule', () => {
       it('should parse assigned value boolean rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueBoolean = true
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -671,11 +672,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value boolean rule with (exactly) modifier', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueBoolean = true (exactly)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -684,11 +685,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value number (decimal) rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueDecimal = 1.23
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -697,11 +698,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value number (integer) rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueInteger = 123
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -710,11 +711,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value string rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueString = "hello world"
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -723,14 +724,14 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value multi-line string rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueString = """
             hello
             world
             """
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -739,11 +740,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value date rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueDateTime = 2019-11-01T12:30:01.999Z
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -753,11 +754,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value time rule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueTime = 12:30:01.999-05:00
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -767,29 +768,29 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value code rule', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: LOINC = http://loinc.org
 
         Profile: ObservationProfile
         Parent: Observation
         * status = #final
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
-        const expectedCode = new FshCode('final').withLocation([6, 20, 6, 25]).withFile('');
+        const expectedCode = new FshCode('final').withLocation([6, 12, 6, 17]).withFile('');
         assertAssignmentRule(profile.rules[0], 'status', expectedCode);
       });
 
       it('should parse assigned value CodeableConcept rule', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: LOINC = http://loinc.org
 
         Profile: ObservationProfile
         Parent: Observation
         * valueCodeableConcept = LOINC#718-7 "Hemoglobin [Mass/volume] in Blood"
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -799,19 +800,19 @@ describe('FSHImporter', () => {
           'http://loinc.org',
           'Hemoglobin [Mass/volume] in Blood'
         )
-          .withLocation([6, 34, 6, 80])
+          .withLocation([6, 26, 6, 72])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueCodeableConcept', expectedCode);
       });
 
       it('should parse assigned value CodeableConcept rule with (exactly) modifier', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: LOINC = http://loinc.org
 
         Profile: ObservationProfile
         Parent: Observation
         * valueCodeableConcept = LOINC#718-7 "Hemoglobin [Mass/volume] in Blood" (exactly)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -821,17 +822,17 @@ describe('FSHImporter', () => {
           'http://loinc.org',
           'Hemoglobin [Mass/volume] in Blood'
         )
-          .withLocation([6, 34, 6, 80])
+          .withLocation([6, 26, 6, 72])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueCodeableConcept', expectedCode, true);
       });
 
       it('should ignore the units keyword and log a warning when parsing an assigned value FSHCode rule with units on Quantity', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * valueQuantity units = http://unitsofmeasure.org#cGy
-        `;
+        `);
 
         const result = importSingleText(input, 'UselessUnits.fsh');
         const profile = result.profiles.get('ObservationProfile');
@@ -843,32 +844,32 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value Quantity rule', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueQuantity = 1.5 'mm'
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
         const expectedQuantity = new FshQuantity(
           1.5,
-          new FshCode('mm', 'http://unitsofmeasure.org').withLocation([5, 31, 5, 34]).withFile('')
+          new FshCode('mm', 'http://unitsofmeasure.org').withLocation([5, 23, 5, 26]).withFile('')
         )
-          .withLocation([5, 27, 5, 34])
+          .withLocation([5, 19, 5, 26])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueQuantity', expectedQuantity);
       });
 
       it('should parse assigned value Quantity rule with unit display', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueQuantity = 155.0 '[lb_av]' "lb"
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -876,21 +877,21 @@ describe('FSHImporter', () => {
         const expectedQuantity = new FshQuantity(
           155.0,
           new FshCode('[lb_av]', 'http://unitsofmeasure.org', 'lb')
-            .withLocation([5, 33, 5, 41])
+            .withLocation([5, 25, 5, 33])
             .withFile('')
         )
-          .withLocation([5, 27, 5, 46])
+          .withLocation([5, 19, 5, 38])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueQuantity', expectedQuantity);
       });
 
       it('should parse assigned value Ratio rule', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueRatio = 130 'mg' : 1 'dL'
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -898,54 +899,54 @@ describe('FSHImporter', () => {
         const expectedRatio = new FshRatio(
           new FshQuantity(
             130,
-            new FshCode('mg', 'http://unitsofmeasure.org').withLocation([5, 28, 5, 31]).withFile('')
+            new FshCode('mg', 'http://unitsofmeasure.org').withLocation([5, 20, 5, 23]).withFile('')
           )
-            .withLocation([5, 24, 5, 31])
+            .withLocation([5, 16, 5, 23])
             .withFile(''),
           new FshQuantity(
             1,
-            new FshCode('dL', 'http://unitsofmeasure.org').withLocation([5, 37, 5, 40]).withFile('')
+            new FshCode('dL', 'http://unitsofmeasure.org').withLocation([5, 29, 5, 32]).withFile('')
           )
-            .withLocation([5, 35, 5, 40])
+            .withLocation([5, 27, 5, 32])
             .withFile('')
         )
-          .withLocation([5, 24, 5, 40])
+          .withLocation([5, 16, 5, 32])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse assigned value Ratio rule w/ numeric numerator', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueRatio = 130 : 1 'dL'
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
         const expectedRatio = new FshRatio(
-          new FshQuantity(130).withLocation([5, 24, 5, 26]).withFile(''),
+          new FshQuantity(130).withLocation([5, 16, 5, 18]).withFile(''),
           new FshQuantity(
             1,
-            new FshCode('dL', 'http://unitsofmeasure.org').withLocation([5, 32, 5, 35]).withFile('')
+            new FshCode('dL', 'http://unitsofmeasure.org').withLocation([5, 24, 5, 27]).withFile('')
           )
-            .withLocation([5, 30, 5, 35])
+            .withLocation([5, 22, 5, 27])
             .withFile('')
         )
-          .withLocation([5, 24, 5, 35])
+          .withLocation([5, 16, 5, 27])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse assigned value Ratio rule w/ numeric denominator', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueRatio = 130 'mg' : 1
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -953,63 +954,63 @@ describe('FSHImporter', () => {
         const expectedRatio = new FshRatio(
           new FshQuantity(
             130,
-            new FshCode('mg', 'http://unitsofmeasure.org').withLocation([5, 28, 5, 31]).withFile('')
+            new FshCode('mg', 'http://unitsofmeasure.org').withLocation([5, 20, 5, 23]).withFile('')
           )
-            .withLocation([5, 24, 5, 31])
+            .withLocation([5, 16, 5, 23])
             .withFile(''),
-          new FshQuantity(1).withLocation([5, 35, 5, 35]).withFile('')
+          new FshQuantity(1).withLocation([5, 27, 5, 27]).withFile('')
         )
-          .withLocation([5, 24, 5, 35])
+          .withLocation([5, 16, 5, 27])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse assigned value Ratio rule w/ numeric numerator and denominator', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * valueRatio = 130 : 1
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
         const expectedRatio = new FshRatio(
-          new FshQuantity(130).withLocation([5, 24, 5, 26]).withFile(''),
-          new FshQuantity(1).withLocation([5, 30, 5, 30]).withFile('')
+          new FshQuantity(130).withLocation([5, 16, 5, 18]).withFile(''),
+          new FshQuantity(1).withLocation([5, 22, 5, 22]).withFile('')
         )
-          .withLocation([5, 24, 5, 30])
+          .withLocation([5, 16, 5, 22])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse assigned value Reference rule', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * basedOn = Reference(fooProfile)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedReference = new FshReference('fooProfile')
-          .withLocation([5, 21, 5, 41])
+          .withLocation([5, 13, 5, 33])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'basedOn', expectedReference);
       });
 
       it('should parse assigned value Reference rules while allowing and translating aliases', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: FOO = http://hl7.org/fhir/StructureDefinition/Foo
 
         Profile: ObservationProfile
         Parent: Observation
         * basedOn = Reference(FOO) "bar"
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1019,61 +1020,61 @@ describe('FSHImporter', () => {
           'http://hl7.org/fhir/StructureDefinition/Foo',
           'bar'
         )
-          .withLocation([6, 21, 6, 40])
+          .withLocation([6, 13, 6, 32])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'basedOn', expectedReference);
       });
 
       it('should parse assigned value Reference rule with a display string', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * basedOn = Reference(fooProfile) "bar"
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedReference = new FshReference('fooProfile', 'bar')
-          .withLocation([5, 21, 5, 47])
+          .withLocation([5, 13, 5, 39])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'basedOn', expectedReference);
       });
 
       it('should parse assigned value Reference rule with whitespace', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * basedOn = Reference(   fooProfile   )
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedReference = new FshReference('fooProfile')
-          .withLocation([5, 21, 5, 47])
+          .withLocation([5, 13, 5, 39])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'basedOn', expectedReference);
       });
 
       it('should log an error when an assigned value Reference rule has a choice of references', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * basedOn = Reference(cakeProfile or pieProfile)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedReference = new FshReference('cakeProfile')
-          .withLocation([5, 21, 5, 56])
+          .withLocation([5, 13, 5, 48])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'basedOn', expectedReference);
         expect(loggerSpy.getLastMessage('error')).toMatch(
@@ -1082,7 +1083,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse assigned value using Canonical', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: Example
         * #first
         * #second
@@ -1090,20 +1091,20 @@ describe('FSHImporter', () => {
         Profile: ObservationProfile
         Parent: Observation
         * code.coding.system = Canonical(Example)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedCanonical = new FshCanonical('Example')
-          .withLocation([8, 32, 8, 49])
+          .withLocation([8, 24, 8, 41])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'code.coding.system', expectedCanonical);
       });
 
       it('should parse assigned value using Canonical with spaces around entity name', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: SpaceyExample
         * #first
         * #second
@@ -1111,20 +1112,20 @@ describe('FSHImporter', () => {
         Profile: ObservationProfile
         Parent: Observation
         * code.coding.system = Canonical(   SpaceyExample )
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedCanonical = new FshCanonical('SpaceyExample') // No spaces are included in the entityName
-          .withLocation([8, 32, 8, 59])
+          .withLocation([8, 24, 8, 51])
           .withFile('');
         assertAssignmentRule(profile.rules[0], 'code.coding.system', expectedCanonical);
       });
 
       it('should parse assigned value using Canonical with a version', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: Example
         * #first
         * #second
@@ -1132,21 +1133,21 @@ describe('FSHImporter', () => {
         Profile: ObservationProfile
         Parent: Observation
         * code.coding.system = Canonical(Example|1.2.3)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedCanonical = new FshCanonical('Example')
-          .withLocation([8, 32, 8, 55])
+          .withLocation([8, 24, 8, 47])
           .withFile('');
         expectedCanonical.version = '1.2.3';
         assertAssignmentRule(profile.rules[0], 'code.coding.system', expectedCanonical);
       });
 
       it('should parse assigned value using Canonical with a version which contains a |', () => {
-        const input = `
+        const input = leftAlign(`
         CodeSystem: Example
         * #first
         * #second
@@ -1154,27 +1155,27 @@ describe('FSHImporter', () => {
         Profile: ObservationProfile
         Parent: Observation
         * code.coding.system = Canonical(  Example|1.2.3|aWeirdVersion  )
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
 
         const expectedCanonical = new FshCanonical('Example')
-          .withLocation([8, 32, 8, 73])
+          .withLocation([8, 24, 8, 65])
           .withFile('');
         expectedCanonical.version = '1.2.3|aWeirdVersion';
         assertAssignmentRule(profile.rules[0], 'code.coding.system', expectedCanonical);
       });
 
       it('should parse assigned values that are an alias', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: EXAMPLE = http://example.org
 
         Profile: PatientProfile
         Parent: Patient
         * identifier.system = EXAMPLE
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('PatientProfile');
@@ -1183,12 +1184,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an assigned value Resource rule', () => {
-        const input = `
+        const input = leftAlign(`
 
         Profile: ObservationProfile
         Parent: Observation
         * contained[0] = SomeInstance
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1199,11 +1200,11 @@ describe('FSHImporter', () => {
 
     describe('#onlyRule', () => {
       it('should parse an only rule with one type', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * value[x] only Quantity
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1212,11 +1213,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with multiple types', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * value[x] only Quantity or CodeableConcept or string
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1231,11 +1232,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with one numeric type name', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * value[x] only 123
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1244,11 +1245,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with multiple numeric type names', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * value[x] only 123 or 456 or 789
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1263,11 +1264,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with a reference to one type', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * performer only Reference(Practitioner)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1276,11 +1277,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with a reference to multiple types', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * performer only Reference(Organization or CareTeam)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1294,11 +1295,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an only rule with a reference to multiple types with whitespace', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * performer only Reference(   Organization    or  CareTeam)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1312,14 +1313,14 @@ describe('FSHImporter', () => {
       });
 
       it('should allow and translate aliases for only types', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: QUANTITY = http://hl7.org/fhir/StructureDefinition/Quantity
         Alias: CODING = http://hl7.org/fhir/StructureDefinition/Coding
 
         Profile: ObservationProfile
         Parent: Observation
         * value[x] only CodeableConcept or CODING or string or QUANTITY
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1335,11 +1336,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when references are listed with pipes', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * performer only Reference(Organization | CareTeam)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1352,11 +1353,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when references are listed with pipes with whitespace', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * performer only Reference(   Organization  |   CareTeam)
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1371,11 +1372,11 @@ describe('FSHImporter', () => {
 
     describe('#containsRule', () => {
       it('should parse contains rule with one item', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * component contains SystolicBP 1..1
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1385,12 +1386,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rule with one item declaring an aliased type', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: OffsetExtension = http://hl7.org/fhir/StructureDefinition/observation-timeOffset
         Profile: ObservationProfile
         Parent: Observation
         * component.extension contains OffsetExtension named offset 0..1
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1403,7 +1404,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rule with one item declaring an FSH extension type', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * component.extension contains ComponentExtension named compext 0..1
@@ -1411,7 +1412,7 @@ describe('FSHImporter', () => {
         Extension: ComponentExtension
         Id: component-extension
         * value[x] only CodeableConcept
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1424,11 +1425,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rules with multiple items', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * component contains SystolicBP 1..1 and DiastolicBP 2..*
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1439,7 +1440,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rule with mutliple items, some declaring types', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: FocusCodeExtension = http://hl7.org/fhir/StructureDefinition/observation-focusCode
         Alias: PreconditionExtension = http://hl7.org/fhir/StructureDefinition/observation-precondition
         Profile: ObservationProfile
@@ -1449,7 +1450,7 @@ describe('FSHImporter', () => {
             FocusCodeExtension named focus 1..1 and
             bar 0..* and
             PreconditionExtension named pc 1..*
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1475,11 +1476,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rules with flags', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * component contains SystolicBP 1..1 MS D and DiastolicBP 2..* MS SU
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1510,12 +1511,12 @@ describe('FSHImporter', () => {
       });
 
       it('should parse contains rule with item declaring a type and flags', () => {
-        const input = `
+        const input = leftAlign(`
         Alias: OffsetExtension = http://hl7.org/fhir/StructureDefinition/observation-timeOffset
         Profile: ObservationProfile
         Parent: Observation
         * component.extension contains OffsetExtension named offset 0..1 MS TU
-        `;
+        `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
@@ -1540,13 +1541,13 @@ describe('FSHImporter', () => {
 
     describe('#caretValueRule', () => {
       it('should parse caret value rules with no path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * ^description = "foo"
         * ^experimental = false
         * ^keyword[0] = foo#bar "baz"
-        `;
+        `);
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         assertCaretValueRule(profile.rules[0], '', 'description', 'foo', false);
@@ -1555,19 +1556,19 @@ describe('FSHImporter', () => {
           profile.rules[2],
           '',
           'keyword[0]',
-          new FshCode('bar', 'foo', 'baz').withLocation([6, 25, 6, 37]).withFile(''),
+          new FshCode('bar', 'foo', 'baz').withLocation([6, 17, 6, 29]).withFile(''),
           false
         );
       });
 
       it('should parse caret value rules with a path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * status ^short = "foo"
         * status ^sliceIsConstraining = false
         * status ^code[0] = foo#bar "baz"
-        `;
+        `);
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         assertCaretValueRule(profile.rules[0], 'status', 'short', 'foo', false);
@@ -1576,28 +1577,28 @@ describe('FSHImporter', () => {
           profile.rules[2],
           'status',
           'code[0]',
-          new FshCode('bar', 'foo', 'baz').withLocation([6, 29, 6, 41]).withFile(''),
+          new FshCode('bar', 'foo', 'baz').withLocation([6, 21, 6, 33]).withFile(''),
           false
         );
       });
 
       it('should not include non-breaking spaces as part of the caret path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * status ^short\u00A0= "Non-breaking"
-        `;
+        `);
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         assertCaretValueRule(profile.rules[0], 'status', 'short', 'Non-breaking', false);
       });
 
       it('should add resources to the contained array using a CaretValueRule', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * ^contained = myResource
-        `;
+        `);
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
         assertCaretValueRule(profile.rules[0], '', 'contained', 'myResource', true);
@@ -1606,11 +1607,11 @@ describe('FSHImporter', () => {
 
     describe('#obeysRule', () => {
       it('should parse an obeys rule with one invariant and no path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * obeys SomeInvariant
-        `;
+        `);
         const result = importSingleText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
@@ -1618,11 +1619,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an obeys rule with one invariant and a path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category obeys SomeInvariant
-        `;
+        `);
         const result = importSingleText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
@@ -1630,11 +1631,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an obeys rule with multiple invariants and no path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * obeys SomeInvariant and ThisInvariant and ThatInvariant
-        `;
+        `);
         const result = importSingleText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(3);
@@ -1644,11 +1645,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an obeys rule with multiple invariants and a path', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * category obeys SomeInvariant and ThisInvariant and ThatInvariant
-        `;
+        `);
         const result = importSingleText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(3);
@@ -1658,11 +1659,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an obeys rule with a numeric invariant name', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * obeys 123
-        `;
+        `);
         const result = importSingleText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
@@ -1777,11 +1778,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with a single RuleSet', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MyRuleSet
-        `;
+        `);
         const result = importSingleText(input, 'Insert.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
@@ -1789,11 +1790,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with a RuleSet with one parameter', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert OneParamRuleSet (#final)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -1826,11 +1827,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with a RuleSet with multiple parameters', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MultiParamRuleSet (#preliminary, "this is a string value\\, right?", 4)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -1888,11 +1889,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with a parameter that contains right parenthesis', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert OneParamRuleSet (#final "(Final\\)")
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -1926,11 +1927,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with parameters that contain newline, tab, or backslash characters', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MultiParamRuleSet (#final, "very\\nstrange\\rvalue\\\\\\tindeed", 1)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -1979,7 +1980,7 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule that separates its parameters onto multiple lines', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MultiParamRuleSet (
@@ -1987,7 +1988,7 @@ describe('FSHImporter', () => {
           "string value",
           7
         )
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -2025,12 +2026,12 @@ describe('FSHImporter', () => {
       });
 
       it('should generate a RuleSet only once when inserted with the same parameters multiple times in the same document', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MultiParamRuleSet (#preliminary, "something", 3)
         * insert MultiParamRuleSet (#preliminary, "something", 3)
-        `;
+        `);
         const visitDocSpy = jest.spyOn(importer, 'visitDoc');
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -2056,11 +2057,11 @@ describe('FSHImporter', () => {
       });
 
       it('should parse an insert rule with parameters that will use the same RuleSet more than once with different parameters each time', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert EntryRules (Recursive)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
         expect(allDocs).toHaveLength(1);
@@ -2129,11 +2130,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error and not add a rule when an insert rule has the wrong number of parameters', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert OneParamRuleSet (#final, "Final")
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         const doc = allDocs[0];
         const profile = doc.profiles.get('ObservationProfile');
@@ -2145,11 +2146,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error and not add a rule when an insert rule with parameters refers to an undefined parameterized RuleSet', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: ObservationProfile
         Parent: Observation
         * insert MysteriousRuleSet ("mystery")
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         const doc = allDocs[0];
         const profile = doc.profiles.get('ObservationProfile');
@@ -2161,11 +2162,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when an insert rule with parameters results in a parser error in the generated RuleSet', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: MyObservation
         Parent: Observation
         * insert CardRuleSet(path with spaces, 1, *)
-        `;
+        `);
         importer.import([new RawFSH(input, 'Insert.fsh')]);
 
         expect(stats.numError).toBe(1);
@@ -2176,12 +2177,12 @@ describe('FSHImporter', () => {
       });
 
       it('should log one error when nested insert rules with parameters result in multiple parser errors in the generated RuleSets', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: MyObservation
         Parent: Observation
         * note 0..1
         * insert FirstRiskyRuleSet("Observation.id")
-        `;
+        `);
         importer.import([new RawFSH(input, 'Insert.fsh')]);
 
         expect(stats.numError).toBe(1);
@@ -2194,11 +2195,11 @@ describe('FSHImporter', () => {
       });
 
       it('should not log an error when an insert rule with parameters results in rules that are syntactically correct but semantically invalid', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: MyObservation
         Parent: Observation
         * insert CardRuleSet(nonExistentPath, 7, 4)
-        `;
+        `);
         const allDocs = importer.import([new RawFSH(input, 'Insert.fsh')]);
         expect(allDocs).toHaveLength(1);
         const doc = allDocs[0];
@@ -2224,11 +2225,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log one error when an insert rule with parameters results in warnings', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: MyObservation
         Parent: Observation
         * insert WarningRuleSet(Device)
-        `;
+        `);
         importer.import([new RawFSH(input, 'Insert.fsh')]);
 
         expect(stats.numError).toBe(1);
@@ -2241,11 +2242,11 @@ describe('FSHImporter', () => {
       });
 
       it('should log one error when an insert rule with parameters results in non-parser errors', () => {
-        const input = `
+        const input = leftAlign(`
         Profile: MyObservation
         Parent: Observation
         * insert CardRuleSet(nonExistentPath, , )
-        `;
+        `);
         importer.import([new RawFSH(input, 'Insert.fsh')]);
 
         expect(stats.numError).toBe(1);
@@ -2262,14 +2263,14 @@ describe('FSHImporter', () => {
     //   Resource, Logical
     describe('#addElementRule', () => {
       it('should parse basic addElement rules with defaulted definition', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 boolean "short boolean"
         * stuff 0..* string "short string"
         * address 1..* Address "short Address"
         * person 0..1 Reference(Patient) "short Reference"
         * medication 0..1 Canonical(Medication) "short Canonical"
-        `;
+        `);
 
         const result = importSingleText(input);
         const resource = result.resources.get('TestResource');
@@ -2302,14 +2303,14 @@ describe('FSHImporter', () => {
       });
 
       it('should parse basic addElement rules with specified definition', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 boolean "short boolean" "definition boolean"
         * stuff 0..* string "short string" "definition string"
         * address 1..* Address "short Address" "definition Address"
         * person 0..1 Reference(Patient) "short Reference" "definition Reference"
         * medication 0..1 Canonical(Medication|4.0.1) "short Canonical" "definition Canonical"
-        `;
+        `);
 
         const result = importSingleText(input);
         const resource = result.resources.get('TestResource');
@@ -2342,14 +2343,14 @@ describe('FSHImporter', () => {
       });
 
       it('should parse addElement rules with multiple targetTypes', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 boolean or number "short boolean"
         * stuff 0..* string or markdown "short string"
         * address 1..* Address "short Address"
         * person 0..1 HumanName or Reference(Patient or RelatedPerson) "short multi-type"
         * medication 0..1 CodeableConcept or Canonical(Medication or Immunization) "short multi-type 2"
-        `;
+        `);
 
         const result = importSingleText(input);
         const resource = result.resources.get('TestResource');
@@ -2390,13 +2391,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse addElement rules with flags', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 MS ?! boolean "short boolean"
         * stuff 0..* MS SU string "short string"
         * address 1..* N Address "short Address"
         * person 0..1 D TU Reference(Patient) "short Reference"
-        `;
+        `);
 
         const result = importSingleText(input);
         const resource = result.resources.get('TestResource');
@@ -2428,13 +2429,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse addElement rules with docs', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 MS boolean "is it valid?"
         * stuff 0..* string "just stuff" "a list of some stuff"
         * address 1..* N Address "current addresses" "at least one address is required"
         * person 0..1 D TU Reference(Patient) "an associated patient" "added for TRIAL USE"
-        `;
+        `);
 
         const result = importSingleText(input);
         const resource = result.resources.get('TestResource');
@@ -2465,13 +2466,13 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error for missing path', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * 1..1 boolean "short boolean"
         * stuff 0..* string "short string"
         * address 1..* Address "short Address"
         * person 0..1 Reference(Patient) "short Reference"
-       `;
+       `);
 
         const result = importSingleText(input, 'BadPath.fsh');
         const resource = result.resources.get('TestResource');
@@ -2483,13 +2484,13 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error for missing cardinality', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 boolean "short boolean"
         * stuff string "short string"
         * address 1..* Address "short Address"
         * person 0..1 Reference(Patient) "short Reference"
-       `;
+       `);
 
         const result = importSingleText(input, 'BadCard.fsh');
         const resource = result.resources.get('TestResource');
@@ -2502,10 +2503,10 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when min cardinality is not specified', () => {
-        const input = `
+        const input = leftAlign(`
         Logical: LogicalModel
         * isInValid ..* string "short string"
-        `;
+        `);
 
         const result = importSingleText(input, 'Invalid.fsh');
         const logical = result.logicals.get('LogicalModel');
@@ -2522,10 +2523,10 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error when max cardinality is not specified', () => {
-        const input = `
+        const input = leftAlign(`
         Logical: LogicalModel
         * isInValid 0.. string "short string"
-        `;
+        `);
 
         const result = importSingleText(input, 'Invalid.fsh');
         const logical = result.logicals.get('LogicalModel');
@@ -2542,13 +2543,13 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error for extra docs/strings', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 MS boolean "is it valid?"
         * stuff 0..* string "just stuff" "a list of some stuff" "invalid additional string"
         * address 1..* N Address "current addresses" "at least one address is required"
         * person 0..1 D TU Reference(Patient) "an associated patient" "added for TRIAL USE"
-        `;
+        `);
 
         const result = importSingleText(input, 'BadDocs.fsh)');
         const resource = result.resources.get('TestResource');
@@ -2560,13 +2561,13 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error for missing short', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 boolean
         * stuff 0..* string "short string"
         * address 1..* Address "short Address"
         * person 0..1 Reference(Patient) "short Reference"
-       `;
+       `);
 
         const result = importSingleText(input, 'BadDefs.fsh');
         const resource = result.resources.get('TestResource');
@@ -2582,13 +2583,13 @@ describe('FSHImporter', () => {
       });
 
       it('should log an error for missing targetType with docs', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 boolean "is it valid?"
         * stuff 0..* string "just stuff" "a list of some stuff"
         * address 1..* "current addresses" "at least one address is required"
         * person 0..1 Reference(Patient) "an associated patient" "added for TRIAL USE"
-       `;
+       `);
 
         const result = importSingleText(input, 'BadType.fsh');
         const resource = result.resources.get('TestResource');
@@ -2600,13 +2601,13 @@ describe('FSHImporter', () => {
       });
 
       it('should log a warning for missing targetType with flags and docs', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 MS ?! boolean "is it valid?"
         * stuff 0..* MS SU string "just stuff" "a list of some stuff"
         * address 1..* N TU "current addresses" "at least one address is required"
         * person 0..1 D TU Reference(Patient) "an associated patient" "added for TRIAL USE"
-       `;
+       `);
 
         const result = importSingleText(input, 'BadType.fsh');
         const resource = result.resources.get('TestResource');
@@ -2641,13 +2642,13 @@ describe('FSHImporter', () => {
       });
 
       it('should log a error for missing targetType with modifier flag and docs', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 MS ?! boolean "is it valid?"
         * stuff 0..* MS SU string "just stuff" "a list of some stuff"
         * address 1..* N ?! "current addresses" "at least one address is required"
         * person 0..1 D TU Reference(Patient) "an associated patient" "added for TRIAL USE"
-       `;
+       `);
 
         const result = importSingleText(input, 'BadType.fsh');
         const resource = result.resources.get('TestResource');
@@ -2660,13 +2661,13 @@ describe('FSHImporter', () => {
       });
 
       it('should parse rules according to rule patterns for CardRule and AddElementRule', () => {
-        const input = `
+        const input = leftAlign(`
         Resource: TestResource
         * isValid 1..1 boolean "is it valid?"
         * stuff 0..* string "just stuff" "a list of some stuff"
         * address 1..* "current addresses" "at least one address is required"
         * person 0..1 Reference(Patient) "an associated patient"
-       `;
+       `);
 
         const result = importSingleText(input, 'BadType.fsh');
         const resource = result.resources.get('TestResource');

--- a/test/import/FSHImporter.context.test.ts
+++ b/test/import/FSHImporter.context.test.ts
@@ -12,6 +12,7 @@ import {
   assertAddElementRule
 } from '../testhelpers/asserts';
 import { FshCode } from '../../src/fshtypes';
+import { leftAlign } from '../utils/leftAlign';
 
 describe('FSHImporter', () => {
   beforeEach(() => {
@@ -20,12 +21,12 @@ describe('FSHImporter', () => {
 
   describe('context', () => {
     it('should parse non-indented rules', () => {
-      const input = `
+      const input = leftAlign(`
         Instance: Foo
         InstanceOf: Patient
         * name.family = "foo"
         * name.given = "bar"
-      `;
+      `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -40,13 +41,13 @@ describe('FSHImporter', () => {
     });
 
     it('should parse a rule that has context while ignoring whitespace lines', () => {
-      const input = `
+      const input = leftAlign(`
       Instance: Foo
       InstanceOf: Patient
       * name.family = "foo"
 
         * id = "foo-id"
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -61,12 +62,12 @@ describe('FSHImporter', () => {
     });
 
     it('should parse a rule that has context', () => {
-      const input = `
+      const input = leftAlign(`
       Instance: Foo
       InstanceOf: Patient
       * name.family = "foo"
         * id = "foo-id"
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -81,13 +82,13 @@ describe('FSHImporter', () => {
     });
 
     it('should parse multiple rules at the same level of context', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: Foo
       Parent: Patient
       * name 1..1
         * family 1..1
         * given 1..1
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -103,7 +104,7 @@ describe('FSHImporter', () => {
     });
 
     it('should preserve higher level context when decreasing indent', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: Foo
       Parent: Patient
       * name 1..1
@@ -111,7 +112,7 @@ describe('FSHImporter', () => {
           * id 1..1
             * id 1..1
         * given 1..1
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -129,11 +130,11 @@ describe('FSHImporter', () => {
     });
 
     it('should parse a rule that only sets a path context', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: Foo
       Parent: Patient
       * name
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -147,12 +148,12 @@ describe('FSHImporter', () => {
     });
 
     it('should use context from rules that only set context', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: Foo
       Parent: Patient
       * name
         * family 1..1
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -166,14 +167,14 @@ describe('FSHImporter', () => {
     });
 
     it('should change + to = when setting context on children of soft indexed rules', () => {
-      const input = `
+      const input = leftAlign(`
       Instance: Foo
       InstanceOf: Questionnaire
       * item[+]
         * linkId = "foo"
         * item[+]
           * linkId = "bar"
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -188,14 +189,14 @@ describe('FSHImporter', () => {
     });
 
     it('should change nested + to = when setting context on children of soft indexed rules', () => {
-      const input = `
+      const input = leftAlign(`
       Instance: Foo
       InstanceOf: Questionnaire
       * item[+].item[+]
         * linkId = "foo"
         * item[+]
           * linkId = "bar"
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -210,13 +211,13 @@ describe('FSHImporter', () => {
     });
 
     it('should parse child rules that have a blank path', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: Foo
       Parent: Patient
       * name 1..1
         * ^short = "foo"
         * obeys inv1
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -232,12 +233,12 @@ describe('FSHImporter', () => {
     });
 
     it('should apply context to multiple paths', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: Foo
       Parent: Patient
       * name
         * family and given MS
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -270,12 +271,12 @@ describe('FSHImporter', () => {
     });
 
     it('should apply the last path in a list when multiple paths are used to set context', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: Foo
       Parent: Patient
       * name and birthDate MS
         * ^short = "foo"
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -309,12 +310,12 @@ describe('FSHImporter', () => {
     });
 
     it('should apply context to AddElement rules', () => {
-      const input = `
+      const input = leftAlign(`
       Logical: Human
       * family 0..1 BackboneElement "Family"
         * mother 0..2 string "Mother"
         * father 0..2 string "Father"
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
@@ -341,12 +342,12 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when a . rule is indented', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: Foo
       Parent: Patient
       * name 1..1
         * . ^short = "foo"
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
@@ -362,12 +363,12 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when a rule is indented below a rule without a path', () => {
-      const input = `
+      const input = leftAlign(`
       Profile: Foo
       Parent: Patient
       * ^url = "http://example.org"
         * name 1..1
-    `;
+    `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
@@ -384,12 +385,12 @@ describe('FSHImporter', () => {
 
     it('should log an error when a rule is indented an invalid amount of spaces', () => {
       // only 1 space of indent
-      const input = `
+      const input = leftAlign(`
         Instance: Foo
         InstanceOf: Patient
         * name.family = "foo"
          * id = "bar"
-      `;
+      `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
@@ -407,43 +408,18 @@ describe('FSHImporter', () => {
       assertAssignmentRule(instance.rules[1], 'id', 'bar');
     });
 
-    it('should log an error when a rule is indented a negative amount of spaces', () => {
-      // -2 space of indent
-      const input = `
-        Instance: Foo
-        InstanceOf: Patient
-      * name.family = "foo"
-        * id = "bar"
-      `;
-
-      const result = importSingleText(input, 'Context.fsh');
-      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
-      expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Unable to determine path context.*-2 space/
-      );
-      expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
-      expect(result.instances.size).toBe(1);
-      const instance = result.instances.get('Foo');
-      expect(instance.name).toBe('Foo');
-      expect(instance.instanceOf).toBe('Patient');
-      expect(instance.rules.length).toBe(2);
-      assertAssignmentRule(instance.rules[0], 'name.family', 'foo');
-      // rule is not assigned any context
-      assertAssignmentRule(instance.rules[1], 'id', 'bar');
-    });
-
     it('should log an error when the first rule of a definition is indented', () => {
-      const input = `
+      const input = leftAlign(`
         Instance: Foo
         InstanceOf: Patient
           * name.family = "foo"
         * id = "bar"
-      `;
+      `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /first rule of a definition cannot be indented/
+        /first rule of a definition must be left-aligned/
       );
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
       expect(result.instances.size).toBe(1);
@@ -458,12 +434,12 @@ describe('FSHImporter', () => {
 
     it('should log an error when a rule is indented too deeply', () => {
       // 4 spaces of indent
-      const input = `
+      const input = leftAlign(`
         Instance: Foo
         InstanceOf: Patient
         * name.family = "foo"
             * id = "bar"
-      `;
+      `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
@@ -480,11 +456,11 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when a ValueSetFilterComponentRule is indented', () => {
-      const input = `
+      const input = leftAlign(`
         ValueSet: Foo
         * include codes from system http://example.org
           * include codes from system http://indent.org
-      `;
+      `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
@@ -502,11 +478,11 @@ describe('FSHImporter', () => {
     });
 
     it('should log an error when a ValueSetConceptComponentRule is indented', () => {
-      const input = `
+      const input = leftAlign(`
         ValueSet: Foo
         * http://example.org#foo
           * http://example.org#bar
-      `;
+      `);
 
       const result = importSingleText(input, 'Context.fsh');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
@@ -520,23 +496,21 @@ describe('FSHImporter', () => {
       expect(vs.rules.length).toBe(1);
       assertValueSetConceptComponent(vs.rules[0], 'http://example.org', undefined, [
         new FshCode('foo', 'http://example.org')
-          .withLocation([3, 11, 3, 32])
+          .withLocation([3, 3, 3, 24])
           .withFile('Context.fsh'),
-        new FshCode('bar', 'http://example.org')
-          .withLocation([4, 13, 4, 34])
-          .withFile('Context.fsh')
+        new FshCode('bar', 'http://example.org').withLocation([4, 5, 4, 26]).withFile('Context.fsh')
       ]);
     });
   });
 
   describe('code context', () => {
     it('should parse a code system with indented hierarchical rules', () => {
-      const input = `
+      const input = leftAlign(`
       CodeSystem: ZOO
       * #bear "Bear" "A member of family Ursidae."
         * #sunbear "Sun bear" "Helarctos malayanus"
           * #ursula "Ursula the sun bear"
-      `;
+      `);
       const result = importSingleText(input, 'Zoo.fsh');
       expect(result.codeSystems.size).toBe(1);
       const codeSystem = result.codeSystems.get('ZOO');
@@ -545,18 +519,18 @@ describe('FSHImporter', () => {
       assertConceptRule(codeSystem.rules[0], 'bear', 'Bear', 'A member of family Ursidae.', []);
       expect(codeSystem.rules[0].sourceInfo.location).toEqual({
         startLine: 3,
-        startColumn: 7,
+        startColumn: 1,
         endLine: 3,
-        endColumn: 50
+        endColumn: 44
       });
       assertConceptRule(codeSystem.rules[1], 'sunbear', 'Sun bear', 'Helarctos malayanus', [
         'bear'
       ]);
       expect(codeSystem.rules[1].sourceInfo.location).toEqual({
         startLine: 4,
-        startColumn: 9,
+        startColumn: 3,
         endLine: 4,
-        endColumn: 51
+        endColumn: 45
       });
       assertConceptRule(codeSystem.rules[2], 'ursula', 'Ursula the sun bear', undefined, [
         'bear',
@@ -564,19 +538,19 @@ describe('FSHImporter', () => {
       ]);
       expect(codeSystem.rules[2].sourceInfo.location).toEqual({
         startLine: 5,
-        startColumn: 11,
+        startColumn: 5,
         endLine: 5,
-        endColumn: 41
+        endColumn: 35
       });
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
 
     it('should parse a code system that uses an indented CaretValueRule on a top-level concept', () => {
-      const input = `
+      const input = leftAlign(`
       CodeSystem: ZOO
       * #anteater "Anteater"
         * ^property[0].valueString = "Their threat pose is really cute."
-      `;
+      `);
       const result = importSingleText(input, 'Zoo.fsh');
       const codeSystem = result.codeSystems.get('ZOO');
       assertConceptRule(codeSystem.rules[0], 'anteater', 'Anteater', undefined, []);
@@ -594,12 +568,12 @@ describe('FSHImporter', () => {
     });
 
     it('should parse a code system that uses an indented CaretValueRule on a nested concept', () => {
-      const input = `
+      const input = leftAlign(`
       CodeSystem: ZOO
       * #anteater "Anteater"
         * #northern "Northern tamandua"
           * ^property[0].valueString = "They are strong climbers."
-      `;
+      `);
       const result = importSingleText(input, 'Zoo.fsh');
       const codeSystem = result.codeSystems.get('ZOO');
       assertConceptRule(codeSystem.rules[0], 'anteater', 'Anteater', undefined, []);
@@ -621,14 +595,14 @@ describe('FSHImporter', () => {
     });
 
     it('should allow code path context to be set by referencing an existing top-level code', () => {
-      const input = `
+      const input = leftAlign(`
       CodeSystem: ZOO
       * #anteater "Anteater"
         * #northern "Northern tamandua"
           * ^property[0].valueString = "They are strong climbers."
       * #anteater
         * ^property[0].valueString = "Their threat pose is really cute."
-      `;
+      `);
       const result = importSingleText(input, 'Zoo.fsh');
       const codeSystem = result.codeSystems.get('ZOO');
       expect(codeSystem.rules).toHaveLength(4);
@@ -660,14 +634,14 @@ describe('FSHImporter', () => {
     });
 
     it('should allow code path context to be set by referencing an existing nested code', () => {
-      const input = `
+      const input = leftAlign(`
       CodeSystem: ZOO
       * #anteater "Anteater"
         * #northern "Northern tamandua"
         * #southern "Southern tamandua"
       * #anteater #northern
         * ^property[0].valueString = "They are strong climbers."
-      `;
+      `);
       const result = importSingleText(input, 'Zoo.fsh');
       const codeSystem = result.codeSystems.get('ZOO');
       expect(codeSystem.rules).toHaveLength(4);
@@ -694,11 +668,11 @@ describe('FSHImporter', () => {
     });
 
     it('should parse a rule set that uses an indented CaretValueRule on a top-level concept', () => {
-      const input = `
+      const input = leftAlign(`
       RuleSet: ZOO
       * #anteater "Anteater"
         * ^property[0].valueString = "Their threat pose is really cute."
-      `;
+      `);
       const result = importSingleText(input, 'Zoo.fsh');
       const codeSystem = result.ruleSets.get('ZOO');
       assertConceptRule(codeSystem.rules[0], 'anteater', 'Anteater', undefined, []);

--- a/test/run/FshToFhir.test.ts
+++ b/test/run/FshToFhir.test.ts
@@ -6,6 +6,7 @@ import { fshToFhir } from '../../src/run';
 import * as processing from '../../src/utils/Processing';
 import { Configuration } from '../../src/fshtypes';
 import { FHIRDefinitions } from '../../src/fhirdefs';
+import { leftAlign } from '../utils/leftAlign';
 
 describe('#FshToFhir', () => {
   let loadSpy: jest.SpyInstance;
@@ -147,11 +148,11 @@ describe('#FshToFhir', () => {
 
     it('should convert valid FSH into FHIR with a single input', async () => {
       const results = await fshToFhir(
-        `
+        leftAlign(`
       Profile: MyPatient
       Parent: Patient
       * name MS
-      `
+       `)
       );
       expect(results.errors).toHaveLength(0);
       expect(results.warnings).toHaveLength(0);
@@ -164,16 +165,16 @@ describe('#FshToFhir', () => {
 
     it('should convert valid FSH into FHIR with several inputs', async () => {
       const results = await fshToFhir([
-        `
+        leftAlign(`
       Profile: MyPatient1
       Parent: Patient
       * name MS
-      `,
-        `
+       `),
+        leftAlign(`
       Profile: MyPatient2
       Parent: Patient
       * gender MS
-      `
+       `)
       ]);
       expect(results.errors).toHaveLength(0);
       expect(results.warnings).toHaveLength(0);
@@ -190,16 +191,16 @@ describe('#FshToFhir', () => {
 
     it('should trace errors back to the originating input when multiple inputs are given', async () => {
       const results = await fshToFhir([
-        `
+        leftAlign(`
       Profile: MyPatient1
       Parent: FakeProfile
       * name MS
-      `,
-        `
+       `),
+        leftAlign(`
       Profile: MyPatient2
       Parent: AlsoFakeProfile
       * gender MS
-      `
+       `)
       ]);
       expect(results.errors).toHaveLength(2);
       expect(results.errors[0].message).toMatch(/Parent FakeProfile not found/);

--- a/test/utils/leftAlign.ts
+++ b/test/utils/leftAlign.ts
@@ -1,11 +1,10 @@
-import { EOL } from 'os';
 /**
  * Removes white space in each non-empty line of a string, such that the first line is left-aligned
  * @param {string} inputFSH - The string to be made left-aligned
- * @returns {string} - The altered string to be left-aligned
+ * @returns {string} - The altered string
  */
 export function leftAlign(inputFSH: string): string {
-  const lineArray = inputFSH.split(EOL);
+  const lineArray = inputFSH.split(/\r?\n/);
   let offsetAmount: number;
   const letterRegex = /[a-z]/i;
 
@@ -16,5 +15,5 @@ export function leftAlign(inputFSH: string): string {
     }
   }
 
-  return lineArray.map(l => (l.length >= offsetAmount ? l.slice(offsetAmount) : l)).join(EOL);
+  return lineArray.map(l => (l.length >= offsetAmount ? l.slice(offsetAmount) : l)).join('\n');
 }

--- a/test/utils/leftAlign.ts
+++ b/test/utils/leftAlign.ts
@@ -1,0 +1,20 @@
+import { EOL } from 'os';
+/**
+ * Removes white space in each non-empty line of a string, such that the first line is left-aligned
+ * @param {string} inputFSH - The string to be made left-aligned
+ * @returns {string} - The altered string to be left-aligned
+ */
+export function leftAlign(inputFSH: string): string {
+  const lineArray = inputFSH.split(EOL);
+  let offsetAmount: number;
+  const letterRegex = /[a-z]/i;
+
+  for (const line of lineArray) {
+    if (letterRegex.test(line)) {
+      offsetAmount = line.search(/\S/);
+      break;
+    }
+  }
+
+  return lineArray.map(l => (l.length >= offsetAmount ? l.slice(offsetAmount) : l)).join(EOL);
+}


### PR DESCRIPTION
Addresses [CIMPL-789](https://standardhealthrecord.atlassian.net/browse/CIMPL-789) and fixes #874, requiring the first rule in a context path sequence to be left-aligned, rather than in line with the entity.

Something like this should work when run against the master branch, but fail when run against this branch:
```
  CodeSystem: ZOO
  * #anteater "Anteater"
    * #northern "Northern tamandua"
      * ^property[0].valueString = "They are strong climbers."
```