### PR TITLE
Support quoted code without closing quote

### DIFF
--- a/src/import/parseCodeLexeme.ts
+++ b/src/import/parseCodeLexeme.ts
@@ -19,7 +19,7 @@ export function parseCodeLexeme(conceptText: string): FshCode {
     code = conceptText.slice(splitPoint.index + splitPoint[0].length);
   }
   system = system.replace(/\\\\/g, '\\').replace(/\\#/g, '#');
-  if (code.startsWith('"')) {
+  if (code.startsWith('"') && code.endsWith('"')) {
     code = code
       .slice(1, code.length - 1)
       .replace(/\\\\/g, '\\')

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -83,6 +83,21 @@ describe('FSHImporter', () => {
     assertAssignmentRule(profile.rules[2], 'bonusCode', expectedBonusCode);
   });
 
+  it('should parse a code that has an unmatched quote (") at the start of the code', () => {
+    const input = `
+    Profile: MismatchedQuote
+    Parent: Observation
+    * code = https://breakfast.com/goodfood#"potatoes
+    `;
+    const result = importSingleText(input, 'MismatchedQuote.fsh');
+    const profile = result.profiles.get('MismatchedQuote');
+    const expectedCode = new FshCode('"potatoes', 'https://breakfast.com/goodfood')
+      .withLocation([4, 14, 4, 53])
+      .withFile('MismatchedQuote.fsh');
+    expect(profile.rules).toHaveLength(1);
+    assertAssignmentRule(profile.rules[0], 'code', expectedCode);
+  });
+
   it('should parse a rule that uses non-breaking spaces in a concept string', () => {
     const input = `
     Profile: NonBreakingObservation


### PR DESCRIPTION
While testing out PR #883, @mint-thompson noticed the following case wasn't working properly:

```
* code = http://example.org#"something
```
produced the following JSON:

```
{
  "code": "somethin",
  "system": "http://example.org"
}
```
This PR fixes this case so the same FSH now correctly produces the following JSON:

```
{
  "code": "\"something",
  "system": "http://example.org"
}
```