### PR TITLE
Support sushi-ignoreWarnings.txt file to ignore warnings

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -71,9 +71,21 @@ async function app() {
   if (program.debug) logger.level = 'debug';
   input = ensureInputDir(input);
 
-  const ignoreWarningsPath = path.join(input, 'sushi-ignoreWarnings.txt');
-  if (fs.existsSync(ignoreWarningsPath)) {
-    setIgnoredWarnings(fs.readFileSync(ignoreWarningsPath, 'utf-8'));
+  const rootIgnoreWarningsPath = path.join(input, 'sushi-ignoreWarnings.txt');
+  const nestedIgnoreWarningsPath = path.join(input, 'input', 'sushi-ignoreWarnings.txt');
+  if (fs.existsSync(rootIgnoreWarningsPath)) {
+    setIgnoredWarnings(fs.readFileSync(rootIgnoreWarningsPath, 'utf-8'));
+    if (fs.existsSync(nestedIgnoreWarningsPath)) {
+      logger.warn(
+        'Found sushi-ignoreWarnings.txt files in the following locations:\n\n' +
+          ` - ${rootIgnoreWarningsPath}\n` +
+          ` - ${nestedIgnoreWarningsPath}\n\n` +
+          `Only the file at ${rootIgnoreWarningsPath} will be processed. ` +
+          'Remove one of these files to avoid this warning.'
+      );
+    }
+  } else if (fs.existsSync(nestedIgnoreWarningsPath)) {
+    setIgnoredWarnings(fs.readFileSync(nestedIgnoreWarningsPath, 'utf-8'));
   }
 
   logger.info(`Running ${getVersion()}`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,7 +27,8 @@ import {
   writePreprocessedFSH,
   getRawFSHes,
   init,
-  getRandomPun
+  getRandomPun,
+  setIgnoredWarnings
 } from './utils';
 
 const FSH_VERSION = '1.1.0';
@@ -69,6 +70,11 @@ async function app() {
   }
   if (program.debug) logger.level = 'debug';
   input = ensureInputDir(input);
+
+  const ignoreWarningsPath = path.join(input, 'sushi-ignoreWarnings.txt');
+  if (fs.existsSync(ignoreWarningsPath)) {
+    setIgnoredWarnings(fs.readFileSync(ignoreWarningsPath, 'utf-8'));
+  }
 
   logger.info(`Running ${getVersion()}`);
 

--- a/src/utils/FSHLogger.ts
+++ b/src/utils/FSHLogger.ts
@@ -117,13 +117,16 @@ export const logger = createLogger({
 
 let ignoredWarnings: (string | RegExp)[];
 export const setIgnoredWarnings = (messages: string): void => {
-  ignoredWarnings = messages.split(/\r?\n/).map(m => {
-    if (m.startsWith('/') && m.endsWith('/')) {
-      return new RegExp(m.slice(1, -1));
-    } else {
-      return m;
-    }
-  });
+  ignoredWarnings = messages
+    .split(/\r?\n/)
+    .map(m => m.trim())
+    .map(m => {
+      if (m.startsWith('/') && m.endsWith('/')) {
+        return new RegExp(m.slice(1, -1));
+      } else {
+        return m;
+      }
+    });
 };
 
 class LoggerStats {

--- a/src/utils/FSHLogger.ts
+++ b/src/utils/FSHLogger.ts
@@ -120,6 +120,7 @@ export const setIgnoredWarnings = (messages: string): void => {
   ignoredWarnings = messages
     .split(/\r?\n/)
     .map(m => m.trim())
+    .filter(m => !m.startsWith('#'))
     .map(m => {
       if (m.startsWith('/') && m.endsWith('/')) {
         return new RegExp(m.slice(1, -1));

--- a/test/utils/FSHLogger.test.ts
+++ b/test/utils/FSHLogger.test.ts
@@ -161,6 +161,15 @@ describe('FSHLogger', () => {
       expect(messages[0]).toMatch(/error.*error1/);
     });
 
+    it('should ignore leading and trailing whitespace for warnings which are listed directly', () => {
+      logger.transports[0]['write'] = logMock;
+      setIgnoredWarnings(' warn1  ');
+      logger.warn('warn1');
+      logger.error('error1');
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatch(/error.*error1/);
+    });
+
     it('should not ignore warnings which are unlisted', () => {
       logger.transports[0]['write'] = logMock;
       setIgnoredWarnings(
@@ -199,6 +208,16 @@ describe('FSHLogger', () => {
         /ignore.*/
         `)
       );
+      logger.warn('ignore this message');
+      logger.warn(`ignore this message even though
+      it goes over
+      multiple lines`);
+      expect(messages).toHaveLength(0);
+    });
+
+    it('should ignore warnings which are matched via regex with leading or trailing whitespace', () => {
+      logger.transports[0]['write'] = logMock;
+      setIgnoredWarnings(' /ignore.*/ ');
       logger.warn('ignore this message');
       logger.warn(`ignore this message even though
       it goes over

--- a/test/utils/FSHLogger.test.ts
+++ b/test/utils/FSHLogger.test.ts
@@ -161,6 +161,22 @@ describe('FSHLogger', () => {
       expect(messages[0]).toMatch(/error.*error1/);
     });
 
+    it('should ignore lines beginning with # when listing warnings', () => {
+      logger.transports[0]['write'] = logMock;
+      setIgnoredWarnings(
+        leftAlign(`
+        warn1
+        # warn2
+        `)
+      );
+      logger.warn('warn1');
+      logger.warn('warn2');
+      logger.error('error1');
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatch(/warn.*warn2/);
+      expect(messages[1]).toMatch(/error.*error1/);
+    });
+
     it('should ignore leading and trailing whitespace for warnings which are listed directly', () => {
       logger.transports[0]['write'] = logMock;
       setIgnoredWarnings(' warn1  ');


### PR DESCRIPTION
This addresses [CIMPL-787](https://standardhealthrecord.atlassian.net/browse/CIMPL-787) by adding support for a `sushi-ignoreWarnings.txt` file which can list warnings to be ignored either by directly listing the warning, or by listing a regex that matches the desired warning.

The file must be named `sushi-ignoreWarnings.txt` and must be in the root directory that SUSHI is working on. Only warnings can be ignored, and each line of the file should either list the full content of a warning to be ignored, for example:
```
Instance I2 is not an instance of a resource, so it should only be used inline on other instances, and it will not be exported to a standalone file. Specify "Usage: #inline" to remove this warning.
```
or list a regex that will be used to match certain messages:
```
/Detected the following non-conformant Resource definitions.*/
```

The only way to ignore a multi-line warning is with a regex.

To test this, I would recommend using a FSH file that will generate some warnings. Here is the sample I was using: https://fshschool.org/FSHOnline/#/share/3flTq4D. In `sushi-beta.2` that should generate 3 warnings, one of which is split over multiple lines. Then test out different ways of ignoring those messages, and ensure it aligns with your expectations.

This will need to be documented on FSHSchool, I'll make a corresponding PR there and link it here when I'm done with it, but first I'm going to let people do an initial review in case anything major changes.