### PR TITLE
Detect duplicates across files

### DIFF
--- a/test/import/FSHImporter.Invariant.test.ts
+++ b/test/import/FSHImporter.Invariant.test.ts
@@ -1,6 +1,7 @@
 import { importSingleText } from '../testhelpers/importSingleText';
 import { FshCode } from '../../src/fshtypes';
 import { loggerSpy } from '../testhelpers/loggerSpy';
+import { importText, RawFSH } from '../../src/import';
 
 describe('FSHImporter', () => {
   describe('Invariant', () => {
@@ -176,6 +177,30 @@ describe('FSHImporter', () => {
         expect(invariant.description).toBe('First description.');
         expect(loggerSpy.getLastMessage('error')).toMatch(/Invariant named same-1 already exists/s);
         expect(loggerSpy.getLastMessage('error')).toMatch(/File: SameName\.fsh.*Line: 6 - 8\D*/s);
+      });
+
+      it('should log an error and skip the invariant when encountering an invariant with a name used by another invariant in another file', () => {
+        const input1 = `
+          Invariant: same-1
+          Severity: #error
+          Description: "First description."
+        `;
+
+        const input2 = `
+          Invariant: same-1
+          Severity: #error
+          Description: "Second description."
+        `;
+
+        const result = importText([
+          new RawFSH(input1, 'File1.fsh'),
+          new RawFSH(input2, 'File2.fsh')
+        ]);
+        expect(result.reduce((sum, d2) => sum + d2.invariants.size, 0)).toBe(1);
+        const invariant = result[0].invariants.get('same-1');
+        expect(invariant.description).toBe('First description.');
+        expect(loggerSpy.getLastMessage('error')).toMatch(/Invariant named same-1 already exists/s);
+        expect(loggerSpy.getLastMessage('error')).toMatch(/File: File2\.fsh.*Line: 2 - 4\D*/s);
       });
     });
   });

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -495,4 +495,23 @@ Long statement:
     );
     expect(result).toBeDefined();
   });
+
+  it('should log no error when two entities of different types have the same name', () => {
+    const input = `
+      CodeSystem: Foo
+      Title: "This"
+
+      ValueSet: Foo
+      Title: "That"
+    `;
+
+    const result = importSingleText(input, 'RepeatedName.fsh');
+    expect(result.codeSystems.size).toBe(1);
+    expect(result.valueSets.size).toBe(1);
+    const codesystem = result.codeSystems.get('Foo');
+    expect(codesystem.title).toBe('This');
+    const valueSet = result.valueSets.get('Foo');
+    expect(valueSet.title).toBe('That');
+    expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/FHIR/sushi/issues/865.

It seems that our current duplicate detection for all entities only worked within the same file. This updates that so that now duplicate detection is done globally across all files, for all entities.

The bug is specific to instances, but this should fix it for all types of entities.

To test, just make a FSH project with two files, and two entities of the same name, one in each file. On this branch, you should get an error alerting you that there are two entities of the same name, and so one is being ignored. On master, no such error will be logged, even though the second defined entity is ignored.