### PR TITLE
Do not add duplicate concepts from insert rules

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -490,7 +490,17 @@ export function applyInsertRules(
             }
             ruleSetRuleClone.path = newPath;
           }
-          expandedRules.push(ruleSetRuleClone);
+          if (ruleSetRuleClone instanceof ConceptRule && fshDefinition instanceof FshCodeSystem) {
+            try {
+              if (fshDefinition.checkConcept(ruleSetRuleClone)) {
+                expandedRules.push(ruleSetRuleClone);
+              }
+            } catch (e) {
+              logger.error(e.message, ruleSetRuleClone.sourceInfo);
+            }
+          } else {
+            expandedRules.push(ruleSetRuleClone);
+          }
           if (firstRule) {
             // Once one rule has been applied, all future rules should inherit the index used on that rule
             // rather than continuing to increment the index with the [+] operator

--- a/src/fshtypes/FshCodeSystem.ts
+++ b/src/fshtypes/FshCodeSystem.ts
@@ -27,6 +27,12 @@ export class FshCodeSystem extends FshEntity {
   }
 
   addConcept(newConcept: ConceptRule) {
+    if (this.checkConcept(newConcept)) {
+      this.rules.push(newConcept);
+    }
+  }
+
+  checkConcept(newConcept: ConceptRule): boolean {
     const existingConcept = this.rules.find(
       rule => rule instanceof ConceptRule && rule.code == newConcept.code
     ) as ConceptRule;
@@ -39,7 +45,7 @@ export class FshCodeSystem extends FshEntity {
         newConcept.definition == null &&
         isEqual(existingConcept.hierarchy, newConcept.hierarchy)
       ) {
-        return;
+        return false;
       } else {
         throw new CodeSystemDuplicateCodeError(this.id, newConcept.code);
       }
@@ -62,7 +68,7 @@ export class FshCodeSystem extends FshEntity {
         throw new CodeSystemIncorrectHierarchyError(this.id, newConcept.code);
       }
     });
-    this.rules.push(newConcept);
+    return true;
   }
 
   metadataToFSH(): string {


### PR DESCRIPTION
Completes task [CIMPL-726](https://standardhealthrecord.atlassian.net/browse/CIMPL-726).

When inserting a rule set into a CodeSystem, check to make sure that none of the rules in the rule set would add concepts that are already part of the CodeSystem. This check is done using a function that is also used when checking concepts that are added from concept rules directly on the CodeSystem.