### PR TITLE
Try to detect name conflicts adjacent to ParentNotDefinedError

### DIFF
--- a/src/errors/ParentNameConflictError.ts
+++ b/src/errors/ParentNameConflictError.ts
@@ -1,0 +1,17 @@
+import { WithSource } from './WithSource';
+import { SourceInfo } from '../fshtypes';
+
+export class ParentNameConflictError extends Error implements WithSource {
+  constructor(
+    public childName: string,
+    public parentName: string,
+    public parentType: string,
+    public sourceInfo: SourceInfo
+  ) {
+    super(
+      `Parent ${parentName} for ${childName} is defined as ${
+        /^[AEIOU]/.test(parentType) ? 'an' : 'a'
+      } ${parentType} in FSH, which can't be used as a parent. A FHIR definition also exists with this name. If you intended to use that, reference it by its URL.`
+    );
+  }
+}

--- a/src/errors/ParentNotDefinedError.ts
+++ b/src/errors/ParentNotDefinedError.ts
@@ -4,16 +4,7 @@ import { SourceInfo } from '../fshtypes';
 
 export class ParentNotDefinedError extends Error implements Annotated, WithSource {
   specReferences = ['https://www.hl7.org/fhir/R4/profiling.html#resources'];
-  constructor(
-    public childName: string,
-    public parentName: string,
-    public sourceInfo: SourceInfo,
-    public conflict?: boolean
-  ) {
-    super(
-      `Parent ${parentName} not found for ${childName}${
-        conflict ? ' - Do you have conflicting names in your definitions?' : ''
-      }`
-    );
+  constructor(public childName: string, public parentName: string, public sourceInfo: SourceInfo) {
+    super(`Parent ${parentName} not found for ${childName}`);
   }
 }

--- a/src/errors/ParentNotDefinedError.ts
+++ b/src/errors/ParentNotDefinedError.ts
@@ -4,7 +4,16 @@ import { SourceInfo } from '../fshtypes';
 
 export class ParentNotDefinedError extends Error implements Annotated, WithSource {
   specReferences = ['https://www.hl7.org/fhir/R4/profiling.html#resources'];
-  constructor(public childName: string, public parentName: string, public sourceInfo: SourceInfo) {
-    super(`Parent ${parentName} not found for ${childName}`);
+  constructor(
+    public childName: string,
+    public parentName: string,
+    public sourceInfo: SourceInfo,
+    public conflict?: boolean
+  ) {
+    super(
+      `Parent ${parentName} not found for ${childName}${
+        conflict ? ' - Do you have conflicting names in your definitions?' : ''
+      }`
+    );
   }
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -30,6 +30,7 @@ export * from './CannotResolvePathError';
 export * from './InvalidElementAccessError';
 export * from './InvalidSumOfSliceMinsError';
 export * from './InvalidMaxOfSliceError';
+export * from './ParentNameConflictError';
 export * from './ParentNotDefinedError';
 export * from './ParentNotProvidedError';
 export * from './PackageLoadError';

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -182,11 +182,14 @@ export class StructureDefinitionExporter implements Fishable {
       parentJson = STRUCTURE_DEFINITION_R4_BASE;
     }
     if (!parentJson) {
+      // see if the parent is in the FHIR defs, as it may have been what they meant to reference.
+      const conflictingDef = this.fisher.fhir.fishForFHIR(fshDefinition.parent);
       // If parentJson is not defined, then the provided parent's StructureDefinition is not defined
       throw new ParentNotDefinedError(
         fshDefinition.name,
         fshDefinition.parent,
-        fshDefinition.sourceInfo
+        fshDefinition.sourceInfo,
+        conflictingDef != null
       );
     }
 

--- a/src/fshtypes/Invariant.ts
+++ b/src/fshtypes/Invariant.ts
@@ -19,6 +19,10 @@ export class Invariant extends FshEntity {
     super();
   }
 
+  get constructorName() {
+    return 'Invariant';
+  }
+
   /**
    * Read only property for id that just returns the name of the invariant
    * This was added so that all types that are returned by FSHTank.fish have an id that can be accessed

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -347,6 +347,21 @@ describe('StructureDefinitionExporter R4', () => {
       }).toThrow('Parent Bar not found for Foo');
     });
 
+    it('should throw ParentNotDefinedError with a helpful suggestion when the parent name is shared by a valid-type FHIR resource and an invalid-type tank resource', () => {
+      // This happens if a resource in the tank has the same name as a resource in the package
+      const valueSet = new FshValueSet('PractitionerRole');
+      doc.valueSets.set(valueSet.name, valueSet);
+      const profile = new Profile('Foo');
+      profile.parent = 'PractitionerRole';
+      doc.profiles.set(profile.name, profile);
+
+      expect(() => {
+        exporter.exportStructDef(profile);
+      }).toThrow(
+        'Parent PractitionerRole not found for Foo - Do you have conflicting names in your definitions?'
+      );
+    });
+
     it('should throw ParentDeclaredAsNameError when the extension declares itself as the parent', () => {
       const extension = new Extension('Foo');
       extension.parent = 'Foo';

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -347,7 +347,7 @@ describe('StructureDefinitionExporter R4', () => {
       }).toThrow('Parent Bar not found for Foo');
     });
 
-    it('should throw ParentNotDefinedError with a helpful suggestion when the parent name is shared by a valid-type FHIR resource and an invalid-type tank resource', () => {
+    it('should throw ParentNameConflictError when the parent name is shared by a valid-type FHIR resource and an invalid-type tank resource', () => {
       // This happens if a resource in the tank has the same name as a resource in the package
       const valueSet = new FshValueSet('PractitionerRole');
       doc.valueSets.set(valueSet.name, valueSet);
@@ -358,7 +358,7 @@ describe('StructureDefinitionExporter R4', () => {
       expect(() => {
         exporter.exportStructDef(profile);
       }).toThrow(
-        'Parent PractitionerRole not found for Foo - Do you have conflicting names in your definitions?'
+        "Parent PractitionerRole for Foo is defined as a ValueSet in FSH, which can't be used as a parent. A FHIR definition also exists with this name. If you intended to use that, reference it by its URL."
       );
     });
 


### PR DESCRIPTION
Fixes #858 and completes task [CIMPL-790](https://standardhealthrecord.atlassian.net/browse/CIMPL-790).

If the name of an entity in the tank (defined by the author) is the same as the name of an entity in the FHIR definitions, the entity in the tank will prevent the entity in the FHIR definitions from being found while fishing. This can result in somewhat confusing scenarios if, for example, a ValueSet in the tank has the same name as a Profile in the FHIR definitions, and another Profile tries to use that name as its parent. Try to detect that scenario, and when detected, let the author know that there may be conflicting names.