### PR TITLE
Extension slices now always include a type field in the differential 

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -392,6 +392,14 @@ export class ElementDefinition {
           // @ts-ignore
           diff[prop] = cloneDeep(this[prop]);
         }
+      } else if (
+        prop &&
+        prop === 'type' &&
+        this.sliceName &&
+        this.id.slice(0, this.id.lastIndexOf(':')).endsWith('.extension')
+      ) {
+        // Due to a quirk in the IG Publisher, we'll want to include the type within the diff on extension slices
+        diff[prop] = cloneDeep(this[prop]);
       }
     }
     // Set the diff id, which may be different than snapshot id in the case of choices (e.g., value[x] -> valueString)

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -88,6 +88,65 @@ describe('ElementDefinition', () => {
         new ElementDefinitionType('Period')
       ]);
     });
+
+    it('should include the type property within the differential array of extension slices', () => {
+      const baseElement = {
+        id: 'Profile.element.extension:extensionSlice',
+        sliceName: 'extensionSlice',
+        type: [
+          {
+            code: 'Extension',
+            profile: ['http://example.org/StructureDefinition/extensionSlice']
+          }
+        ]
+      };
+
+      const sliceElement = {
+        id: 'Profile.element:elementSlice.extension:extensionSlice',
+        sliceName: 'extensionSlice',
+        type: [
+          {
+            code: 'Extension',
+            profile: ['http://example.org/StructureDefinition/extensionSlice']
+          }
+        ],
+        _original: baseElement
+      };
+
+      const slicedElementDef = ElementDefinition.fromJSON(sliceElement);
+      const elementDiff = slicedElementDef.calculateDiff();
+      expect(elementDiff.type).toBeDefined();
+      expect(elementDiff.type[0].profile).toBeDefined();
+      expect(elementDiff.type[0].profile[0]).toEqual(
+        'http://example.org/StructureDefinition/extensionSlice'
+      );
+    });
+
+    it('should not include the type property within the differential array of non-extension slices', () => {
+      const baseElement = {
+        id: 'Profile.element',
+        type: [
+          {
+            code: 'code'
+          }
+        ]
+      };
+
+      const sliceElement = {
+        id: 'Profile.element:elementSlice',
+        sliceName: 'elementSlice',
+        type: [
+          {
+            code: 'code'
+          }
+        ],
+        _original: baseElement
+      };
+
+      const slicedElementDef = ElementDefinition.fromJSON(sliceElement);
+      const elementDiff = slicedElementDef.calculateDiff();
+      expect(elementDiff.type).not.toBeDefined();
+    });
   });
 
   describe('#toJSON', () => {


### PR DESCRIPTION
Fixes #871, ensuring that the type element on extension slices is present in the differential array whether it's changed or not. This must be done to comply with the IG Publisher, as it will occasionally throw errors if an extension slice inherited from a slice on the extension's parent element does not explicitly state its type in the differential. 