### PR TITLE
Fix bug with indentation + soft indexing

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -2057,13 +2057,10 @@ export class FSHImporter extends FSHVisitor {
     }
 
     // Replace '[+]' with '[=]' in the version of the path to add to pathContext, unless the rule is only used to set a path
-    const newContext = pc.hasPathRule(parentCtx.parentCtx)
-      ? path
-      : path.map(c => c.replace(/\[\+\]/g, '[=]'));
 
     // If the element is not indented, just reset the context
     if (contextIndex === 0) {
-      this.pathContext = [newContext];
+      this.pathContext = [path];
       return path;
     }
 
@@ -2096,7 +2093,7 @@ export class FSHImporter extends FSHVisitor {
         this.pathContext.length - 1
       ].map(c => c.replace(/\[\+\]/g, '[=]'));
     }
-    const fullPath = currentContext.concat(newContext);
+    const fullPath = currentContext.concat(path);
     this.pathContext.push(fullPath);
 
     return fullPath;

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -2056,8 +2056,6 @@ export class FSHImporter extends FSHVisitor {
       return path;
     }
 
-    // Replace '[+]' with '[=]' in the version of the path to add to pathContext, unless the rule is only used to set a path
-
     // If the element is not indented, just reset the context
     if (contextIndex === 0) {
       this.pathContext = [path];

--- a/test/import/FSHImporter.context.test.ts
+++ b/test/import/FSHImporter.context.test.ts
@@ -173,8 +173,7 @@ describe('FSHImporter', () => {
       InstanceOf: Questionnaire
       * item[+]
         * linkId = "foo"
-        * item[+]
-          * linkId = "bar"
+        * item[+].linkId = "bar"
     `);
 
       const result = importSingleText(input, 'Context.fsh');

--- a/test/import/FSHImporter.context.test.ts
+++ b/test/import/FSHImporter.context.test.ts
@@ -173,6 +173,28 @@ describe('FSHImporter', () => {
       InstanceOf: Questionnaire
       * item[+]
         * linkId = "foo"
+        * item[+]
+          * linkId = "bar"
+    `);
+
+      const result = importSingleText(input, 'Context.fsh');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+      expect(result.instances.size).toBe(1);
+      const instance = result.instances.get('Foo');
+      expect(instance.name).toBe('Foo');
+      expect(instance.instanceOf).toBe('Questionnaire');
+      expect(instance.rules.length).toBe(2);
+      assertAssignmentRule(instance.rules[0], 'item[+].linkId', 'foo');
+      assertAssignmentRule(instance.rules[1], 'item[=].item[+].linkId', 'bar');
+    });
+
+    it('should change + to = when setting context on children of soft indexed rules which are not path rules', () => {
+      const input = leftAlign(`
+      Instance: Foo
+      InstanceOf: Questionnaire
+      * item[+]
+        * linkId = "foo"
         * item[+].linkId = "bar"
     `);
 


### PR DESCRIPTION
Fixes #879, see that issue for further details.

This fixes a bug that happened when a soft indexed path was indented below another path, and the soft indexed path was _not_ a `PathRule`. See https://fshschool.org/FSHOnline/#/share/3sDl7Lm for a minimal example.

This PR fixes that by removing what appears to be a completely un-needed bit of code that was causing this bug. I believe that code was a relic from when I combined the handling of path context for normal rules and `CodeCaretRules`. But please as reviewers take a second to see if you could come up with a test case that would make the reviewed code necessary, because I would like that to get double checked.