### PR TITLE
Url property now set automatically on instance definitions

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -297,6 +297,9 @@ export class InstanceExporter implements Fishable {
     }
     if (fshDefinition.usage) {
       instanceDef._instanceMeta.usage = fshDefinition.usage;
+      if (fshDefinition.usage === 'Definition') {
+        instanceDef.url = `${this.tank.config.canonical}/${instanceOfStructureDefinition.type}/${fshDefinition.id}`;
+      }
     }
     if (isResource) {
       instanceDef.resourceType = instanceOfStructureDefinition.type; // ResourceType is determined by the StructureDefinition of the type

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -297,7 +297,12 @@ export class InstanceExporter implements Fishable {
     }
     if (fshDefinition.usage) {
       instanceDef._instanceMeta.usage = fshDefinition.usage;
-      if (fshDefinition.usage === 'Definition') {
+      if (
+        fshDefinition.usage === 'Definition' &&
+        instanceOfStructureDefinition.elements.some(
+          element => element.id === `${instanceOfStructureDefinition.type}.url`
+        )
+      ) {
         instanceDef.url = `${this.tank.config.canonical}/${instanceOfStructureDefinition.type}/${fshDefinition.id}`;
       }
     }

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -537,6 +537,26 @@ describe('InstanceExporter', () => {
       ]);
     });
 
+    it('should automatically set the URL property on definition instances', () => {
+      const codeSystemInstance = new Instance('TestInstance');
+      codeSystemInstance.instanceOf = 'CodeSystem';
+      codeSystemInstance.usage = 'Definition';
+      const exported = exportInstance(codeSystemInstance);
+      expect(exported.url).toBe('http://hl7.org/fhir/us/minimal/CodeSystem/TestInstance');
+    });
+
+    it('should not automatically set the URL property on definition instances if the URl is set explicitly', () => {
+      const codeSystemInstance = new Instance('TestInstance');
+      codeSystemInstance.instanceOf = 'CodeSystem';
+      codeSystemInstance.usage = 'Definition';
+
+      const urlRule = new AssignmentRule('url');
+      urlRule.value = 'http://someDifferentCanonical.org/testInstance';
+      codeSystemInstance.rules.push(urlRule);
+      const exported = exportInstance(codeSystemInstance);
+      expect(exported.url).toBe('http://someDifferentCanonical.org/testInstance');
+    });
+
     // Setting instance id
     it('should set id to instance name by default', () => {
       const myExamplePatient = new Instance('MyExample');

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -545,7 +545,7 @@ describe('InstanceExporter', () => {
       expect(exported.url).toBe('http://hl7.org/fhir/us/minimal/CodeSystem/TestInstance');
     });
 
-    it('should not automatically set the URL property on definition instances if the URl is set explicitly', () => {
+    it('should not automatically set the URL property on definition instances if the URL is set explicitly', () => {
       const codeSystemInstance = new Instance('TestInstance');
       codeSystemInstance.instanceOf = 'CodeSystem';
       codeSystemInstance.usage = 'Definition';
@@ -555,6 +555,15 @@ describe('InstanceExporter', () => {
       codeSystemInstance.rules.push(urlRule);
       const exported = exportInstance(codeSystemInstance);
       expect(exported.url).toBe('http://someDifferentCanonical.org/testInstance');
+    });
+
+    it('should not automatically set the URL property on definition instances if the profile does not support URL setting', () => {
+      const patientInstance = new Instance('TestInstance');
+      patientInstance.instanceOf = 'Patient';
+      patientInstance.usage = 'Definition';
+
+      const exported = exportInstance(patientInstance);
+      expect(exported.url).toBeUndefined;
     });
 
     // Setting instance id


### PR DESCRIPTION
Fixes #791, making it so that SUSHI now sets the URL on instances with a `Usage: #definition` just as it does on other entities. You can see this in action with [this simple example](https://fshschool.org/FSHOnline/#/share/3mtrCzr). Running this in FSHOnline will not set the url automatically, but running this same example on this branch will set a url based on the canonical. An assignment rule explicitly setting the url will take precedence over the auto-generated URL.