### PR TITLE
SUSHI now resolves systems in FSH Codes defined in an instance

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -301,8 +301,11 @@ export function replaceReferences<T extends AssignmentRule | CaretValueRule>(
   } else if (value instanceof FshCode) {
     const [system, ...versionParts] = value.system?.split('|') ?? [];
     const version = versionParts.join('|');
-    const codeSystem = tank.fish(system, Type.CodeSystem);
-    const codeSystemMeta = fisher.fishForMetadata(codeSystem?.name, Type.CodeSystem);
+    const codeSystem = tank.fish(system, Type.CodeSystem) ?? tank.fish(system, Type.Instance);
+    const codeSystemMeta =
+      codeSystem instanceof FshCodeSystem
+        ? fisher.fishForMetadata(codeSystem?.name, Type.CodeSystem)
+        : fisher.fishForMetadata(codeSystem?.name, Type.Instance);
     if (codeSystem && codeSystemMeta) {
       clone = cloneDeep(rule);
       const assignedCode = getRuleValue(clone) as FshCode;

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -2226,6 +2226,33 @@ describe('InstanceExporter', () => {
       ]);
     });
 
+    it('should assign a code to a top level element if the code system was defined as an instance of type definition', () => {
+      const visibleSystem = new Instance('Visible');
+      visibleSystem.instanceOf = 'CodeSystem';
+      const urlRule = new AssignmentRule('url');
+      urlRule.value = 'http://hl7.org/fhir/us/minimal/Instance/Visible';
+      const nameRule = new AssignmentRule('name');
+      nameRule.value = 'Visible';
+      visibleSystem.rules.push(urlRule, nameRule);
+      doc.instances.set(visibleSystem.name, visibleSystem);
+      exportInstance(visibleSystem);
+
+      const brightInstance = new Instance('BrightObservation');
+      brightInstance.instanceOf = 'Observation';
+      const assignedCodeRule = new AssignmentRule('code');
+      assignedCodeRule.value = new FshCode('bright', 'Visible');
+      brightInstance.rules.push(assignedCodeRule);
+      doc.instances.set(brightInstance.name, brightInstance);
+
+      const exported = exportInstance(brightInstance);
+      expect(exported.code.coding).toEqual([
+        {
+          code: 'bright',
+          system: 'http://hl7.org/fhir/us/minimal/Instance/Visible'
+        }
+      ]);
+    });
+
     it('should assign a code to a nested element while replacing the local code system name with its url', () => {
       const brightInstance = new Instance('BrightObservation');
       brightInstance.instanceOf = 'Observation';


### PR DESCRIPTION
Fixes #801, making it so that SUSHI looks for code systems defined as an `Instance` if a literal `CodeSystem` with the same name is not found.