### PR TITLE
Show error when inserting RuleSet with concepts at a path

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -491,6 +491,14 @@ export function applyInsertRules(
             ruleSetRuleClone.path = newPath;
           }
           if (ruleSetRuleClone instanceof ConceptRule && fshDefinition instanceof FshCodeSystem) {
+            // ConceptRules should not have a path context, so if one exists, show an error.
+            // The concept is still added to the CodeSystem.
+            if (context) {
+              logger.error(
+                'Do not insert a RuleSet at a path when the RuleSet adds a concept.',
+                ruleSetRuleClone.sourceInfo
+              );
+            }
             try {
               if (fshDefinition.checkConcept(ruleSetRuleClone)) {
                 expandedRules.push(ruleSetRuleClone);


### PR DESCRIPTION
Completes task [CIMPL-807](https://standardhealthrecord.atlassian.net/browse/CIMPL-807).

If a RuleSet is inserted at a path, that path is the context for the rules in the RuleSet. However, a ConceptRule should not have a path as context. So, if a RuleSet that contains a ConceptRule is inserted at a path, show an error so that the author knows that this should not be done. The ConceptRule should still be applied.