### PR TITLE
Include source location in ValueSet filter operand type warning

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1972,7 +1972,8 @@ export class FSHImporter extends FSHVisitor {
           logger.warn(
             `The match value of filter operator "${operator}" must be a code. ` +
               'For string valued properties, use the regex filter operator with a regular expression value. ' +
-              'Support for using strings as filter values has been deprecated and will be removed in a future release.'
+              'Support for using strings as filter values has been deprecated and will be removed in a future release.',
+            { location: this.extractStartStop(ctx), file: this.currentFile }
           );
         }
         if (typeof value !== 'string' && !(value instanceof FshCode)) {

--- a/test/import/FSHImporter.ValueSet.test.ts
+++ b/test/import/FSHImporter.ValueSet.test.ts
@@ -561,6 +561,7 @@ describe('FSHImporter', () => {
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /match value of filter operator "=" must be a code/
         );
+        expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Zoo\.fsh.*Line: 3\D*/s);
       });
 
       it('should parse a value set that uses filter operator = with code value', () => {
@@ -786,6 +787,7 @@ describe('FSHImporter', () => {
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /match value of filter operator "in" must be a code/
         );
+        expect(loggerSpy.getLastMessage('warn')).toMatch(/File: CatDog\.fsh.*Line: 3\D*/s);
       });
 
       it('should parse a value set that use filter operator in with a code value', () => {
@@ -839,6 +841,7 @@ describe('FSHImporter', () => {
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /match value of filter operator "not-in" must be a code/
         );
+        expect(loggerSpy.getLastMessage('warn')).toMatch(/File: NoGoose\.fsh.*Line: 3\D*/s);
       });
 
       it('should parse a value set that uses filter operator not-in with a code value', () => {


### PR DESCRIPTION
Fixes #910 and completes task [CIMPL-821](https://standardhealthrecord.atlassian.net/browse/CIMPL-821).

The logic for deciding to log a warning already exists. This pull request just adds the source information when logging.