### PR TITLE
Update "widening" cardinality message

### DIFF
--- a/src/errors/ConstrainingCardinalityError.ts
+++ b/src/errors/ConstrainingCardinalityError.ts
@@ -1,6 +1,6 @@
 import { Annotated } from './Annotated';
 
-export class WideningCardinalityError extends Error implements Annotated {
+export class ConstrainingCardinalityError extends Error implements Annotated {
   specReferences = ['http://hl7.org/fhir/R4/profiling.html#cardinality'];
   constructor(
     public originalMin: number,

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -24,7 +24,7 @@ export * from './SlicingNotDefinedError';
 export * from './DuplicateSliceError';
 export * from './TypeNotFoundError';
 export * from './UnitMismatchError';
-export * from './WideningCardinalityError';
+export * from './ConstrainingCardinalityError';
 export * from './NarrowingRootCardinalityError';
 export * from './CannotResolvePathError';
 export * from './InvalidElementAccessError';

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -40,7 +40,7 @@ import {
   TypeNotFoundError,
   ValueAlreadyAssignedError,
   ValueConflictsWithClosedSlicingError,
-  WideningCardinalityError,
+  ConstrainingCardinalityError,
   InvalidChoiceTypeRulePathError,
   CannotResolvePathError,
   MismatchedBindingTypeError,
@@ -656,7 +656,7 @@ export class ElementDefinition {
    * @param {number} min - the minimum cardinality
    * @param {number|string} max - the maximum cardinality
    * @throws {InvalidCardinalityError} when min > max
-   * @throws {WideningCardinalityError} when new cardinality is wider than existing cardinality
+   * @throws {ConstrainingCardinalityError} when new cardinality is wider than existing cardinality
    * @throws {InvalidSumOfSliceMinsError} when the mins of slice elements > max of sliced element
    * @throws {NarrowingRootCardinalityError} when the new cardinality on an element is narrower than
    *   the cardinality on a connected element
@@ -676,12 +676,12 @@ export class ElementDefinition {
 
     // Check to ensure min >= existing min
     if (this.min != null && min < this.min) {
-      throw new WideningCardinalityError(this.min, this.max, min, max);
+      throw new ConstrainingCardinalityError(this.min, this.max, min, max);
     }
 
     // Check to ensure max <= existing max
     if (this.max != null && this.max !== '*' && (maxInt > parseInt(this.max) || isUnbounded)) {
-      throw new WideningCardinalityError(this.min, this.max, min, max);
+      throw new ConstrainingCardinalityError(this.min, this.max, min, max);
     }
 
     // Sliced elements and slices have special card rules described here:

--- a/test/fhirtypes/ElementDefinition.constrainCardinality.test.ts
+++ b/test/fhirtypes/ElementDefinition.constrainCardinality.test.ts
@@ -119,7 +119,7 @@ describe('ElementDefinition', () => {
       expect(clone).toEqual(identifier);
     });
 
-    it('should throw WideningCardinalityError when min < original min', () => {
+    it('should throw ConstrainingCardinalityError when min < original min', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
       const clone = cloneDeep(status);
       expect(() => {
@@ -129,7 +129,7 @@ describe('ElementDefinition', () => {
       expect(clone).toEqual(status);
     });
 
-    it('should throw WideningCardinalityError when max > original max', () => {
+    it('should throw ConstrainingCardinalityError when max > original max', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
       const clone = cloneDeep(status);
       expect(() => {
@@ -139,7 +139,7 @@ describe('ElementDefinition', () => {
       expect(clone).toEqual(status);
     });
 
-    it('should throw WideningCardinalityError when min < original min and max > original max at the same time', () => {
+    it('should throw ConstrainingCardinalityError when min < original min and max > original max at the same time', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
       const clone = cloneDeep(status);
       expect(() => {
@@ -149,7 +149,7 @@ describe('ElementDefinition', () => {
       expect(clone).toEqual(status);
     });
 
-    it('should throw WideningCardinalityError when max is * and original max is not *', () => {
+    it('should throw ConstrainingCardinalityError when max is * and original max is not *', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
       const clone = cloneDeep(status);
       expect(() => {


### PR DESCRIPTION
This PR updates the error message we get to more clearly reflect why constraining a cardinality is not allowed (based on #938). Because the error no longer referenced "widening" the cardinality, I also updated the name of the error itself, but I can revert the name change or change it to something else if it less clear now.