### PR TITLE
Fix slicing cardinality validation

### DIFF
--- a/src/errors/InvalidElementForSlicingError.ts
+++ b/src/errors/InvalidElementForSlicingError.ts
@@ -1,5 +1,12 @@
-export class InvalidElementForSlicingError extends Error {
+import { Annotated } from '.';
+
+export class InvalidElementForSlicingError extends Error implements Annotated {
+  specReferences = [
+    'http://hl7.org/fhir/elementdefinition-definitions.html#ElementDefinition.slicing'
+  ];
   constructor(public path: string) {
-    super(`Cannot slice element '${path}' which is not an array or choice`);
+    super(
+      `Cannot slice element '${path}' since FHIR only allows slicing on choice elements (e.g., value[x]) or elements with max > 1`
+    );
   }
 }

--- a/src/errors/InvalidElementForSlicingError.ts
+++ b/src/errors/InvalidElementForSlicingError.ts
@@ -1,0 +1,5 @@
+export class InvalidElementForSlicingError extends Error {
+  constructor(public path: string) {
+    super(`Cannot slice element '${path}' which is not an array or choice`);
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -55,3 +55,4 @@ export * from './InvalidMustSupportError';
 export * from './InvalidChoiceTypeRulePathError';
 export * from './MismatchedBindingTypeError';
 export * from './ValidationError';
+export * from './InvalidElementForSlicingError';

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -21,7 +21,8 @@ import {
   ParentNameConflictError,
   ParentNotDefinedError,
   ParentNotProvidedError,
-  MismatchedBindingTypeError
+  MismatchedBindingTypeError,
+  InvalidElementForSlicingError
 } from '../errors';
 import {
   AddElementRule,
@@ -528,6 +529,9 @@ export class StructureDefinitionExporter implements Fishable {
             if (isExtension) {
               this.handleExtensionContainsRule(fshDefinition, rule, structDef, element);
             } else {
+              if (!element.isArrayOrChoice()) {
+                throw new InvalidElementForSlicingError(rule.path);
+              }
               // Not an extension -- just add a slice for each item
               rule.items.forEach(item => {
                 if (item.type) {

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -308,18 +308,6 @@ export class ElementDefinition {
 
   private validateSlicing(slicing: ElementDefinitionSlicing): ValidationError[] {
     const validationErrors: ValidationError[] = [];
-    if (
-      this.max !== '*' &&
-      parseInt(this.max) <= 1 &&
-      this.base.max !== '*' &&
-      parseInt(this.base.max) <= 1 &&
-      !this.id.endsWith('[x]')
-    ) {
-      validationErrors.push(
-        new ValidationError('Cannot slice element which is not an array or choice', 'slicing')
-      );
-    }
-
     validationErrors.push(this.validateRequired(slicing.rules, 'slicing.rules'));
     validationErrors.push(
       this.validateIncludes(slicing.rules, ALLOWED_SLICING_RULES, 'slicing.rules')

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -306,6 +306,16 @@ export class ElementDefinition {
     return null;
   }
 
+  isArrayOrChoice(): boolean {
+    return (
+      this.max === '*' ||
+      parseInt(this.max) > 1 ||
+      this.base.max === '*' ||
+      parseInt(this.base.max) > 1 ||
+      this.id.endsWith('[x]')
+    );
+  }
+
   private validateSlicing(slicing: ElementDefinitionSlicing): ValidationError[] {
     const validationErrors: ValidationError[] = [];
     validationErrors.push(this.validateRequired(slicing.rules, 'slicing.rules'));

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -5259,7 +5259,7 @@ describe('StructureDefinitionExporter R4', () => {
       const slice = sd.elements.find(e => e.id === 'Observation.status:test');
       expect(slice).toBeUndefined();
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Cannot slice element 'status' which is not an array or choice.*File: SingleElement\.fsh.*Line: 6\D*/s
+        /Cannot slice element 'status'.*File: SingleElement\.fsh.*Line: 6\D*/s
       );
     });
   });

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -13,14 +13,10 @@ describe('ElementDefinition', () => {
   let jsonObservation: any;
   let jsonValueX: any;
   let jsonValueId: any;
-  let jsonValueComponent: any;
-  let jsonSubject: any;
   let observation: StructureDefinition;
   let resprate: StructureDefinition;
   let valueX: ElementDefinition;
   let valueId: ElementDefinition;
-  let valueComponent: ElementDefinition;
-  let subject: ElementDefinition;
   let fisher: TestFisher;
   beforeAll(() => {
     defs = new FHIRDefinitions();
@@ -36,16 +32,12 @@ describe('ElementDefinition', () => {
     jsonObservation = defs.fishForFHIR('Observation', Type.Resource);
     jsonValueX = jsonObservation.snapshot.element[21];
     jsonValueId = jsonObservation.snapshot.element[1];
-    jsonValueComponent = jsonObservation.snapshot.element[41];
-    jsonSubject = jsonObservation.snapshot.element[15];
   });
   beforeEach(() => {
     observation = StructureDefinition.fromJSON(jsonObservation);
     resprate = fisher.fishForStructureDefinition('resprate');
     valueX = ElementDefinition.fromJSON(jsonValueX);
     valueId = ElementDefinition.fromJSON(jsonValueId);
-    valueComponent = ElementDefinition.fromJSON(jsonValueComponent);
-    subject = ElementDefinition.fromJSON(jsonSubject);
     valueX.structDef = observation;
     valueId.structDef = observation;
   });
@@ -823,32 +815,6 @@ describe('ElementDefinition', () => {
       expect(validationErrors).toHaveLength(1);
       expect(validationErrors[0].message).toMatch(
         /slicing.discriminator\[0\].type: Invalid value: #foo. Value must be selected from one of the following: #value, #exists, #pattern, #type, #profile/
-      );
-    });
-
-    it('should be valid to slice array element', () => {
-      const clone = valueComponent.clone(false);
-      clone.slicing = { rules: 'open' };
-      const validationErrors = clone.validate();
-      expect(validationErrors).toHaveLength(0);
-    });
-
-    it('should be valid to slice constrained array element', () => {
-      const clone = valueComponent.clone(false);
-      clone.max = '2';
-      clone.slicing = { rules: 'open' };
-      const validationErrors = clone.validate();
-      expect(validationErrors).toHaveLength(0);
-    });
-
-    it('should be invalid to slice single element', () => {
-      const clone = subject.clone(false);
-      clone.max = '1';
-      clone.slicing = { rules: 'open' };
-      const validationErrors = clone.validate();
-      expect(validationErrors).toHaveLength(1);
-      expect(validationErrors[0].message).toMatch(
-        /slicing: Cannot slice element which is not an array or choice/
       );
     });
   });


### PR DESCRIPTION
This makes it so that if a single element is sliced, we allow it as long as it is inherited from a parent element. But if the FSH tries to apply a `contains` rule on a single element, we log an error.

For example, this should be an error:
```
Profile: V
Parent: Immunization
* vaccineCode ^slicing.discriminator.type = #pattern
* vaccineCode ^slicing.discriminator.path = "$this"
* vaccineCode ^slicing.rules = #open
* vaccineCode ^slicing.description = "Slicing example"
* vaccineCode contains slice1 0..1 and slice2 0..1
```

But if you test the similar situation in the https://github.com/hl7ch/ch-etoc IG on the ChEtocImmunizationSection, which inherits from the ChVacdImmunizationSection profile, it should log no error, because the slicing is introduced in a dependency, not in the FSH itself. 