### PR TITLE
Bump Version to 2.2.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Sushi Unshortens Short Hand Inputs (FSH Compiler)",
   "scripts": {
     "build": "del-cli dist && tsc && cpy src/utils/init-project dist/utils/init-project",

--- a/regression/repos-all.txt
+++ b/regression/repos-all.txt
@@ -79,7 +79,6 @@ ahdis/ch-ig#master
 hl7ch/ch-allergyintolerance#master
 hl7ch/ch-orf#master
 davidhay25/nhip#main
-hl7-be/manzana-ig#master
 hl7-be/riziv-medication-record#master
 hl7-be/vitalink-ig#master
 hl7dk/kl-gateway-national-care-data#master
@@ -100,7 +99,6 @@ DavidPyke/HotBeverage#master
 # Added Wed Jun 16 2021 16:00:22 GMT-0400 (Eastern Daylight Time)
 HL7/fhir-radiation-dose-summary-ig#main
 HL7/pacio-adi#main
-hl7-it/dossier-pharma#main
 hl7-it/terminology#master
 JohnMoehrke/testBundle#main
 hl7dk/kl-ffb-messaging#main
@@ -135,3 +133,19 @@ hl7-eu/gravitate-health#master
 servicewell/wof-portal-fhir-ig#master
 oridashi/pc-au-logical#main
 HL7NZ/sysmex#main
+# Added Wed Nov 10 2021 11:35:18 GMT-0500 (Eastern Standard Time)
+HL7/carin-digital-insurance-card#master
+HL7/fhir-identity-matching-ig#master
+HL7/fhir-pacio-rt#master
+hl7-it/dossier-pharma#master
+ahdis/ch-crl#master
+ahdis/ch-rad-poc#master
+hl7-be/riziv-perinatal#master
+hl7dk/kl-gateway-municipality-healthcare-data#master
+saulakravitz/vrdr-fsh#master
+IHE/pharm-mpd#master
+IHE/QRPH.QORE#master
+IHE/pharm-mm#master
+IHE/ITI.BasicAudit#main
+HL7NZ/structured-path#main
+nightingaleproject/vital_records_fhir_messaging_ig#main


### PR DESCRIPTION
Bumps the version to 2.2.0 and updates the repository list we use for regression.

I've run a full regression on this against the previous 2.1.1 version.  The FHIR output was the same across all IGs, but the proposed 2.2.0 version reported additional errors, mainly related to the new code validation feature.  These new errors are expected.