### PR TITLE
Package loading: Fallback to packages2

### DIFF
--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -114,15 +114,14 @@ export async function loadDependency(
   } else if (!loadedPackage) {
     packageUrl = `https://packages.fhir.org/${packageName}/${version}`;
 
-    // If this is an R4B or R5 package, then we may need to get it from packages2 if it is not in packages
-    if (/^hl7\.fhir\.r(4b|5)\./.test(packageName)) {
-      try {
-        await axios.head(packageUrl);
-      } catch {
-        // It didn't exist in the normal registry.  Fallback to packages2 registry. This should be TEMPORARY.
-        // See: https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Registry.20for.20FHIR.20Core.20packages.20.3E.204.2E0.2E1
-        packageUrl = `https://packages2.fhir.org/packages/${packageName}/${version}`;
-      }
+    // If the package is not available in packages, then we may need to get it from packages2
+    try {
+      await axios.head(packageUrl);
+    } catch {
+      // It didn't exist in the normal registry.  Fallback to packages2 registry.
+      // See: https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Registry.20for.20FHIR.20Core.20packages.20.3E.204.2E0.2E1
+      // See: https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/fhir.2Edicom/near/262334652
+      packageUrl = `https://packages2.fhir.org/packages/${packageName}/${version}`;
     }
   }
 

--- a/test/fhirdefs/load.test.ts
+++ b/test/fhirdefs/load.test.ts
@@ -171,7 +171,8 @@ describe('#loadDependency()', () => {
         uri === 'https://packages2.fhir.org/packages/hl7.fhir.r4b.core/4.1.0' ||
         uri === 'https://packages.fhir.org/hl7.fhir.r4b.core/4.3.0' ||
         uri === 'https://packages2.fhir.org/packages/hl7.fhir.r5.core/4.5.0' ||
-        uri === 'https://packages.fhir.org/hl7.fhir.r4.core/4.0.1'
+        uri === 'https://packages.fhir.org/hl7.fhir.r4.core/4.0.1' ||
+        uri === 'https://packages2.fhir.org/packages/fhir.dicom/2021.4.20210910'
       ) {
         return {
           data: {
@@ -185,7 +186,8 @@ describe('#loadDependency()', () => {
     axiosHeadSpy = jest.spyOn(axios, 'head').mockImplementation((uri: string): any => {
       if (
         uri === 'https://packages.fhir.org/hl7.fhir.r4b.core/4.1.0' ||
-        uri === 'https://packages.fhir.org/hl7.fhir.r5.core/4.5.0'
+        uri === 'https://packages.fhir.org/hl7.fhir.r5.core/4.5.0' ||
+        uri === 'https://packages.fhir.org/fhir.dicom/2021.4.20210910'
       ) {
         throw 'Not Found';
       } else {
@@ -271,6 +273,16 @@ describe('#loadDependency()', () => {
     expectDownloadSequence(
       'https://packages2.fhir.org/packages/hl7.fhir.r5.core/4.5.0',
       path.join('foo', 'hl7.fhir.r5.core#4.5.0')
+    );
+  });
+
+  it('should try to load a package from packages2.fhir.org when it is not on packages.fhir.org', async () => {
+    await expect(loadDependency('fhir.dicom', '2021.4.20210910', defs, 'foo')).rejects.toThrow(
+      'The package fhir.dicom#2021.4.20210910 could not be loaded locally or from the FHIR package registry'
+    ); // the package is never actually added to the cache, since tar is mocked
+    expectDownloadSequence(
+      'https://packages2.fhir.org/packages/fhir.dicom/2021.4.20210910',
+      path.join('foo', 'fhir.dicom#2021.4.20210910')
     );
   });
 


### PR DESCRIPTION
If a package can't be found in the normal packages repo, fallback to the packages2 repo.  This is based on the Zulip conversation here: https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/fhir.2Edicom/near/262334652

To test, create a simple SUSHI project with the following dependency in sushi-config.yaml:

```
dependencies:
  fhir.dicom:
    uri: http://fhir.org/packages/fhir.dicom
    version: 2021.4.20210910
```

On master, SUSHI will fail to load the dependency.  On this branch, it will successfully load it.

Fixes #961.