### PR TITLE
Fix Soft Indexing Path Only Rules w/ Indentation

### DIFF
--- a/regression/repos-all.txt
+++ b/regression/repos-all.txt
@@ -98,7 +98,6 @@ ehealthsuisse/ch-orf#master
 DavidPyke/HotBeverage#master
 # Added Wed Jun 16 2021 16:00:22 GMT-0400 (Eastern Daylight Time)
 HL7/fhir-radiation-dose-summary-ig#main
-HL7/pacio-adi#main
 hl7-it/terminology#master
 JohnMoehrke/testBundle#main
 hl7dk/kl-ffb-messaging#main
@@ -149,3 +148,20 @@ IHE/pharm-mm#master
 IHE/ITI.BasicAudit#main
 HL7NZ/structured-path#main
 nightingaleproject/vital_records_fhir_messaging_ig#main
+# Added Tue Dec 07 2021 10:11:29 GMT-0500 (Eastern Standard Time)
+HL7/fhir-directory-exchange#master
+HL7/fhir-pacio-adi#main
+peturv/fhir-autobuild-test#master
+SvenskaIndustriProfiler/fhir#master
+ahdis/chmed20af#master
+ahdis/scs-versandservice#master
+ahdis/claraspital-versandservice#master
+ahdis/chmed16af#master
+hl7ch/ch-lab-order#master
+hl7nordic/common-nordic-terminology#main
+hl7-be/hl7-be-fhir-laboratory-report#master
+hl7-be/hl7-be-patient-dossier#master
+mcode/mcode-omop#master
+mcode/biomarker#master
+ehealthsuisse/ch-vacd#master
+oliveregger/BundleConformsTo#master

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -1130,13 +1130,17 @@ export class FSHImporter extends FSHVisitor {
     }
   }
 
-  getPathWithContext(path: string, parentCtx: ParserRuleContext): string {
+  getPathWithContext(path: string, parentCtx: ParserRuleContext, isPathRule = false): string {
     const splitPath = path === '.' ? [path] : splitOnPathPeriods(path).filter(p => p);
-    return this.getArrayPathWithContext(splitPath, parentCtx).join('.');
+    return this.getArrayPathWithContext(splitPath, parentCtx, isPathRule).join('.');
   }
 
-  getArrayPathWithContext(pathArray: string[], parentCtx: ParserRuleContext): string[] {
-    return this.prependPathContext(pathArray, parentCtx);
+  getArrayPathWithContext(
+    pathArray: string[],
+    parentCtx: ParserRuleContext,
+    isPathRule = false
+  ): string[] {
+    return this.prependPathContext(pathArray, parentCtx, isPathRule);
   }
 
   visitPath(ctx: pc.PathContext): string {
@@ -1623,7 +1627,7 @@ export class FSHImporter extends FSHVisitor {
   }
 
   visitPathRule(ctx: pc.PathRuleContext) {
-    this.getPathWithContext(this.visitPath(ctx.path()), ctx);
+    this.getPathWithContext(this.visitPath(ctx.path()), ctx, true);
   }
 
   visitCodeInsertRule(ctx: pc.CodeInsertRuleContext): InsertRule {
@@ -2050,7 +2054,11 @@ export class FSHImporter extends FSHVisitor {
    * @param parentCtx - The parent element containing the path
    * @returns {string[]} - The path with context prepended
    */
-  private prependPathContext(path: string[], parentCtx: ParserRuleContext): string[] {
+  private prependPathContext(
+    path: string[],
+    parentCtx: ParserRuleContext,
+    isPathRule: boolean
+  ): string[] {
     const location = this.extractStartStop(parentCtx);
     const currentIndent = location.startColumn - DEFAULT_START_COLUMN;
     const contextIndex = currentIndent / INDENT_WIDTH;
@@ -2088,14 +2096,18 @@ export class FSHImporter extends FSHVisitor {
 
     // Trim out-of-scope contexts
     this.pathContext.splice(contextIndex);
-    // Once we have used the existing context, clear it of any [+] so that a rule that is only setting path only applies [+] once
-    if (this.pathContext.length > 0) {
-      this.pathContext[this.pathContext.length - 1] = this.pathContext[
-        this.pathContext.length - 1
-      ].map(c => c.replace(/\[\+\]/g, '[=]'));
-    }
+
+    // Get the new path and add as the last context
     const fullPath = currentContext.concat(path);
     this.pathContext.push(fullPath);
+
+    // Once we have used the existing context in a non-path-only rule, replace [+] with [=] in all
+    // existing contexts so that the [+] isn't re-applied in further contexts
+    if (!isPathRule) {
+      this.pathContext.forEach((path, i) => {
+        this.pathContext[i] = path.map(c => c.replace(/\[\+\]/g, '[=]'));
+      });
+    }
 
     return fullPath;
   }

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -2069,6 +2069,23 @@ export class FSHImporter extends FSHVisitor {
 
     // If the element is not indented, just reset the context
     if (contextIndex === 0) {
+      // If the last context still has [+], that means the path was never used
+      // and the [+] will be discarded without incrementing
+      if (
+        this.pathContext.length > 0 &&
+        this.pathContext[this.pathContext.length - 1].some(p => /\[\+\]/.test(p))
+      ) {
+        logger.warn(
+          'The previous line(s) use path rules to establish a context using soft indexing ' +
+            '(e.g., [+]), but that context is reset by the following rule before it is ever ' +
+            'used. As a result, the previous path context will be ignored and its ' +
+            'soft-indices will not be incremented',
+          {
+            location,
+            file: this.currentFile
+          }
+        );
+      }
       this.pathContext = [path];
       return path;
     }

--- a/test/import/FSHImporter.context.test.ts
+++ b/test/import/FSHImporter.context.test.ts
@@ -190,6 +190,26 @@ describe('FSHImporter', () => {
       assertAssignmentRule(instance.rules[1], 'item[=].item[+].linkId', 'bar');
     });
 
+    it('should keep + on consecutive path rules when setting context on first child of soft indexed rules', () => {
+      const input = leftAlign(`
+      Instance: Foo
+      InstanceOf: Questionnaire
+      * item[+]
+        * item[+]
+          * linkId = "bar"
+    `);
+
+      const result = importSingleText(input, 'Context.fsh');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+      expect(result.instances.size).toBe(1);
+      const instance = result.instances.get('Foo');
+      expect(instance.name).toBe('Foo');
+      expect(instance.instanceOf).toBe('Questionnaire');
+      expect(instance.rules.length).toBe(1);
+      assertAssignmentRule(instance.rules[0], 'item[+].item[+].linkId', 'bar');
+    });
+
     it('should change + to = when setting context on children of soft indexed rules which are not path rules', () => {
       const input = leftAlign(`
       Instance: Foo

--- a/test/import/FSHImporter.context.test.ts
+++ b/test/import/FSHImporter.context.test.ts
@@ -211,6 +211,31 @@ describe('FSHImporter', () => {
       assertAssignmentRule(instance.rules[1], 'item[=].item[+].linkId', 'bar');
     });
 
+    it('should change + to = when setting context on grandchildren of soft indexed rules which are not path rules', () => {
+      const input = leftAlign(`
+      Instance: Foo
+      InstanceOf: Questionnaire
+      * item[+]
+        * code = #foo
+          * display = "Foo"
+    `);
+
+      const result = importSingleText(input, 'Context.fsh');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+      expect(result.instances.size).toBe(1);
+      const instance = result.instances.get('Foo');
+      expect(instance.name).toBe('Foo');
+      expect(instance.instanceOf).toBe('Questionnaire');
+      expect(instance.rules.length).toBe(2);
+      assertAssignmentRule(
+        instance.rules[0],
+        'item[+].code',
+        new FshCode('foo').withFile('Context.fsh').withLocation([5, 12, 5, 15])
+      );
+      assertAssignmentRule(instance.rules[1], 'item[=].code.display', 'Foo');
+    });
+
     it('should change nested + to = when setting context on children of soft indexed rules', () => {
       const input = leftAlign(`
       Instance: Foo


### PR DESCRIPTION
Fixes #973

SUSHI was not handling the context correctly when there were multiple path rules with soft-indexing.  The first issue was with indented rules like this:
```
* item[+]
  * item[+]
    * linkId = "MyLink"
```
This would result in creating or splitting extra items.  Reproduce this issue w/ FSHOnline here: https://fshschool.org/FSHOnline/#/share/3olm9LN

The 2nd issue was that path-only rules were ignored if they weren't used.  For example:
```
* item[+]
* item[+]
  * linkId = "MyLink"
```
Someone might *think* that the first rule creates an empty item and so the item w/ the linkId is at index 1.  But that's not how SUSHI works.  SUSHI ignores the first rule as a no-op, so just creates the one item at index 0 w/ the linkId.  I think this is actually correct since FSH says that path rules are only used to establish context for indented rules that follow them.  But since it can be confusing to users, I've added a WARNING when this happens.

The tests reproduce the issues, but you can easily reproduce them manually as well.  For the first one, you can just use the same FSH as in the linked FSH Online example.