### PR TITLE
Fix Spurious Soft Indexing Warnings

### DIFF
--- a/test/import/FSHImporter.context.test.ts
+++ b/test/import/FSHImporter.context.test.ts
@@ -233,6 +233,26 @@ describe('FSHImporter', () => {
       assertAssignmentRule(instance.rules[0], 'item[+].linkId', 'bar');
     });
 
+    it('should not log a warning for non-path rules that increment the index', () => {
+      const input = leftAlign(`
+      Instance: Foo
+      InstanceOf: Questionnaire
+      * item[+].linkId = "foo"
+      * item[+].linkId = "bar"
+    `);
+
+      const result = importSingleText(input, 'Context.fsh');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+      expect(result.instances.size).toBe(1);
+      const instance = result.instances.get('Foo');
+      expect(instance.name).toBe('Foo');
+      expect(instance.instanceOf).toBe('Questionnaire');
+      expect(instance.rules.length).toBe(2);
+      assertAssignmentRule(instance.rules[0], 'item[+].linkId', 'foo');
+      assertAssignmentRule(instance.rules[1], 'item[+].linkId', 'bar');
+    });
+
     it('should change + to = when setting context on children of soft indexed rules which are not path rules', () => {
       const input = leftAlign(`
       Instance: Foo


### PR DESCRIPTION
Fixes #978 

SUSHI 2.2.2 introduced a bug that caused warnings to be produced for completely valid uses of soft indexing.  See #978 for an example.

To test, run the example code in #978 using SUSHI 2.2.2 (or master).  Then run the same code using this PR.

_NOTE: I have done a full regression and confirmed this does not affect the actual output of any IGs._