### PR TITLE
Convert dependency package ids to lowercase when extracted from IG resource

### DIFF
--- a/src/import/loadConfigurationFromIgResource.ts
+++ b/src/import/loadConfigurationFromIgResource.ts
@@ -58,6 +58,7 @@ export function loadConfigurationFromIgResource(igRoot: string): Configuration |
   });
   // Extract the configuration from the resource
   if (igResource && igResource.url && !multipleIgs) {
+    logger.info(`Extracting FSHOnly configuration from ${igPath}...`);
     const config = {
       canonical: igResource.url.replace(/\/ImplementationGuide.*/, ''),
       version: igResource.version,
@@ -65,7 +66,16 @@ export function loadConfigurationFromIgResource(igRoot: string): Configuration |
       dependencies: igResource.dependsOn?.filter(dep => dep.packageId && dep.version),
       FSHOnly: true
     };
-    logger.info(`Extracting FSHOnly configuration from ${igPath}:`);
+    config.dependencies?.forEach(dep => {
+      if (/[A-Z]/.test(dep.packageId)) {
+        const lowercasePackageId = dep.packageId.toLowerCase();
+        logger.warn(
+          `Dependency ${dep.packageId} contains uppercase characters, which is discouraged. SUSHI will use ${lowercasePackageId} as the package name.`
+        );
+        dep.packageId = lowercasePackageId;
+      }
+    });
+    logger.info('Extracted configuration:');
     Object.entries(config).forEach(e => {
       if (Array.isArray(e[1])) {
         e[1].forEach((sub: any, i: number) => {

--- a/test/import/fixtures/ig-JSON-uppercase-deps/input/ImplementationGuide.json
+++ b/test/import/fixtures/ig-JSON-uppercase-deps/input/ImplementationGuide.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "ImplementationGuide",
+  "url": "http://example.org/ImplementationGuide",
+  "dependsOn": [
+    { "packageId": "FOO.BAR", "version": "1.2.3" },
+    { "packageId": "bAr.fOo", "version": "current" },
+    { "packageId": "boo.far", "version": "0.0.1" }
+  ],
+  "fhirVersion": [
+    "4.0.1"
+  ],
+  "version": "1.0.0"
+}

--- a/test/import/fixtures/ig-JSON-uppercase-deps/not-config.yaml
+++ b/test/import/fixtures/ig-JSON-uppercase-deps/not-config.yaml
@@ -1,0 +1,1 @@
+# This is not a config file

--- a/test/import/fixtures/ig-XML-uppercase-deps/input/ImplementationGuide.xml
+++ b/test/import/fixtures/ig-XML-uppercase-deps/input/ImplementationGuide.xml
@@ -1,0 +1,17 @@
+
+<ImplementationGuide>
+  <url value="http://example.org/ImplementationGuide"/>
+  <dependsOn>
+    <packageId value="FOO.BAR"/>
+    <version value="1.2.3"/>
+  </dependsOn>
+  <dependsOn>
+    <packageId value="bAr.fOo"/>
+    <version value="current"/>
+  </dependsOn>
+  <dependsOn>
+    <packageId value="boo.far"/>
+    <version value="0.0.1"/>
+  </dependsOn>
+  <fhirVersion value="4.0.1"/>
+</ImplementationGuide>

--- a/test/import/fixtures/ig-XML-uppercase-deps/not-config.yaml
+++ b/test/import/fixtures/ig-XML-uppercase-deps/not-config.yaml
@@ -1,0 +1,1 @@
+# This is not a config file

--- a/test/import/loadConfigurationFromIgResource.test.ts
+++ b/test/import/loadConfigurationFromIgResource.test.ts
@@ -46,16 +46,50 @@ describe('loadConfigurationFromIgResource', () => {
     expect(loggerSpy.getFirstMessage('info')).toMatch(
       new RegExp(`from ${escapeRegExp(path.join(inputPath, 'input', 'ImplementationGuide.json'))}`)
     );
-    expect(loggerSpy.getMessageAtIndex(1, 'info')).toEqual('  canonical: "http://example.org"');
-    expect(loggerSpy.getMessageAtIndex(2, 'info')).toEqual('  version: "1.0.0"');
-    expect(loggerSpy.getMessageAtIndex(3, 'info')).toEqual('  fhirVersion[0]: "4.0.1"');
-    expect(loggerSpy.getMessageAtIndex(4, 'info')).toEqual(
+    expect(loggerSpy.getMessageAtIndex(1, 'info')).toEqual('Extracted configuration:');
+    expect(loggerSpy.getMessageAtIndex(2, 'info')).toEqual('  canonical: "http://example.org"');
+    expect(loggerSpy.getMessageAtIndex(3, 'info')).toEqual('  version: "1.0.0"');
+    expect(loggerSpy.getMessageAtIndex(4, 'info')).toEqual('  fhirVersion[0]: "4.0.1"');
+    expect(loggerSpy.getMessageAtIndex(5, 'info')).toEqual(
       '  dependencies[0]: {"packageId":"foo.bar","version":"1.2.3"}'
     );
-    expect(loggerSpy.getMessageAtIndex(5, 'info')).toEqual(
+    expect(loggerSpy.getMessageAtIndex(6, 'info')).toEqual(
       '  dependencies[1]: {"packageId":"bar.foo","version":"current"}'
     );
-    expect(loggerSpy.getMessageAtIndex(6, 'info')).toEqual('  FSHOnly: true');
+    expect(loggerSpy.getMessageAtIndex(7, 'info')).toEqual('  FSHOnly: true');
+  });
+
+  it('should convert uppercase package Ids to lowercase', () => {
+    const inputPath = path.join(__dirname, 'fixtures', 'ig-JSON-uppercase-deps');
+    const config = loadConfigurationFromIgResource(inputPath);
+    expect(config).toEqual({
+      canonical: 'http://example.org',
+      FSHOnly: true,
+      dependencies: [
+        { packageId: 'foo.bar', version: '1.2.3' },
+        { packageId: 'bar.foo', version: 'current' },
+        { packageId: 'boo.far', version: '0.0.1' }
+      ],
+      fhirVersion: ['4.0.1'],
+      version: '1.0.0'
+    });
+    expect(loggerSpy.getFirstMessage('info')).toMatch(
+      new RegExp(`from ${escapeRegExp(path.join(inputPath, 'input', 'ImplementationGuide.json'))}`)
+    );
+    expect(loggerSpy.getMessageAtIndex(1, 'info')).toEqual('Extracted configuration:');
+    expect(loggerSpy.getMessageAtIndex(2, 'info')).toEqual('  canonical: "http://example.org"');
+    expect(loggerSpy.getMessageAtIndex(3, 'info')).toEqual('  version: "1.0.0"');
+    expect(loggerSpy.getMessageAtIndex(4, 'info')).toEqual('  fhirVersion[0]: "4.0.1"');
+    expect(loggerSpy.getMessageAtIndex(5, 'info')).toEqual(
+      '  dependencies[0]: {"packageId":"foo.bar","version":"1.2.3"}'
+    );
+    expect(loggerSpy.getMessageAtIndex(6, 'info')).toEqual(
+      '  dependencies[1]: {"packageId":"bar.foo","version":"current"}'
+    );
+    expect(loggerSpy.getMessageAtIndex(7, 'info')).toEqual(
+      '  dependencies[2]: {"packageId":"boo.far","version":"0.0.1"}'
+    );
+    expect(loggerSpy.getMessageAtIndex(8, 'info')).toEqual('  FSHOnly: true');
   });
 
   it('should extract an XML configuration with a url and dependencies', () => {
@@ -73,6 +107,49 @@ describe('loadConfigurationFromIgResource', () => {
     expect(loggerSpy.getFirstMessage('info')).toMatch(
       new RegExp(`from ${escapeRegExp(path.join(inputPath, 'input', 'ImplementationGuide.xml'))}`)
     );
+    expect(loggerSpy.getMessageAtIndex(1, 'info')).toEqual('Extracted configuration:');
+    expect(loggerSpy.getMessageAtIndex(2, 'info')).toEqual('  canonical: "http://example.org"');
+    expect(loggerSpy.getMessageAtIndex(3, 'info')).toEqual('  version: undefined');
+    expect(loggerSpy.getMessageAtIndex(4, 'info')).toEqual('  fhirVersion[0]: "4.0.1"');
+    expect(loggerSpy.getMessageAtIndex(5, 'info')).toEqual(
+      '  dependencies[0]: {"packageId":"foo.bar","version":"1.2.3"}'
+    );
+    expect(loggerSpy.getMessageAtIndex(6, 'info')).toEqual(
+      '  dependencies[1]: {"packageId":"bar.foo","version":"current"}'
+    );
+    expect(loggerSpy.getMessageAtIndex(7, 'info')).toEqual('  FSHOnly: true');
+  });
+
+  it('should convert uppercase package Ids to lowercase when extracting from XML configuration', () => {
+    const inputPath = path.join(__dirname, 'fixtures', 'ig-XML-uppercase-deps');
+    const config = loadConfigurationFromIgResource(inputPath);
+    expect(config).toEqual({
+      canonical: 'http://example.org',
+      FSHOnly: true,
+      dependencies: [
+        { packageId: 'foo.bar', version: '1.2.3' },
+        { packageId: 'bar.foo', version: 'current' },
+        { packageId: 'boo.far', version: '0.0.1' }
+      ],
+      fhirVersion: ['4.0.1']
+    });
+    expect(loggerSpy.getFirstMessage('info')).toMatch(
+      new RegExp(`from ${escapeRegExp(path.join(inputPath, 'input', 'ImplementationGuide.xml'))}`)
+    );
+    expect(loggerSpy.getMessageAtIndex(1, 'info')).toEqual('Extracted configuration:');
+    expect(loggerSpy.getMessageAtIndex(2, 'info')).toEqual('  canonical: "http://example.org"');
+    expect(loggerSpy.getMessageAtIndex(3, 'info')).toEqual('  version: undefined');
+    expect(loggerSpy.getMessageAtIndex(4, 'info')).toEqual('  fhirVersion[0]: "4.0.1"');
+    expect(loggerSpy.getMessageAtIndex(5, 'info')).toEqual(
+      '  dependencies[0]: {"packageId":"foo.bar","version":"1.2.3"}'
+    );
+    expect(loggerSpy.getMessageAtIndex(6, 'info')).toEqual(
+      '  dependencies[1]: {"packageId":"bar.foo","version":"current"}'
+    );
+    expect(loggerSpy.getMessageAtIndex(7, 'info')).toEqual(
+      '  dependencies[2]: {"packageId":"boo.far","version":"0.0.1"}'
+    );
+    expect(loggerSpy.getMessageAtIndex(8, 'info')).toEqual('  FSHOnly: true');
   });
 
   it('should find the ImplementationGuide JSON file even when other files are present', () => {


### PR DESCRIPTION
Fixes #980.

A previous code change converted dependency package ids to lowercase when extracted from sushi-config.yaml.  This does the same for dependencies when extracted from an IG resource.

To test, run SUSHI against the following simple project:
[UpperDepsInIG.zip](https://github.com/FHIR/sushi/files/7705437/UpperDepsInIG.zip)

On master (or SUSHI 2.2.2), you'll get this error:
> error Failed to load IHE.ITI.PIXm#3.0.0: The package IHE.ITI.PIXm#3.0.0 could not be loaded locally or from the FHIR package registry.

On this PR, you'll get the following warning, but the build will still succeed:
> warn  Dependency IHE.ITI.PIXm contains uppercase characters, which is discouraged. SUSHI will use ihe.iti.pixm as the package name.

