### PR TITLE
Apply insert rules on Instances when fishing for metadata

### DIFF
--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -15,7 +15,7 @@ import {
 } from '../fshtypes';
 import { AssignmentRule } from '../fshtypes/rules';
 import { Type, Metadata, Fishable } from '../utils/Fishable';
-import { getUrlFromFshDefinition } from '../fhirtypes/common';
+import { getUrlFromFshDefinition, applyInsertRules } from '../fhirtypes/common';
 import flatMap from 'lodash/flatMap';
 
 export class FSHTank implements Fishable {
@@ -394,6 +394,8 @@ export class FSHTank implements Fishable {
           meta.resourceType = 'CodeSystem';
         }
       } else if (result instanceof Instance) {
+        // the url may be added in a RuleSet, so apply insert rules
+        applyInsertRules(result, this);
         result.rules?.forEach(r => {
           if (r.path === 'url' && r instanceof AssignmentRule && typeof r.value === 'string') {
             meta.url = r.value;


### PR DESCRIPTION
Fixes #958 and completes task [CIMPL-857](https://standardhealthrecord.atlassian.net/browse/CIMPL-857).

An Instance's url may be set by a rule from a RuleSet. Apply insert rules on the found instance so that these rules can be found in order to correctly determine the url.

It is not necessary to do this with other FSH types because Instances are exported after all other FSH types. So, the correct url can be found on the exported resource in the Package.