### PR TITLE
Fix output paths

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6740,6 +6740,14 @@
         }
       }
     },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -7493,6 +7501,14 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "ts-jest": {
       "version": "26.5.6",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.6.tgz",
@@ -7707,6 +7723,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "junk": "^3.1.0",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",
+    "sanitize-filename": "^1.6.3",
     "sax": "^1.2.4",
     "tar": "^5.0.11",
     "temp": "^0.9.1",

--- a/src/fhirtypes/CodeSystem.ts
+++ b/src/fhirtypes/CodeSystem.ts
@@ -53,7 +53,7 @@ export class CodeSystem {
    * @returns {string} the filename
    */
   getFileName(): string {
-    return sanitize(`CodeSystem-${this.id.replace(/\/\\/g, '-')}.json`, { replacement: '-' });
+    return sanitize(`CodeSystem-${this.id}.json`, { replacement: '-' });
   }
 
   /**

--- a/src/fhirtypes/CodeSystem.ts
+++ b/src/fhirtypes/CodeSystem.ts
@@ -1,3 +1,4 @@
+import sanitize from 'sanitize-filename';
 import { cloneDeep } from 'lodash';
 import { Meta } from './specialTypes';
 import { Extension } from '../fshtypes';
@@ -52,7 +53,7 @@ export class CodeSystem {
    * @returns {string} the filename
    */
   getFileName(): string {
-    return `CodeSystem-${this.id}.json`;
+    return sanitize(`CodeSystem-${this.id.replace(/\/\\/g, '-')}.json`, { replacement: '-' });
   }
 
   /**

--- a/src/fhirtypes/InstanceDefinition.ts
+++ b/src/fhirtypes/InstanceDefinition.ts
@@ -1,3 +1,4 @@
+import sanitize from 'sanitize-filename';
 import { difference, remove, pull, cloneDeep, isObjectLike } from 'lodash';
 import { Meta } from './specialTypes';
 import { HasId } from './mixins';
@@ -22,7 +23,9 @@ export class InstanceDefinition {
    * @returns {string} the filename
    */
   getFileName(): string {
-    return `${this.resourceType}-${this.id ?? this._instanceMeta.name}.json`;
+    return sanitize(`${this.resourceType}-${this.id ?? this._instanceMeta.name}.json`, {
+      replacement: '-'
+    });
   }
 
   toJSON(): any {

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -1,6 +1,7 @@
 import upperFirst from 'lodash/upperFirst';
 import cloneDeep from 'lodash/cloneDeep';
 import escapeRegExp from 'lodash/escapeRegExp';
+import sanitize from 'sanitize-filename';
 import { ElementDefinition, ElementDefinitionType, LooseElementDefJSON } from './ElementDefinition';
 import { Meta } from './specialTypes';
 import { Identifier, CodeableConcept, Coding, Narrative, Resource, Extension } from './dataTypes';
@@ -124,7 +125,7 @@ export class StructureDefinition {
    * @returns {string} the filename
    */
   getFileName(): string {
-    return `StructureDefinition-${this.id}.json`;
+    return sanitize(`StructureDefinition-${this.id}.json`, { replacement: '-' });
   }
 
   get pathType(): string {

--- a/src/fhirtypes/ValueSet.ts
+++ b/src/fhirtypes/ValueSet.ts
@@ -1,5 +1,5 @@
+import sanitize from 'sanitize-filename';
 import { Meta } from './specialTypes';
-
 import { Extension } from '../fshtypes';
 import { Narrative, Resource, Identifier, CodeableConcept, Coding } from './dataTypes';
 import { ContactDetail, UsageContext } from './metaDataTypes';
@@ -46,7 +46,7 @@ export class ValueSet {
    * @returns {string} the filename
    */
   getFileName(): string {
-    return `ValueSet-${this.id}.json`;
+    return sanitize(`ValueSet-${this.id}.json`, { replacement: '-' });
   }
 
   /**

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import ini from 'ini';
+import sanitize from 'sanitize-filename';
 import { EOL } from 'os';
 import { sortBy, words, pad, padEnd, repeat, cloneDeep } from 'lodash';
 import { titleCase } from 'title-case';
@@ -1071,7 +1072,11 @@ export class IGExporter {
    */
   addImplementationGuide(igPath: string): void {
     const igJSONFolder = path.join('fsh-generated', 'resources');
-    const igJsonPath = path.join(igPath, igJSONFolder, `ImplementationGuide-${this.ig.id}.json`);
+    const igJsonPath = path.join(
+      igPath,
+      igJSONFolder,
+      sanitize(`ImplementationGuide-${this.ig.id}.json`, { replacement: '-' })
+    );
     outputJSONSync(igJsonPath, this.ig, { spaces: 2 });
     logger.info(`Generated ImplementationGuide-${this.ig.id}.json`);
   }

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -16,7 +16,6 @@ import { FHIRDefinitions, loadFromPath, loadCustomResources } from '../../src/fh
 import { loggerSpy, TestFisher } from '../testhelpers';
 import { cloneDeep } from 'lodash';
 import { minimalConfig } from '../utils/minimalConfig';
-import { debug } from 'console';
 
 describe('IGExporter', () => {
   temp.track();

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -842,6 +842,54 @@ describe('Processing', () => {
         expect(loggerSpy.getLastMessage('info')).toMatch(/Exported 14 FHIR resources/s);
       });
 
+      it('should not allow devious characters in the resource file names', () => {
+        const tempDeviousIGPubRoot = temp.mkdirSync('output-ig-dir');
+        const deviousOutPackage = cloneDeep(outPackage);
+        deviousOutPackage.profiles.forEach(d => (d.id = `/../../devious/${d.id}`));
+        deviousOutPackage.extensions.forEach(d => (d.id = `/../../devious/${d.id}`));
+        deviousOutPackage.logicals.forEach(d => (d.id = `/../../devious/${d.id}`));
+        deviousOutPackage.resources.forEach(d => (d.id = `/../../devious/${d.id}`));
+        deviousOutPackage.valueSets.forEach(d => (d.id = `/../../devious/${d.id}`));
+        deviousOutPackage.codeSystems.forEach(d => (d.id = `/../../devious/${d.id}`));
+        deviousOutPackage.instances.forEach(d => (d.id = `/../../devious/${d.id}`));
+        writeFHIRResources(tempDeviousIGPubRoot, deviousOutPackage, defs, false);
+
+        // Make sure we didn't create the devious path
+        const deviousPath = path.join(tempDeviousIGPubRoot, 'fsh-generated', 'devious');
+        expect(fs.existsSync(deviousPath)).toBeFalse();
+
+        // Make sure we do have all the good file names
+        const angelicPath = path.join(tempDeviousIGPubRoot, 'fsh-generated', 'resources');
+        expect(fs.existsSync(angelicPath)).toBeTruthy();
+        const allAngelicFiles = fs.readdirSync(angelicPath);
+        expect(allAngelicFiles.length).toBe(16);
+        expect(allAngelicFiles).toContain(
+          'CapabilityStatement--..-..-devious-my-capabilities.json'
+        );
+        expect(allAngelicFiles).toContain('CodeSystem--..-..-devious-my-code-system.json');
+        expect(allAngelicFiles).toContain('ConceptMap--..-..-devious-my-concept-map.json');
+        expect(allAngelicFiles).toContain('Observation--..-..-devious-my-example.json');
+        expect(allAngelicFiles).toContain('Observation--..-..-devious-my-other-instance.json');
+        expect(allAngelicFiles).toContain('OperationDefinition--..-..-devious-my-operation.json');
+        expect(allAngelicFiles).toContain('Patient--..-..-devious-my-duplicate-instance.json');
+        expect(allAngelicFiles).toContain(
+          'StructureDefinition--..-..-devious-my-duplicate-profile.json'
+        );
+        expect(allAngelicFiles).toContain(
+          'StructureDefinition--..-..-devious-my-extension-instance.json'
+        );
+        expect(allAngelicFiles).toContain('StructureDefinition--..-..-devious-my-extension.json');
+        expect(allAngelicFiles).toContain('StructureDefinition--..-..-devious-my-logical.json');
+        expect(allAngelicFiles).toContain('StructureDefinition--..-..-devious-my-model.json');
+        expect(allAngelicFiles).toContain(
+          'StructureDefinition--..-..-devious-my-profile-instance.json'
+        );
+        expect(allAngelicFiles).toContain('StructureDefinition--..-..-devious-my-profile.json');
+        expect(allAngelicFiles).toContain('StructureDefinition--..-..-devious-my-resource.json');
+        expect(allAngelicFiles).toContain('ValueSet--..-..-devious-my-value-set.json');
+        expect(loggerSpy.getLastMessage('info')).toMatch(/Exported 16 FHIR resources/s);
+      });
+
       it('should not write a resource if that resource already exists in the "input" folder', () => {
         expect(
           fs.existsSync(


### PR DESCRIPTION
Fixes #990.

Since SUSHI uses resource ids and IG ids to name files, it is possible to provide an id w/ path traversal characters (e.g., `/../../` to write to an arbitrary location).  Since SUSHI only writes `JSON` files, however, note that this can only be used to write/overwrite files w/ a `.json` extension.

You can test this by first checking out only 7c8a745 and confirming the tests do not pass.  Then checking out the rest of the branch and confirming the tests pass.

I am also attaching a simple project ([NaughtyPaths.zip](https://github.com/FHIR/sushi/files/7748077/NaughtyPaths.zip)) that exercises the bug.  If you unzip it and run SUSHI on it:
* the currently released SUSHI will write SURPRISE.json and BOO.json files to your project root (instead of `fsh-generated/resources`)
* this PR branch will write them to `fsh-generated/resources` as expected, with problematic characters converted to `-`.