### PR TITLE
Support 5.0.0-snapshot1

### DIFF
--- a/regression/repos-all.txt
+++ b/regression/repos-all.txt
@@ -165,3 +165,17 @@ mcode/mcode-omop#master
 mcode/biomarker#master
 ehealthsuisse/ch-vacd#master
 oliveregger/BundleConformsTo#master
+# Added Tue Dec 21 2021 16:33:22 GMT-0500 (Eastern Standard Time)
+HL7/fhir-directory-query#master
+HL7/fhircast-docs#master
+JohnMoehrke/SlicingSlicedExtension#main
+hl7ch/ch-resp#master
+hl7ch/ch-ems#master
+hl7dk/dk-medcom-core#master
+hl7dk/dk-medcom-hospitalnotification#master
+hl7dk/dk-medcom-messaging#main
+IHE/ITI.MHDS#master
+medcomdk/FFBFSHTestScripts#master
+medcomdk/HospitalnotificationFSHTestScripts#master
+ehealthsuisse/ch-epr-mhealth#master
+ehealthsuisse/ch-mhd#master

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -357,6 +357,18 @@ describe('Processing', () => {
       });
     });
 
+    it('should support prerelease FHIR R4B snapshot dependencies', () => {
+      const config = cloneDeep(minimalConfig);
+      config.fhirVersion = ['4.3.0-snapshot1'];
+      const defs = new FHIRDefinitions();
+      return loadExternalDependencies(defs, config).then(() => {
+        expect(defs.packages).toEqual(['hl7.fhir.r4b.core#4.3.0-snapshot1']);
+        expect(loggerSpy.getLastMessage('warn')).toMatch(
+          /support for pre-release versions of FHIR is experimental/s
+        );
+      });
+    });
+
     it('should support official FHIR R4B dependency (will be 4.3.0)', () => {
       const config = cloneDeep(minimalConfig);
       config.fhirVersion = ['4.3.0'];
@@ -376,6 +388,28 @@ describe('Processing', () => {
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /support for pre-release versions of FHIR is experimental/s
         );
+      });
+    });
+
+    it('should support prerelease FHIR R5 snapshot dependencies', () => {
+      const config = cloneDeep(minimalConfig);
+      config.fhirVersion = ['5.0.0-snapshot1'];
+      const defs = new FHIRDefinitions();
+      return loadExternalDependencies(defs, config).then(() => {
+        expect(defs.packages).toEqual(['hl7.fhir.r5.core#5.0.0-snapshot1']);
+        expect(loggerSpy.getLastMessage('warn')).toMatch(
+          /support for pre-release versions of FHIR is experimental/s
+        );
+      });
+    });
+
+    it('should support official FHIR R5 dependency (will be 5.0.0)', () => {
+      const config = cloneDeep(minimalConfig);
+      config.fhirVersion = ['5.0.0'];
+      const defs = new FHIRDefinitions();
+      return loadExternalDependencies(defs, config).then(() => {
+        expect(defs.packages).toEqual(['hl7.fhir.r5.core#5.0.0']);
+        expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       });
     });
 


### PR DESCRIPTION
This PR adds support for `fhirVersion: 5.0.0-snapshot1`.  Previous versions of SUSHI expected the version number to always start with `4` (since even the R5 pre-releases used to start with `4`).  Now we support releases starting with `5` and do a better job of detecting pre-releases.

Fixes #994
