### PR TITLE
Do not be fooled by slices with the same name as the sliced element

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -301,7 +301,11 @@ export class StructureDefinition {
           // If matchingElement id ends with pathEnd:, then it is a slice
           // pathPart.brackets is null, so keep nonslices (no ":" in idEnd)
           // and choice slices since valueString is equivalent to value[x]:valueString
-          return !idEnd.includes(`${pathEnd}:`) || idEnd === `${pathEnd}:${pathPart.base}`;
+          // but, make sure to not be fooled by slices where the slice name is the same as the element name
+          return (
+            !idEnd.includes(`${pathEnd}:`) ||
+            (idEnd === `${pathEnd}:${pathPart.base}` && pathEnd !== pathPart.base)
+          );
         });
       }
     }

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -974,6 +974,19 @@ describe('StructureDefinition', () => {
       expect(respRate.elements.length).toBe(originalLength);
     });
 
+    it('should find an element that is the grandchild or deeper descendant of an element that has a slice with the same name as the ancestor element', () => {
+      const component = respRate.findElementByPath('component', fisher);
+      component.slicing = {
+        discriminator: [{ type: 'pattern', path: '$this' }],
+        rules: 'open'
+      };
+      component.addSlice('component');
+      // force an unfolding by finding a descendant of the slice
+      respRate.findElementByPath('component[component].dataAbsentReason', fisher);
+      const descendant = respRate.findElementByPath('component.referenceRange.low', fisher);
+      expect(descendant).toBeDefined();
+    });
+
     it('should find a re-sliced element by path', () => {
       const jsonReslice = JSON.parse(
         fs.readFileSync(


### PR DESCRIPTION
Fixes #993

When finding an element by path, it is permitted to use the name of a choice element slice (such as `valueString`) directly in a path. This is achieved by considering elements to match when the element id contains the appropriate path part and slice name (`value[x]:valueString`, for example). However, this should only be supported for choice elements, so do not consider an element to be a match when the name of the slice and the name of the element are the same.

Basically, without this change, the "remove slices" filter wouldn't remove the slice that had the same name as the element. Also, the bug only occurs when looking for a sufficiently deep descendant of the sliced element. What a thrill!