### PR TITLE
Update link to VS Code FSH extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ For the best experience, developers should use [Visual Studio Code](https://code
         "editor.formatOnSave": true
     }
     ```
-- [vscode-language-fsh](https://marketplace.visualstudio.com/items?itemName=kmahalingam.vscode-language-fsh)
+- [vscode-language-fsh](https://marketplace.visualstudio.com/items?itemName=MITRE-Health.vscode-language-fsh)
 
 # License
 
-Copyright 2019 Health Level Seven International
+Copyright 2019-2022 Health Level Seven International
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/utils/init-project/sushi-config.yaml
+++ b/src/utils/init-project/sushi-config.yaml
@@ -167,20 +167,20 @@ menu:
 # * copyright
 # * packageId
 #
-# 
+#
 # ╭──────────────────────────────────────────SUSHI flags───────────────────────────────────────────╮
 # │  The flags below configure aspects of how SUSHI processes FSH.                                 │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 # The FSHOnly flag indicates if only FSH resources should be exported.
 # If set to true, no IG related content will be generated.
 # The default value for this property is false.
-# 
+#
 # FSHOnly: false
 #
-# 
+#
 # When set to true, the "short" and "definition" field on the root element of an Extension will
 # be set to the "Title" and "Description" of that Extension. Default is true.
-# 
+#
 # applyExtensionMetadataToRoot: true
 #
 #

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -1149,6 +1149,7 @@ describe('Processing', () => {
             'utf-8'
           )
           .replace(/[\n\r]/g, '')
+          .replace('${YEAR}', String(new Date().getFullYear()))
       );
 
       expect(copyFileSpy.mock.calls).toHaveLength(3);
@@ -1221,6 +1222,7 @@ describe('Processing', () => {
             'utf-8'
           )
           .replace(/[\n\r]/g, '')
+          .replace('${YEAR}', String(new Date().getFullYear()))
       );
       expect(copyFileSpy.mock.calls).toHaveLength(3);
       expect(copyFileSpy.mock.calls[0][1]).toMatch(/.*MyNonDefaultName.*fsh.*patient.fsh/);

--- a/test/utils/fixtures/init-config/default-config.yaml
+++ b/test/utils/fixtures/init-config/default-config.yaml
@@ -11,7 +11,7 @@ name: ExampleIG
 status: draft # draft | active | retired | unknown
 version: 0.1.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
-copyrightYear: 2021+
+copyrightYear: ${YEAR}+
 releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
@@ -167,20 +167,20 @@ menu:
 # * copyright
 # * packageId
 #
-# 
+#
 # ╭──────────────────────────────────────────SUSHI flags───────────────────────────────────────────╮
 # │  The flags below configure aspects of how SUSHI processes FSH.                                 │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 # The FSHOnly flag indicates if only FSH resources should be exported.
 # If set to true, no IG related content will be generated.
 # The default value for this property is false.
-# 
+#
 # FSHOnly: false
 #
-# 
+#
 # When set to true, the "short" and "definition" field on the root element of an Extension will
 # be set to the "Title" and "Description" of that Extension. Default is true.
-# 
+#
 # applyExtensionMetadataToRoot: true
 #
 #

--- a/test/utils/fixtures/init-config/user-input-config.yaml
+++ b/test/utils/fixtures/init-config/user-input-config.yaml
@@ -11,7 +11,7 @@ name: MyNonDefaultName
 status: active # draft | active | retired | unknown
 version: 2.0.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
-copyrightYear: 2021+
+copyrightYear: ${YEAR}+
 releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
@@ -167,20 +167,20 @@ menu:
 # * copyright
 # * packageId
 #
-# 
+#
 # ╭──────────────────────────────────────────SUSHI flags───────────────────────────────────────────╮
 # │  The flags below configure aspects of how SUSHI processes FSH.                                 │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 # The FSHOnly flag indicates if only FSH resources should be exported.
 # If set to true, no IG related content will be generated.
 # The default value for this property is false.
-# 
+#
 # FSHOnly: false
 #
-# 
+#
 # When set to true, the "short" and "definition" field on the root element of an Extension will
 # be set to the "Title" and "Description" of that Extension. Default is true.
-# 
+#
 # applyExtensionMetadataToRoot: true
 #
 #


### PR DESCRIPTION
The name kind of says it all.

Actually, it doesn't.  I also updated the copyright dates.

There.  Now it has all been said.

_EDIT: No, it has not all been said. I have also fixed the date-sensitive SUSHI init tests.  So... *now* all has been said._