### PR TITLE
All resource types supported as instance values on fixed value rules

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -318,6 +318,12 @@ export class InstanceExporter implements Fishable {
       if (fshDefinition) {
         this.exportInstance(fshDefinition);
         result = this.pkg.fish(item, Type.Instance) as InstanceDefinition;
+      } else {
+        // If we don't find any Instances with the name, fish for other resources
+        const fishedFHIR = this.fisher.fishForFHIR(item);
+        if (fishedFHIR && fishedFHIR.resourceType) {
+          result = InstanceDefinition.fromJSON(fishedFHIR);
+        }
       }
     }
     return result;

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -3703,6 +3703,24 @@ describe('InstanceExporter', () => {
         ]);
       });
 
+      it('should assign other resources to an instance', () => {
+        const containedRule1 = new AssignmentRule('contained[0]');
+        containedRule1.value = 'allergyintolerance-clinical';
+        containedRule1.isInstance = true;
+        patientInstance.rules.push(containedRule1); // * contained[0] = allergyintolerance-clinical
+
+        const containedRule2 = new AssignmentRule('contained[1]');
+        containedRule2.value = 'w3c-provenance-activity-type';
+        containedRule2.isInstance = true;
+        patientInstance.rules.push(containedRule2); // * contained[1] = w3c-provenance-activity-type
+
+        const exported = exportInstance(patientInstance);
+        expect(exported.contained[0].id).toBe('allergyintolerance-clinical');
+        expect(exported.contained[0].resourceType).toBe('ValueSet');
+        expect(exported.contained[1].id).toBe('w3c-provenance-activity-type');
+        expect(exported.contained[1].resourceType).toBe('CodeSystem');
+      });
+
       it('should assign an inline resource to an instance element with a specific type', () => {
         const bundleValRule = new AssignmentRule('entry[PatientsOnly].resource');
         bundleValRule.value = 'MyInlinePatient';


### PR DESCRIPTION
Fixes #971, allowing `ValueSets` (and all other resource types) to be included on Instances as the value in fixed value rules. Also changes the copyrightDate in our `sushi-config.yaml` fixtures to reflect the new year.