### PR TITLE
Update html-minifier options

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1890,7 +1890,12 @@ export class ElementDefinition {
     } else if (type == 'xhtml' && this.checkXhtml(value)) {
       this.assignFHIRValue(`"${value}"`, value, exactly, type);
       // If we got here, the assigned value is valid. Replace the XML with a minimized version.
-      this[exactly ? 'fixedXhtml' : 'patternXhtml'] = minify(value, { collapseWhitespace: true });
+      // For minimizer options, see: https://www.npmjs.com/package/html-minifier#options-quick-reference
+      this[exactly ? 'fixedXhtml' : 'patternXhtml'] = minify(value, {
+        collapseWhitespace: true,
+        html5: false,
+        keepClosingSlash: true
+      });
     } else {
       throw new MismatchedTypeError('string', value, type);
     }


### PR DESCRIPTION
Updates html-minifier options to that it:
- doesn't remove closing slash from tags like <br/> (since XHTML requires them)
- parses using HTML 4 instead of 5 since XHTML is more like HTML 4 than 5

Fixes #1001

I ran regression against all repos and this affected three:
* AudaciousInquiry/fhir-saner#master
* hl7-eu/gravitate-health#master
* HL7/fhir-pacio-adi#main

I investigated each one and confirmed that the changes are expected and good.

You can test this using a sample project and the following FSH:
```
Instance: MyPatientSelfClosingBR
InstanceOf: Patient
* text.status = #additional
// If you do the RIGHT thing and use a self-closing <br/>, SUSHI strips the /!
* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><br/></div>"

Instance: MyPatientSeparateBRClosingTag
InstanceOf: Patient
* text.status = #additional
// Even if you do a separate closing </br>, SUSHI still strips the /.
// But oddly enough, the closing </div> tag does not get stripped!
* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><br/></div>"
```

On master, the output XHTML will have `<br>`.  On this branch, it will have `<br/>`.