### PR TITLE
Include configured extensions on resources

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -748,6 +748,9 @@ export class IGExporter {
         } else {
           newResource.exampleBoolean = false;
         }
+        if (configResource?.extension?.length) {
+          newResource.extension = configResource.extension;
+        }
         this.ig.definition.resource.push(newResource);
       }
     });
@@ -797,6 +800,9 @@ export class IGExporter {
             } else {
               newResource.exampleBoolean = false;
             }
+          }
+          if (configResource?.extension?.length) {
+            newResource.extension = configResource.extension;
           }
           this.ig.definition.resource.push(newResource);
         }
@@ -939,6 +945,9 @@ export class IGExporter {
                   title ??
                   name ??
                   resourceJSON.id;
+              }
+              if (configResource?.extension?.length) {
+                newResource.extension = configResource.extension;
               }
 
               if (existingIndex >= 0) {

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -110,6 +110,27 @@ describe('IGExporter', () => {
             version: '1.0.0'
           }
         ],
+        resources: [
+          {
+            reference: { reference: 'Patient/patient-example' },
+            name: 'Patient Example',
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/implementationguide-resource-format',
+                valueCode: 'text/plain'
+              }
+            ]
+          },
+          {
+            reference: { reference: 'StructureDefinition/sample-patient' },
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/implementationguide-resource-format',
+                valueCode: 'text/plain'
+              }
+            ]
+          }
+        ],
         status: 'active',
         fhirVersion: ['4.0.1'],
         language: 'en',
@@ -224,6 +245,13 @@ describe('IGExporter', () => {
               reference: {
                 reference: 'StructureDefinition/sample-patient'
               },
+              extension: [
+                // Extension is added from config
+                {
+                  url: 'http://hl7.org/fhir/StructureDefinition/implementationguide-resource-format',
+                  valueCode: 'text/plain'
+                }
+              ],
               name: 'SamplePatient',
               description:
                 'Demographics and other administrative information about an individual or animal receiving care or other health-related services.',
@@ -266,7 +294,14 @@ describe('IGExporter', () => {
               reference: {
                 reference: 'Patient/patient-example'
               },
-              name: 'patient-example',
+              name: 'Patient Example', // Name from config overrides _instanceMeta.name
+              extension: [
+                // Extension is added from config
+                {
+                  url: 'http://hl7.org/fhir/StructureDefinition/implementationguide-resource-format',
+                  valueCode: 'text/plain'
+                }
+              ],
               exampleBoolean: true // No defined Usage on FSH file sets this to true
             },
             {
@@ -1188,6 +1223,17 @@ describe('IGExporter', () => {
       loggerSpy.reset();
       tempOut = temp.mkdirSync('sushi-test');
       config = cloneDeep(minimalConfig);
+      config.resources = [
+        {
+          reference: { reference: 'Patient/BazPatient' },
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/implementationguide-resource-format',
+              valueCode: 'text/plain'
+            }
+          ]
+        }
+      ];
       pkg = new Package(config);
       // Add a patient to the package that will be overwritten
       const fisher = new TestFisher(null, defs, pkg);
@@ -1262,6 +1308,12 @@ describe('IGExporter', () => {
           reference: 'Patient/BazPatient'
         },
         name: 'BazPatient',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/implementationguide-resource-format',
+            valueCode: 'text/plain'
+          }
+        ],
         exampleBoolean: false
       });
       expect(igContent.definition.resource).toContainEqual({


### PR DESCRIPTION
Fixes #1005 

This PR adds support for using the configured extensions when creating the `definition.resource` entries. This resolves the bug because the extensions weren't getting dropped, but instead were just never carried over. The reason this worked with the Logical Model examples is because they are never defined in FSH but are only provided as a JSON/XML resource and added to the sushi-config.yaml file. Now, if you do have FSH defined examples and provide any extensions in sushi-config.yaml, it will be carried over to the generated IG resource.

I this this is an appropriate way to solve this bug because it looks like it follows the pattern that is used for every other property on the `resource` entry, but if this doesn't line up with others' understanding of how we generate the IG resource or the `definition.resource` list, let me know.

Also, I'm running the full regression now ~and will update here if it looks good!~ Edit: It looks good!