### PR TITLE
Don't clone original ElementDefinition's StructureDefinition

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -385,10 +385,11 @@ export class ElementDefinition {
   /**
    * ElementDefinition is capable of producing its own differential, based on differences from a stored "original".
    * This function captures the current state as the "original", so any further changes made would be captured in
-   * the generated differential.
+   * the generated differential. The structDef reference isn't used in the differential, so it can be removed.
    */
   captureOriginal(): void {
     this._original = this.clone();
+    this._original.structDef = undefined;
   }
 
   /**
@@ -2467,18 +2468,9 @@ export class ElementDefinition {
     // We don't want to clone the reference to the StructureDefinition, so temporarily save it and remove it
     const savedStructDef = this.structDef;
     this.structDef = null;
-    // We don't want to clone the reference to the StructureDefinition on the original, either
-    let originalStructDef: StructureDefinition;
-    if (this._original?.structDef != null) {
-      originalStructDef = this._original.structDef;
-      this._original.structDef = null;
-    }
     const clone = cloneDeep(this);
     // Set the reference to the StructureDefinition again
     this.structDef = clone.structDef = savedStructDef;
-    if (originalStructDef != null) {
-      this._original.structDef = clone._original.structDef = originalStructDef;
-    }
     // Clear original if applicable
     if (clearOriginal) {
       clone.clearOriginal();

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -2467,9 +2467,18 @@ export class ElementDefinition {
     // We don't want to clone the reference to the StructureDefinition, so temporarily save it and remove it
     const savedStructDef = this.structDef;
     this.structDef = null;
+    // We don't want to clone the reference to the StructureDefinition on the original, either
+    let originalStructDef: StructureDefinition;
+    if (this._original?.structDef != null) {
+      originalStructDef = this._original.structDef;
+      this._original.structDef = null;
+    }
     const clone = cloneDeep(this);
     // Set the reference to the StructureDefinition again
     this.structDef = clone.structDef = savedStructDef;
+    if (originalStructDef != null) {
+      this._original.structDef = clone._original.structDef = originalStructDef;
+    }
     // Clear original if applicable
     if (clearOriginal) {
       clone.clearOriginal();

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -748,6 +748,12 @@ describe('ElementDefinition', () => {
       expect(clone.structDef).toBe(valueX.structDef);
     });
 
+    it('should keep the same structDef reference on the original version', () => {
+      const clone = valueX.clone(false);
+      // @ts-ignore
+      expect(clone._original.structDef).toBe(valueX._original.structDef);
+    });
+
     it('should clear original by default', () => {
       valueX.captureOriginal();
       const clone = valueX.clone();

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -748,12 +748,6 @@ describe('ElementDefinition', () => {
       expect(clone.structDef).toBe(valueX.structDef);
     });
 
-    it('should keep the same structDef reference on the original version', () => {
-      const clone = valueX.clone(false);
-      // @ts-ignore
-      expect(clone._original.structDef).toBe(valueX._original.structDef);
-    });
-
     it('should clear original by default', () => {
       valueX.captureOriginal();
       const clone = valueX.clone();


### PR DESCRIPTION
Completes task [CIMPL-890](https://standardhealthrecord.atlassian.net/browse/CIMPL-890).

When cloning an ElementDefinition, save and remove the referenced StructureDefinitions on the element and the element's original version. Then, after cloning the other properties, restore those references.

By not duplicating the (often large) object at `ElementDefinition._original.structDef` during the `clone` process, time and memory usage are reduced. This reduction is sufficient to avoid the previously-occurring errors reported in the issue description.

When running a full regression, only one IG showed changes: https://github.com/aehrc/primary-care-data-technical/archive/master.zip. Specifically, the `AUPrimaryCareMedication` profile's `Medication.ingredient.itemCodeableConcept` element is different. The current version of SUSHI produces this element:
```json
{
  "id": "Medication.ingredient.itemCodeableConcept",
  "path": "Medication.ingredient.itemCodeableConcept",
  "mustSupport": true
}
```

The version of SUSHI as of this PR produces this element:
```json
{
  "id": "Medication.ingredient.itemCodeableConcept",
  "path": "Medication.ingredient.itemCodeableConcept",
  "min": 0,
  "max": "1",
  "type": [
    {
      "code": "CodeableConcept"
    }
  ],
  "mustSupport": true
}
```
There is only one rule for this element:
```
* ingredient.itemCodeableConcept[itemCodeableConcept] MS
```
The actual JSON definition of the resource from the downloaded `hl7.fhir.au.base#current` dependency at https://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-medication.html does not contain any constraints on this choice. So, my best guess is that the output with the cardinality and type present is correct, as the individual choice-slice is only now present, and it receives the default cardinality for such an element.