### PR TITLE
Avoid call stack overflow when assigning large base64 values

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1848,6 +1848,16 @@ export class ElementDefinition {
     }
   }
 
+  private isValidBase64(value: string): boolean {
+    const base64Part = /(\s*([0-9a-zA-Z\+\/=]){4}\s*)/y;
+    while (base64Part.lastIndex < value.length) {
+      if (!base64Part.test(value)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * Assigns a string to this element.
    * @see {@link assignValue}
@@ -1865,8 +1875,7 @@ export class ElementDefinition {
       (type === 'uri' && /^\S*$/.test(value)) ||
       (type === 'url' && /^\S*$/.test(value)) ||
       (type === 'canonical' && /^\S*$/.test(value)) ||
-      (type === 'base64Binary' &&
-        (/^(\s*([0-9a-zA-Z\+\/=]){4}\s*)+$/.test(value) || value.startsWith('ig-loader-'))) ||
+      (type === 'base64Binary' && (this.isValidBase64(value) || value.startsWith('ig-loader-'))) ||
       (type === 'instant' &&
         /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))$/.test(
           value

--- a/test/fhirtypes/ElementDefinition.assignString.test.ts
+++ b/test/fhirtypes/ElementDefinition.assignString.test.ts
@@ -381,6 +381,15 @@ describe('ElementDefinition', () => {
       expect(dataElement.patternBase64Binary).toBeUndefined();
     });
 
+    it('should assign a very long string to a base64Binary', () => {
+      const dataElement = binary.elements.find(e => e.id === 'Binary.data');
+      const longValue = fs.readFileSync(path.join(__dirname, 'fixtures', 'imgdata.txt'), {
+        encoding: 'base64'
+      });
+      dataElement.assignValue(longValue);
+      expect(dataElement.patternBase64Binary).toBe(longValue);
+    });
+
     it('should throw ValueAlreadyAssignedError when assigning an already assigned base64Binary by pattern[x]', () => {
       const udiCarrierCarrierAIDC = device.elements.find(
         e => e.id === 'Device.udiCarrier.carrierAIDC'


### PR DESCRIPTION
Fixes #998 and completes task [CIMPL-876](https://standardhealthrecord.atlassian.net/browse/CIMPL-876).

When assigning a string to a base64Binary-type element, the value is checked to make sure it is meets the requirements of that type. The value must be composed of valid base64 chunks. Checking this one chunk at a time avoids the call stack overflow that may occur when checking the entire value all at once.