### PR TITLE
Allow underscore-prefixed primitives to satisfy cardinality requirements

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -219,7 +219,8 @@ export class InstanceExporter implements Fishable {
           .forEach(ce => possibleChoiceSlices.push(...ce.children(true)));
         const choiceSlices = possibleChoiceSlices.filter(c => c.path === child.path && c.sliceName);
         for (const choiceSlice of choiceSlices) {
-          instanceChild = instance[choiceSlice.sliceName];
+          // as above, we use the _ prefixed element if it exists
+          instanceChild = instance[`_${choiceSlice.sliceName}`] ?? instance[choiceSlice.sliceName];
           if (instanceChild != null) {
             // Once we find the the choiceSlice that matches, use it as the child
             child = choiceSlice;


### PR DESCRIPTION
Fixes #1021 and completes task [CIMPL-902](https://standardhealthrecord.atlassian.net/browse/CIMPL-902).

This issue turns out to have been specific to primitive-type choice element slices. When checking choice elements for a required element, use the underscore-prefixed version if it exists. This is consistent with the existing logic for cases that are not choice elements.