### PR TITLE
Update requirement for status and name

### DIFF
--- a/src/import/importConfiguration.ts
+++ b/src/import/importConfiguration.ts
@@ -132,10 +132,10 @@ export function importConfiguration(yaml: YAMLConfiguration | string, file: stri
     modifierExtension: yaml.modifierExtension,
     url: yaml.url ?? `${yaml.canonical}/ImplementationGuide/${yaml.id}`,
     version: normalizeToString(yaml.version), // minimum config property
-    name: required(yaml.name, 'name', file),
+    name: yaml.FSHOnly ? yaml.name : required(yaml.name, 'name', file),
     title: yaml.title,
     status: parseCodeWithRequiredValues(
-      required(yaml.status, 'status', file),
+      yaml.FSHOnly ? yaml.status : required(yaml.status, 'status', file),
       ['draft', 'active', 'retired', 'unknown'],
       'status',
       file

--- a/test/import/importConfiguration.test.ts
+++ b/test/import/importConfiguration.test.ts
@@ -248,6 +248,7 @@ describe('importConfiguration', () => {
       minYAML.FSHOnly = true;
       const config = importConfiguration(minYAML, 'test-config.yaml');
       expect(config.id).toBeUndefined();
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
   });
 
@@ -484,6 +485,7 @@ describe('importConfiguration', () => {
       minYAML.FSHOnly = true;
       const config = importConfiguration(minYAML, 'test-config.yaml');
       expect(config.name).toBeUndefined();
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
   });
 
@@ -530,6 +532,7 @@ describe('importConfiguration', () => {
       minYAML.FSHOnly = true;
       const config = importConfiguration(minYAML, 'test-config.yaml');
       expect(config.status).toBeUndefined();
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
We only require `name` and `status` properties in the `sushi-config.yaml` file when you are creating an IG resource. That means when you have `FSHOnly: true` in your configuration, you should not have any logged errors saying those values are required but missing. This PR updates the import of the configuration to only require those properties if `FSHOnly` is not set to true. This follows the pattern we already had for `copyrightYear` and `releaseLabel` [here](https://github.com/FHIR/sushi/blob/master/src/import/importConfiguration.ts#L687-L692). It also updates the tests to check that no errors are logged.

This should fix [GoFSH Issue #164](https://github.com/FHIR/GoFSH/issues/164) by loosening the requirement for `status`. GoFSH does not _need_ to provide `status` if it cannot find it, but SUSHI should not be expecting to find it on `sushi-config` files that are FSHOnly. When this change is merged into SUSHI and SUSHI is released, that issue will be resolved.