### PR TITLE
Do not warn on invalid names that are overwritten with caret rules + CODEOWNDERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @jafeltra @cmoesel @julianxcarter @mint-thompson @guhanthuran

--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -16,7 +16,7 @@ export class CodeSystemExporter {
   ) {}
 
   private setMetadata(codeSystem: CodeSystem, fshDefinition: FshCodeSystem): void {
-    codeSystem.setName(fshDefinition.name, fshDefinition.sourceInfo);
+    codeSystem.setName(fshDefinition, fshDefinition.sourceInfo);
     codeSystem.setId(fshDefinition.id, fshDefinition.sourceInfo);
     if (fshDefinition.title) codeSystem.title = fshDefinition.title;
     if (fshDefinition.description) codeSystem.description = fshDefinition.description;

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -298,7 +298,7 @@ export class StructureDefinitionExporter implements Fishable {
     // keep url since it was already defined when the StructureDefinition was initially created
     delete structDef.identifier;
     structDef.version = this.tank.config.version; // can be overridden using a rule
-    structDef.setName(fshDefinition.name, fshDefinition.sourceInfo);
+    structDef.setName(fshDefinition, fshDefinition.sourceInfo);
     if (fshDefinition.title) {
       structDef.title = fshDefinition.title;
       if (

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -28,7 +28,7 @@ export class ValueSetExporter {
   constructor(private readonly tank: FSHTank, private pkg: Package, private fisher: MasterFisher) {}
 
   private setMetadata(valueSet: ValueSet, fshDefinition: FshValueSet): void {
-    valueSet.setName(fshDefinition.name, fshDefinition.sourceInfo);
+    valueSet.setName(fshDefinition, fshDefinition.sourceInfo);
     valueSet.setId(fshDefinition.id, fshDefinition.sourceInfo);
     if (fshDefinition.title) {
       valueSet.title = fshDefinition.title;

--- a/src/fshtypes/index.ts
+++ b/src/fshtypes/index.ts
@@ -7,6 +7,7 @@ export * from './FshEntity';
 export * from './FshQuantity';
 export * from './FshRatio';
 export * from './FshReference';
+export * from './FshStructure';
 export * from './Instance';
 export * from './InstanceUsage';
 export * from './Profile';

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -241,6 +241,21 @@ describe('CodeSystemExporter', () => {
     expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Strange\.fsh.*Line: 3 - 8\D*/s);
   });
 
+  it('should not log a message when the code system overrides an invalid name with a Caret Rule', () => {
+    const codeSystem = new FshCodeSystem('Strange.Code.System')
+      .withFile('Strange.fsh')
+      .withLocation([3, 4, 8, 24]);
+    const nameRule = new CaretValueRule('');
+    nameRule.caretPath = 'name';
+    nameRule.value = 'StrangeCodeSystem';
+    codeSystem.rules.push(nameRule);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export().codeSystems;
+    expect(exported.length).toBe(1);
+    expect(exported[0].name).toBe('StrangeCodeSystem');
+    expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
+  });
+
   it('should sanitize the id and log a message when a valid name is used to make an invalid id', () => {
     const codeSystem = new FshCodeSystem('Not_good_id')
       .withFile('Wrong.fsh')

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -107,6 +107,20 @@ describe('StructureDefinitionExporter R4', () => {
       expect(loggerSpy.getLastMessage()).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
     });
 
+    it('should not log a message when the structure definition overrides an invalid name with a Caret Rule', () => {
+      const profile = new Profile('Not-good').withFile('Wrong.fsh').withLocation([2, 8, 5, 18]);
+      profile.parent = 'DomainResource';
+      const nameRule = new CaretValueRule('');
+      nameRule.caretPath = 'name';
+      nameRule.value = 'NotGood';
+      profile.rules.push(nameRule);
+      doc.profiles.set(profile.name, profile);
+      exporter.exportStructDef(profile);
+      const exported = pkg.profiles[0];
+      expect(exported.name).toBe('NotGood');
+      expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
+    });
+
     it('should sanitize the id and log a message when a valid name is used to make an invalid id', () => {
       const profile = new Profile('Not_good_id').withFile('Wrong.fsh').withLocation([2, 8, 5, 18]);
       profile.parent = 'DomainResource';

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -118,6 +118,21 @@ describe('ValueSetExporter', () => {
     expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Breakfast\.fsh.*Line: 2 - 8\D*/s);
   });
 
+  it('should not log a message when the value set overrides an invalid name with a Caret Rule', () => {
+    const valueSet = new FshValueSet('All-you-can-eat')
+      .withFile('Strange.fsh')
+      .withLocation([3, 4, 8, 24]);
+    const nameRule = new CaretValueRule('');
+    nameRule.caretPath = 'name';
+    nameRule.value = 'AllYouCanEat';
+    valueSet.rules.push(nameRule);
+    doc.valueSets.set(valueSet.name, valueSet);
+    const exported = exporter.export().valueSets;
+    expect(exported.length).toBe(1);
+    expect(exported[0].name).toBe('AllYouCanEat');
+    expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
+  });
+
   it('should sanitize the id and log a message when a valid name is used to make an invalid id', () => {
     const valueSet = new FshValueSet('Not_good_id')
       .withFile('Wrong.fsh')


### PR DESCRIPTION
Fixes #1024, making it so that a user is not warned for an invalid entity name when a Caret Rule is used to overwrite that name with a valid one. Also adds a `CODEOWNERS` file so we no longer need to manually add each other as reviewers on our PRs.