### PR TITLE
Merge existing values when assigning References

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -230,15 +230,12 @@ export function setPropertyOnInstance(
         } else {
           // Check if the instance already has the element being defined
           if (current[key] != null && typeof current[key] === 'object') {
-            // Check if the instance already has a quantity element
-            // Quantity elements are the only FHIR types with both a code and value
-            if (current[key].hasOwnProperty('value') && assignedValue.hasOwnProperty('code')) {
-              // Ensure that the existing value is not being overwritten
-              assignedValue = {
-                value: current[key].value,
-                ...assignedValue
-              };
-            }
+            // If the instance already has the element, we should merge it
+            // Cases where this applies:
+            // - Quantity elements that set a value and then set a code with the FSH code syntax
+            // - Reference elements that set other properties of reference (like identifier) directly
+            //   and set reference with the FSH Reference() keyword
+            Object.assign(assignedValue, current[key]);
           }
           current[key] = assignedValue;
         }

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -3840,6 +3840,22 @@ describe('InstanceExporter', () => {
       ]);
     });
 
+    it('should keep additional values assigned directly on a sibling path before assigning a value with Reference()', () => {
+      const observationInstance = new Instance('MyObs');
+      observationInstance.instanceOf = 'Observation';
+      const identifierValueRule = new AssignmentRule('subject.identifier.value');
+      identifierValueRule.value = 'foo';
+      observationInstance.rules.push(identifierValueRule); // * subject.identifier.value = "foo"
+      const referenceRule = new AssignmentRule('subject');
+      referenceRule.value = new FshReference('Bar'); // Patient
+      observationInstance.rules.push(referenceRule); // * subject = Reference(Bar)
+      doc.instances.set(observationInstance.name, observationInstance);
+
+      const result = exportInstance(observationInstance);
+      expect(result.subject.reference).toEqual('Patient/Bar');
+      expect(result.subject.identifier).toEqual({ value: 'foo' });
+    });
+
     describe('#Inline Instances', () => {
       beforeEach(() => {
         const inlineInstance = new Instance('MyInlinePatient');


### PR DESCRIPTION
Addresses [CIMPL-901](https://standardhealthrecord.atlassian.net/browse/CIMPL-901).

Previously, when assigning values to a `Reference` element that was `0..1` or `1..1` and then using the `Reference()` keyword, the previous values were overwritten. The [issue](https://standardhealthrecord.atlassian.net/browse/CIMPL-901) provides a good example to demonstrate this. Another very simple example is below:

```
Instance: ExamplePatient
InstanceOf: Patient

Instance: ExampleObservation
InstanceOf: Observation
* subject.identifier.use = #official
* subject.identifier.system = "https://example.org"
* subject.identifier.value = "12345"
* subject = Reference(ExamplePatient)
```

On master, this instance will produce the following `subject`:

```
"subject": {
  "reference": "Patient/ExamplePatient"
}
```

On this branch, it is correct and will produce this `subject`:

```
"subject": {
  "reference": "Patient/ExamplePatient",
  "identifier": {
    "use": "official",
    "system": "https://example.org",
    "value": "12345"
  }
}
```

To fix this, I made a pretty generic update that merges the existing object with the new value. This is similar to what happens when the reference can be an array (cardinality is `0..*` or `1..*`) and no tests broke, but if anyone thinks of a case that is negatively affected by this, please let me know.

