### PR TITLE
Register plugins from configuration

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6960,9 +6960,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,7 +30,8 @@ import {
   getRandomPun,
   setIgnoredWarnings,
   getLocalSushiVersion,
-  checkSushiVersion
+  checkSushiVersion,
+  PluginManager
 } from './utils';
 
 const FSH_VERSION = '2.0.0';
@@ -143,6 +144,10 @@ async function app() {
       process.exit(0);
     }
     config = readConfig(originalInput);
+    await PluginManager.processPluginConfiguration(
+      config.plugins,
+      path.join(input, '..', 'plugin')
+    );
     tank = fillTank(rawFSH, config);
   } catch {
     program.outputHelp();

--- a/src/errors/InvalidHookError.ts
+++ b/src/errors/InvalidHookError.ts
@@ -1,0 +1,7 @@
+export class InvalidHookError extends Error {
+  constructor(badHook: string, availableHooks: string[]) {
+    super(
+      `Cannot bind function to hook ${badHook}. Available hooks are: ${availableHooks.join(', ')}`
+    );
+  }
+}

--- a/src/errors/MissingPluginError.ts
+++ b/src/errors/MissingPluginError.ts
@@ -1,0 +1,5 @@
+export class MissingPluginError extends Error {
+  constructor(name: string) {
+    super(`Could not find ${name} in project plugin directory.`);
+  }
+}

--- a/src/errors/QuestionableNpmNameError.ts
+++ b/src/errors/QuestionableNpmNameError.ts
@@ -1,0 +1,5 @@
+export class QuestionableNpmNameError extends Error {
+  constructor() {
+    super('Target name does not appear to be a valid npm package name.');
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -56,3 +56,6 @@ export * from './InvalidChoiceTypeRulePathError';
 export * from './MismatchedBindingTypeError';
 export * from './ValidationError';
 export * from './InvalidElementForSlicingError';
+export * from './InvalidHookError';
+export * from './MissingPluginError';
+export * from './QuestionableNpmNameError';

--- a/src/fshtypes/Configuration.ts
+++ b/src/fshtypes/Configuration.ts
@@ -149,7 +149,7 @@ export type ConfigurationResource = ImplementationGuideDefinitionResource & { om
 
 export type PluginConfiguration = {
   name: string;
-  args?: any[];
+  args?: (string | number | boolean)[];
 };
 
 export type ConfigurationMenuItem = {

--- a/src/fshtypes/Configuration.ts
+++ b/src/fshtypes/Configuration.ts
@@ -96,6 +96,8 @@ export type Configuration = {
   // parameters see: https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
   parameters?: ImplementationGuideDefinitionParameter[];
 
+  plugins?: PluginConfiguration[];
+
   // The templates property corresponds 1:1 with IG.definition.template. Note that plural templates
   // refers to the IG.definiton.template definitions; not the publisher template in ig.ini.
   templates?: ImplementationGuideDefinitionTemplate[];
@@ -144,6 +146,11 @@ export type ConfigurationGroup = {
 };
 
 export type ConfigurationResource = ImplementationGuideDefinitionResource & { omit?: boolean };
+
+export type PluginConfiguration = {
+  name: string;
+  args?: any[];
+};
 
 export type ConfigurationMenuItem = {
   name: string;

--- a/src/import/YAMLConfiguration.ts
+++ b/src/import/YAMLConfiguration.ts
@@ -126,6 +126,8 @@ export type YAMLConfiguration = {
   // allowed parameters see: https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
   parameters?: YAMLConfigurationParameterMap;
 
+  plugins?: YAMLPluginConfiguration[];
+
   // The templates property corresponds 1:1 with IG.definition.template. The templates value can be
   // a single item or a list. Note that the pluralized name 'templates' refers to the
   // IG.definiton.template definitions; the singularized name 'template' refers to the specific
@@ -359,6 +361,11 @@ export type YAMLConfigurationPage = null | {
 export type YAMLConfigurationParameterMap = {
   // YAML will parse some of parameter values as numbers or booleans
   [key: string]: string | number | boolean | (string | number | boolean)[];
+};
+
+export type YAMLPluginConfiguration = {
+  name: string;
+  args?: (string | number | boolean)[];
 };
 
 export type YAMLConfigurationMenuTree = {

--- a/src/import/importConfiguration.ts
+++ b/src/import/importConfiguration.ts
@@ -153,6 +153,7 @@ export function importConfiguration(yaml: YAMLConfiguration | string, file: stri
     resources: parseResources(yaml.resources, file),
     pages: parsePages(yaml.pages, file),
     parameters: parseParameters(yaml, yaml.FSHOnly, file),
+    plugins: yaml.plugins,
     templates: parseTemplates(yaml.templates, file),
     template: yaml.template,
     menu: parseMenu(yaml.menu),

--- a/src/utils/PluginManager.ts
+++ b/src/utils/PluginManager.ts
@@ -1,0 +1,123 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { execFile } from 'child_process';
+import util from 'util';
+import { InvalidHookError, MissingPluginError, QuestionableNpmNameError } from '../errors';
+import { PluginConfiguration } from '../fshtypes';
+import { logger } from './FSHLogger';
+
+export const AVAILABLE_HOOKS = [
+  'beforeFillTank',
+  'beforeLoadCustomResources',
+  'afterLoadCustomResources',
+  'afterExportFHIR'
+];
+
+export class PluginManager {
+  static hooks = new Map<string, ((...args: any) => any)[]>();
+
+  static async processPluginConfiguration(
+    plugins: PluginConfiguration[],
+    pluginBasePath: string
+  ): Promise<void> {
+    for (const plugin of plugins) {
+      // if the plugin name is given as name@version, it's something we may need to load from npm
+      // otherwise, we load it from the filesystem
+      // when we load from the filesystem, it might be at pluginBasePath, or at pluginBasePath/node_modules
+      const versionSeparator = plugin.name.lastIndexOf('@');
+      let pluginName: string;
+      let pluginVersion: string;
+      if (versionSeparator > 0) {
+        pluginName = plugin.name.slice(0, versionSeparator);
+        pluginVersion = plugin.name.slice(versionSeparator + 1);
+      } else {
+        pluginName = plugin.name;
+      }
+      try {
+        if (pluginVersion != null) {
+          // this is a plugin that can be acquired from npm.
+          // it might already be installed, so check for that first.
+          const existingInstallationPath = path.join(pluginBasePath, 'node_modules', pluginName);
+          if (fs.existsSync(path.join(existingInstallationPath, 'package.json'))) {
+            // check the version number in package.json
+            const packageContents = fs.readJsonSync(
+              path.join(existingInstallationPath, 'package.json')
+            );
+            if (packageContents.version === pluginVersion) {
+              PluginManager.loadFromFilesystem([existingInstallationPath], pluginName, plugin.args);
+            } else {
+              await PluginManager.installFromNpm(pluginBasePath, plugin.name);
+              PluginManager.loadFromFilesystem([existingInstallationPath], pluginName, plugin.args);
+            }
+          } else {
+            await PluginManager.installFromNpm(pluginBasePath, plugin.name);
+            PluginManager.loadFromFilesystem([existingInstallationPath], pluginName, plugin.args);
+          }
+        } else {
+          // this is a plugin managed on the local filesystem.
+          // it may be at the base path, or in the node_modules directory
+          PluginManager.loadFromFilesystem(
+            [
+              path.join(pluginBasePath, pluginName),
+              path.join(pluginBasePath, 'node_modules', pluginName)
+            ],
+            pluginName,
+            plugin.args
+          );
+        }
+      } catch (err) {
+        logger.error(`Couldn't load plugin ${plugin.name}: ${err.message}`);
+      }
+    }
+  }
+
+  // a small test for name safety, based on typical naming patterns for npm packages
+  static isNameNpmSafe(name: string): boolean {
+    return /^[\w\d@/._-]+$/.test(name);
+  }
+
+  static async installFromNpm(installPath: string, installTarget: string) {
+    if (PluginManager.isNameNpmSafe(installTarget)) {
+      fs.ensureDirSync(installPath);
+      const installationResult = await util.promisify(execFile)(
+        'npm',
+        ['install', '--prefix', '.', installTarget],
+        {
+          cwd: installPath,
+          shell: true
+        }
+      );
+      if (installationResult.stderr.length > 0) {
+        throw new Error(installationResult.stderr);
+      } else {
+        logger.info(`Installed plugin ${installTarget}`);
+      }
+    } else {
+      throw new QuestionableNpmNameError();
+    }
+  }
+
+  static loadFromFilesystem(basePaths: string[], name: string, pluginArgs: any[] = []) {
+    for (const basePath of basePaths) {
+      const pluginPath = path.resolve(basePath);
+      if (fs.existsSync(pluginPath) && fs.statSync(pluginPath).isDirectory()) {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require(pluginPath).initialize(PluginManager.registerHook, ...pluginArgs);
+        logger.info(`Initialized plugin: ${name}`);
+        return;
+      }
+    }
+    throw new MissingPluginError(name);
+  }
+
+  static registerHook(hook: string, action: (...args: any) => any): void {
+    if (AVAILABLE_HOOKS.includes(hook)) {
+      if (!PluginManager.hooks.has(hook)) {
+        PluginManager.hooks.set(hook, []);
+      }
+      PluginManager.hooks.get(hook).push(action);
+    } else {
+      throw new InvalidHookError(hook, AVAILABLE_HOOKS);
+    }
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,4 +4,5 @@ export * from './MasterFisher';
 export * from './Mixin';
 export * from './Processing';
 export * from './PathUtils';
+export * from './PluginManager';
 export * from './puns';

--- a/test/import/YAMLConfiguration.test.ts
+++ b/test/import/YAMLConfiguration.test.ts
@@ -48,6 +48,15 @@ describe('YAMLConfiguration', () => {
         }
       ]);
       expect(config.jurisdiction).toBe('urn:iso:std:iso:3166#US "United States of America"');
+      expect(config.plugins).toEqual([
+        {
+          name: 'simple-plugin'
+        },
+        {
+          name: 'fancy-plugin@1.0.3',
+          args: ['cookie', true]
+        }
+      ]);
       expect(config.dependencies).toEqual({
         'hl7.fhir.us.core': '3.1.0',
         'hl7.fhir.us.mcode': {

--- a/test/import/fixtures/example-config.yaml
+++ b/test/import/fixtures/example-config.yaml
@@ -59,6 +59,14 @@ contact:
 # code syntax can be used here.
 jurisdiction: urn:iso:std:iso:3166#US "United States of America"
 
+# The plugins property is used to specify and configure plugins to load when SUSHI runs.
+plugins:
+  - name: simple-plugin
+  - name: fancy-plugin@1.0.3
+    args:
+      - cookie
+      - true
+
 # The dependencies property corresponds to IG.dependsOn. The key is the
 # package id and the value is the version (or dev/current). For advanced
 # use cases a more complex value can be used with id, uri, and/or version

--- a/test/import/importConfiguration.test.ts
+++ b/test/import/importConfiguration.test.ts
@@ -66,6 +66,15 @@ describe('importConfiguration', () => {
       version: '1.0.0',
       fhirVersion: ['4.0.1'],
       template: 'hl7.fhir.template#0.0.5',
+      plugins: [
+        {
+          name: 'simple-plugin'
+        },
+        {
+          name: 'fancy-plugin@1.0.3',
+          args: ['cookie', true]
+        }
+      ],
       publisher: 'HL7 FHIR Management Group',
       contact: [
         {
@@ -1698,6 +1707,25 @@ describe('importConfiguration', () => {
         { code: 'releaselabel', value: 'Build CI' },
         { code: 'validation', value: 'allow-any-extensions' },
         { code: 'validation', value: 'no-broken-links' }
+      ]);
+    });
+  });
+
+  describe('#plugins', () => {
+    it('should support plugins with or without parameters', () => {
+      minYAML.plugins = [
+        { name: 'my-plugin' },
+        { name: 'my-fancy-plugin@2.1.2', args: ['cookie', true] }
+      ];
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(config.plugins).toEqual([
+        {
+          name: 'my-plugin'
+        },
+        {
+          name: 'my-fancy-plugin@2.1.2',
+          args: ['cookie', true]
+        }
       ]);
     });
   });

--- a/test/utils/PluginManager.test.ts
+++ b/test/utils/PluginManager.test.ts
@@ -1,0 +1,311 @@
+import fs from 'fs-extra';
+import path from 'path';
+import temp from 'temp';
+import { loggerSpy } from '../testhelpers/loggerSpy';
+import { PluginManager } from '../../src/utils';
+import { InvalidHookError, MissingPluginError } from '../../src/errors';
+import { PluginConfiguration } from '../../src/fshtypes';
+
+describe('PluginManager', () => {
+  let tempRoot: string;
+  beforeAll(() => {
+    tempRoot = temp.mkdirSync();
+  });
+
+  beforeEach(() => {
+    loggerSpy.reset();
+    fs.emptyDirSync(tempRoot);
+    fs.mkdirSync(path.join(tempRoot, 'some-plugin'));
+    fs.mkdirSync(path.join(tempRoot, 'problem-plugin'));
+    fs.mkdirpSync(path.join(tempRoot, 'node_modules', 'my-npm-plugin'));
+    fs.copySync(
+      path.join(__dirname, 'fixtures', 'plugins', 'some-plugin'),
+      path.join(tempRoot, 'some-plugin')
+    );
+    fs.copySync(
+      path.join(__dirname, 'fixtures', 'plugins', 'problem-plugin'),
+      path.join(tempRoot, 'problem-plugin')
+    );
+    fs.copySync(
+      path.join(__dirname, 'fixtures', 'plugins', 'my-npm-plugin128'),
+      path.join(tempRoot, 'node_modules', 'my-npm-plugin')
+    );
+  });
+
+  afterAll(() => {
+    temp.cleanupSync();
+  });
+
+  describe('#processPluginConfiguration', () => {
+    let loadFromFilesystemSpy: jest.SpyInstance;
+    let installFromNpmSpy: jest.SpyInstance;
+    beforeAll(() => {
+      loadFromFilesystemSpy = jest.spyOn(PluginManager, 'loadFromFilesystem');
+      installFromNpmSpy = jest.spyOn(PluginManager, 'installFromNpm');
+      // mock the installation implementation so as not to actually rely on npm during tests
+      installFromNpmSpy.mockImplementation((installPath: string, installTarget: string) => {
+        if (installTarget === 'your-npm-plugin@1.0.1') {
+          // installing a new package
+          fs.copySync(
+            path.join(__dirname, 'fixtures', 'plugins', 'your-npm-plugin'),
+            path.join(installPath, 'node_modules', 'your-npm-plugin')
+          );
+        } else if (installTarget === 'my-npm-plugin@5.7.3') {
+          // changing version of an existing package
+          fs.copySync(
+            path.join(__dirname, 'fixtures', 'plugins', 'my-npm-plugin573'),
+            path.join(installPath, 'node_modules', 'my-npm-plugin')
+          );
+        } else if (installTarget === '@example/scoped-plugin@2.2.2-alpha') {
+          // installing a scoped plugin
+          fs.copySync(
+            path.join(__dirname, 'fixtures', 'plugins', 'scoped-plugin'),
+            path.join(installPath, 'node_modules', '@example', 'scoped-plugin')
+          );
+        } else {
+          throw new Error('Could not find that package on npm');
+        }
+      });
+    });
+
+    beforeEach(() => {
+      loadFromFilesystemSpy.mockClear();
+      installFromNpmSpy.mockClear();
+    });
+
+    afterAll(() => {
+      loadFromFilesystemSpy.mockRestore();
+      installFromNpmSpy.mockRestore();
+    });
+
+    it('should attempt to load each plugin in the configuration when they are all on the filesystem', async () => {
+      const plugins: PluginConfiguration[] = [
+        { name: 'some-plugin', args: [] },
+        { name: 'my-npm-plugin@1.2.8', args: ['oats', 'cake'] }
+      ];
+      await PluginManager.processPluginConfiguration(plugins, tempRoot);
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loadFromFilesystemSpy).toHaveBeenCalledTimes(2);
+      expect(loadFromFilesystemSpy).toHaveBeenNthCalledWith<[string[], string, any[]]>(
+        1,
+        [path.join(tempRoot, 'some-plugin'), path.join(tempRoot, 'node_modules', 'some-plugin')],
+        'some-plugin',
+        []
+      );
+      expect(loadFromFilesystemSpy).toHaveBeenNthCalledWith<[string[], string, any[]]>(
+        2,
+        [path.join(tempRoot, 'node_modules', 'my-npm-plugin')],
+        'my-npm-plugin',
+        ['oats', 'cake']
+      );
+    });
+
+    it('should attempt to load each plugin in the configuration when some of them need to be installed from npm', async () => {
+      const plugins: PluginConfiguration[] = [
+        { name: 'your-npm-plugin@1.0.1', args: [] },
+        { name: 'my-npm-plugin@5.7.3', args: ['coffee', 'cookie'] }
+      ];
+      await PluginManager.processPluginConfiguration(plugins, tempRoot);
+
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+
+      expect(
+        fs.existsSync(path.join(tempRoot, 'node_modules', 'your-npm-plugin', 'package.json'))
+      ).toBeTruthy();
+      const yourPackage = fs.readJsonSync(
+        path.join(tempRoot, 'node_modules', 'your-npm-plugin', 'package.json')
+      );
+      expect(yourPackage.name).toBe('your-npm-plugin');
+      expect(yourPackage.version).toBe('1.0.1');
+
+      expect(
+        fs.existsSync(path.join(tempRoot, 'node_modules', 'my-npm-plugin', 'package.json'))
+      ).toBeTruthy();
+      const myPackage = fs.readJsonSync(
+        path.join(tempRoot, 'node_modules', 'my-npm-plugin', 'package.json')
+      );
+      expect(myPackage.name).toBe('my-npm-plugin');
+      expect(myPackage.version).toBe('5.7.3');
+
+      expect(installFromNpmSpy).toHaveBeenCalledTimes(2);
+      expect(installFromNpmSpy).toHaveBeenNthCalledWith<[string, string]>(
+        1,
+        tempRoot,
+        'your-npm-plugin@1.0.1'
+      );
+      expect(installFromNpmSpy).toHaveBeenNthCalledWith<[string, string]>(
+        2,
+        tempRoot,
+        'my-npm-plugin@5.7.3'
+      );
+      expect(loadFromFilesystemSpy).toHaveBeenCalledTimes(2);
+      expect(loadFromFilesystemSpy).toHaveBeenNthCalledWith<[string[], string, any[]]>(
+        1,
+        [path.join(tempRoot, 'node_modules', 'your-npm-plugin')],
+        'your-npm-plugin',
+        []
+      );
+      expect(loadFromFilesystemSpy).toHaveBeenNthCalledWith<[string[], string, any[]]>(
+        2,
+        [path.join(tempRoot, 'node_modules', 'my-npm-plugin')],
+        'my-npm-plugin',
+        ['coffee', 'cookie']
+      );
+    });
+
+    it('should load plugins with a scope in their npm package name', async () => {
+      const plugins: PluginConfiguration[] = [
+        { name: '@example/scoped-plugin@2.2.2-alpha', args: [] }
+      ];
+      await PluginManager.processPluginConfiguration(plugins, tempRoot);
+
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+
+      expect(
+        fs.existsSync(
+          path.join(tempRoot, 'node_modules', '@example', 'scoped-plugin', 'package.json')
+        )
+      ).toBeTruthy();
+      const scopedPackage = fs.readJsonSync(
+        path.join(tempRoot, 'node_modules', '@example', 'scoped-plugin', 'package.json')
+      );
+      expect(scopedPackage.name).toBe('@example/scoped-plugin');
+      expect(scopedPackage.version).toBe('2.2.2-alpha');
+
+      expect(installFromNpmSpy).toHaveBeenCalledTimes(1);
+      expect(installFromNpmSpy).toHaveBeenNthCalledWith<[string, string]>(
+        1,
+        tempRoot,
+        '@example/scoped-plugin@2.2.2-alpha'
+      );
+
+      expect(loadFromFilesystemSpy).toHaveBeenCalledTimes(1);
+      expect(loadFromFilesystemSpy).toHaveBeenNthCalledWith<[string[], string, any[]]>(
+        1,
+        [path.join(tempRoot, 'node_modules', '@example', 'scoped-plugin')],
+        '@example/scoped-plugin',
+        []
+      );
+    });
+
+    it('should log an error for each filesystem-managed plugin that could not be loaded', async () => {
+      const plugins: PluginConfiguration[] = [
+        { name: 'some-plugin', args: [] },
+        { name: 'problem-plugin', args: [] }
+      ];
+      await PluginManager.processPluginConfiguration(plugins, tempRoot);
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('error')).toMatch("Couldn't load plugin problem-plugin");
+      expect(loadFromFilesystemSpy).toHaveBeenCalledTimes(2);
+      expect(loadFromFilesystemSpy).toHaveBeenNthCalledWith<[string[], string, any[]]>(
+        1,
+        [path.join(tempRoot, 'some-plugin'), path.join(tempRoot, 'node_modules', 'some-plugin')],
+        'some-plugin',
+        []
+      );
+      expect(loadFromFilesystemSpy).toHaveBeenNthCalledWith<[string[], string, any[]]>(
+        2,
+        [
+          path.join(tempRoot, 'problem-plugin'),
+          path.join(tempRoot, 'node_modules', 'problem-plugin')
+        ],
+        'problem-plugin',
+        []
+      );
+    });
+
+    it('should log an error when a plugin fails to be installed from npm', async () => {
+      const plugins: PluginConfiguration[] = [{ name: 'bogus-npm-plugin@1.0.4', args: [] }];
+      await PluginManager.processPluginConfiguration(plugins, tempRoot);
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        "Couldn't load plugin bogus-npm-plugin@1.0.4"
+      );
+      expect(installFromNpmSpy).toHaveBeenCalledTimes(1);
+      expect(installFromNpmSpy).toHaveBeenNthCalledWith<[string, string]>(
+        1,
+        tempRoot,
+        'bogus-npm-plugin@1.0.4'
+      );
+    });
+  });
+
+  describe('#loadFromFilesystem', () => {
+    beforeEach(() => {
+      PluginManager.hooks = new Map<string, ((...args: any) => any)[]>();
+    });
+
+    it('should initialize a plugin when one path is provided', () => {
+      PluginManager.loadFromFilesystem([path.join(tempRoot, 'some-plugin')], 'some-plugin', []);
+      expect(loggerSpy.getLastMessage('info')).toBe('Initialized plugin: some-plugin');
+    });
+
+    it('should initialize a plugin when multiple paths are provided and the correct path is not the first', () => {
+      PluginManager.loadFromFilesystem(
+        [
+          path.join(tempRoot, 'my-npm-plugin'),
+          path.join(tempRoot, 'node_modules', 'my-npm-plugin')
+        ],
+        'my-npm-plugin',
+        []
+      );
+      expect(loggerSpy.getLastMessage('info')).toBe('Initialized plugin: my-npm-plugin');
+    });
+
+    it('should throw a MissingPluginError when the plugin is missing', () => {
+      expect(() => {
+        PluginManager.loadFromFilesystem(
+          [
+            path.join(tempRoot, 'mysterious-orb'),
+            path.join(tempRoot, 'node_modules', 'mysterious-orb')
+          ],
+          'mysterious-orb',
+          []
+        );
+      }).toThrowError(MissingPluginError);
+    });
+
+    it('should throw when the plugin is present, but an error occurs when loading or initializing it', () => {
+      expect(() => {
+        PluginManager.loadFromFilesystem(
+          [path.join(tempRoot, 'problem-plugin')],
+          'problem-plugin',
+          []
+        );
+      }).toThrow();
+    });
+  });
+
+  describe('#registerHook', () => {
+    beforeEach(() => {
+      PluginManager.hooks = new Map<string, ((...args: any) => any)[]>();
+    });
+
+    it('should add functions to the available hooks', () => {
+      const beforeFillTankHook = () => 7;
+      const beforeLoadCustomResourcesHook = (x: number) => x * x;
+      const afterExportFHIRHookA = (name: string) => name.toLowerCase();
+      const afterExportFHIRHookB = () => 'cookie!';
+
+      PluginManager.registerHook('beforeFillTank', beforeFillTankHook);
+      PluginManager.registerHook('beforeLoadCustomResources', beforeLoadCustomResourcesHook);
+      PluginManager.registerHook('afterExportFHIR', afterExportFHIRHookA);
+      PluginManager.registerHook('afterExportFHIR', afterExportFHIRHookB);
+
+      expect(PluginManager.hooks.get('beforeFillTank')).toEqual([beforeFillTankHook]);
+      expect(PluginManager.hooks.get('beforeLoadCustomResources')).toEqual([
+        beforeLoadCustomResourcesHook
+      ]);
+      expect(PluginManager.hooks.get('afterExportFHIR')).toEqual([
+        afterExportFHIRHookA,
+        afterExportFHIRHookB
+      ]);
+    });
+
+    it('should throw an InvalidHookError when adding to an unavailable hook', () => {
+      expect(() => {
+        PluginManager.registerHook('beforeBreakfast', () => 'six impossible things');
+      }).toThrowError(InvalidHookError);
+    });
+  });
+});

--- a/test/utils/fixtures/plugins/my-npm-plugin128/fancy.js
+++ b/test/utils/fixtures/plugins/my-npm-plugin128/fancy.js
@@ -1,0 +1,7 @@
+function initialize(register, simple, complex) {
+  register('afterExportFHIR', () => {
+    return `simple: ${simple}\ncomplex: ${complex}`;
+  });
+}
+
+module.exports = { initialize };

--- a/test/utils/fixtures/plugins/my-npm-plugin128/package.json
+++ b/test/utils/fixtures/plugins/my-npm-plugin128/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "my-npm-plugin",
+  "version": "1.2.8",
+  "description": "",
+  "main": "fancy.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/utils/fixtures/plugins/my-npm-plugin573/fancy.js
+++ b/test/utils/fixtures/plugins/my-npm-plugin573/fancy.js
@@ -1,0 +1,7 @@
+function initialize(register, simple, complex) {
+  register('afterExportFHIR', () => {
+    return `simple: ${simple}\ncomplex: ${complex}`;
+  });
+}
+
+module.exports = { initialize };

--- a/test/utils/fixtures/plugins/my-npm-plugin573/package.json
+++ b/test/utils/fixtures/plugins/my-npm-plugin573/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "my-npm-plugin",
+  "version": "5.7.3",
+  "description": "",
+  "main": "fancy.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/utils/fixtures/plugins/problem-plugin/index.js
+++ b/test/utils/fixtures/plugins/problem-plugin/index.js
@@ -1,0 +1,8 @@
+function initialize(register) {
+  register('beforeFillTank', () => {
+    return 'prepare the tank';
+  });
+  throw new Error('ran out of cookies');
+}
+
+module.exports = { initialize };

--- a/test/utils/fixtures/plugins/scoped-plugin/index.js
+++ b/test/utils/fixtures/plugins/scoped-plugin/index.js
@@ -1,0 +1,7 @@
+function initialize(register) {
+  register('afterExportFHIR', () => {
+    return "that's the scope";
+  });
+}
+
+module.exports = { initialize };

--- a/test/utils/fixtures/plugins/scoped-plugin/package.json
+++ b/test/utils/fixtures/plugins/scoped-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@example/scoped-plugin",
+  "version": "2.2.2-alpha",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/utils/fixtures/plugins/some-plugin/index.js
+++ b/test/utils/fixtures/plugins/some-plugin/index.js
@@ -1,0 +1,7 @@
+function initialize(register) {
+  register('beforeFillTank', () => {
+    return 'prepare the tank';
+  });
+}
+
+module.exports = { initialize };

--- a/test/utils/fixtures/plugins/your-npm-plugin/index.js
+++ b/test/utils/fixtures/plugins/your-npm-plugin/index.js
@@ -1,0 +1,7 @@
+function initialize(register) {
+  register('afterExportFHIR', () => {
+    return "now it's yours";
+  });
+}
+
+module.exports = { initialize };

--- a/test/utils/fixtures/plugins/your-npm-plugin/package.json
+++ b/test/utils/fixtures/plugins/your-npm-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "your-npm-plugin",
+  "version": "1.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Completes [CIMPL-946](https://standardhealthrecord.atlassian.net/browse/CIMPL-946).

A new configuration attribute is added to allow users to register plugins. Plugins can be managed directly on the filesystem or installed from npm. For npm plugins, a version must be included. Plugins should export an initialize function, which will be called when the plugin is loaded. The initialize function is passed a function that allows hooks to be registered. Additionally, any parameters provided in the configuration will also be passed to the initialize function.

The available hooks at which functions may be registered are:
- beforeFillTank
- beforeLoadCustomResources
- afterLoadCustomResources
- afterExportFHIR

The code to call registered functions at these points is not yet implemented.

For testing this, locally-managed plugins should be placed at the FSH project's `input/plugins` path. There currently aren't any SUSHI plugins on npm, so using that feature will usually result in the plugin failing to initialize properly. The package should still get installed to `input/plugins/node_modules/${package-name}`, even if it will not initialize.