### PR TITLE
Warn when a slice element is accessed via numeric index

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -119,7 +119,8 @@ export class InstanceExporter implements Fishable {
           rule.path,
           rule.value,
           this.fisher,
-          inlineResourceTypes
+          inlineResourceTypes,
+          rule.sourceInfo
         );
         // Record each valid rule in a map
         // Choice elements on an instance must use a specific type, so if the path still has an unchosen choice element,

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -663,22 +663,30 @@ export class ElementDefinition {
   }
 
   /**
+   * Returns an array of slices that will be pre-loaded.
+   * A slice is pre-loaded if if has a min of 1 and contains a fixed or pattern value on itself or it's descendents
+   * @returns {ElementDefinition[]} - Array of slices to be pre-loaded
+   */
+  getPreloadedSlices(): ElementDefinition[] {
+    return this.getSlices().filter(
+      slice =>
+        slice.min > 0 &&
+        slice
+          .getAssignableDescendents()
+          .some((element: ElementDefinition) =>
+            Object.keys(element).find(k => k.startsWith('fixed') || k.startsWith('pattern'))
+          )
+    );
+  }
+
+  /**
    * Determines if an array index references a slice that will be preloaded.
    * A slice is pre-loaded if if has a min of 1 and contains a fixed or pattern value on itself or it's descendents
    * @param {number} sliceIndex - The index
    * @returns {boolean}
    */
   isPreloadedSlice(sliceIndex: number): boolean {
-    const slice = this.getSlices()[sliceIndex];
-    return (
-      slice &&
-      slice.min > 0 &&
-      slice
-        .getAssignableDescendents()
-        .some((element: ElementDefinition) =>
-          Object.keys(element).find(k => k.startsWith('fixed') || k.startsWith('pattern'))
-        )
-    );
+    return sliceIndex <= this.getPreloadedSlices().length - 1;
   }
 
   /**

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -664,7 +664,7 @@ export class ElementDefinition {
 
   /**
    * Determines if an array index references a slice that will be preloaded.
-   * A slice is pre-loaded if if has a min of 1 and contains a fixed or pattern value on itself or it's dependendents
+   * A slice is pre-loaded if if has a min of 1 and contains a fixed or pattern value on itself or it's descendents
    * @param {number} sliceIndex - The index
    * @returns {boolean}
    */

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -663,6 +663,25 @@ export class ElementDefinition {
   }
 
   /**
+   * Determines if an array index references a slice that will be preloaded.
+   * A slice is pre-loaded if if has a min of 1 and contains a fixed or pattern value on itself or it's dependendents
+   * @param {number} sliceIndex - The index
+   * @returns {boolean}
+   */
+  isPreloadedSlice(sliceIndex: number): boolean {
+    const slice = this.getSlices()[sliceIndex];
+    return (
+      slice &&
+      slice.min > 0 &&
+      slice
+        .getAssignableDescendents()
+        .some((element: ElementDefinition) =>
+          Object.keys(element).find(k => k.startsWith('fixed') || k.startsWith('pattern'))
+        )
+    );
+  }
+
+  /**
    * Constrains the cardinality of this element.  Cardinality constraints can only narrow
    * cardinality.  Attempts to constrain to a wider cardinality will throw.
    * @see {@link http://hl7.org/fhir/R4/profiling.html#cardinality}

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -671,11 +671,12 @@ export class ElementDefinition {
     return this.getSlices().filter(
       slice =>
         slice.min > 0 &&
-        slice
-          .getAssignableDescendents()
-          .some((element: ElementDefinition) =>
-            Object.keys(element).find(k => k.startsWith('fixed') || k.startsWith('pattern'))
-          )
+        (Object.keys(slice).find(k => k.startsWith('fixed') || k.startsWith('pattern')) ||
+          slice
+            .getAssignableDescendents()
+            .some((element: ElementDefinition) =>
+              Object.keys(element).find(k => k.startsWith('fixed') || k.startsWith('pattern'))
+            ))
     );
   }
 


### PR DESCRIPTION
Fixes #1030, logging a warning when users access a slice using a numeric index. This warning is only logged when an array has it's slicing rules set to `closed` (in which case all elements in the array are slices by definition), or if the numeric index is determined to reference a slice that will be pre-loaded onto an instance as an implied property. A slice will be loaded automatically if it's cardinality indicates that it is required _and_ it contains a `pattern[x]` or `fixed[x]` value on itself or any of its children. 

This [FSH Online link](https://fshschool.org/FSHOnline/#/share/3ryTLXM) includes test cases.