### PR TITLE
Only load current packages from main or master branches

### DIFF
--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -69,7 +69,9 @@ export async function loadDependency(
     // Find matching packages and sort by date to get the most recent
     let newestPackage;
     if (qaData?.length > 0) {
-      const matchingPackages = qaData.filter(p => p['package-id'] === packageName);
+      const matchingPackages = qaData
+        .filter(p => p['package-id'] === packageName)
+        .filter(p => p.repo.match(/(master|main)\/qa\.json$/));
       newestPackage = matchingPackages.sort((p1, p2) => {
         return Date.parse(p2['date']) - Date.parse(p1['date']);
       })[0];

--- a/test/fhirdefs/load.test.ts
+++ b/test/fhirdefs/load.test.ts
@@ -81,17 +81,21 @@ describe('#loadDependency()', () => {
   const expectDownloadSequence = (
     sources: string | string[],
     destination: string,
-    isCurrent = false
+    isCurrent = false,
+    isCurrentFound = true
   ): void => {
     if (!Array.isArray(sources)) {
       sources = [sources];
     }
     if (isCurrent) {
-      expect(axiosSpy.mock.calls).toEqual([
-        ['https://build.fhir.org/ig/qas.json'],
-        [sources[0].replace(/package\.tgz$/, 'package.manifest.json')],
-        [sources[0], { responseType: 'arraybuffer' }]
-      ]);
+      const mockCalls: any[] = [['https://build.fhir.org/ig/qas.json']];
+      if (isCurrentFound) {
+        mockCalls.push(
+          [sources[0].replace(/package\.tgz$/, 'package.manifest.json')],
+          [sources[0], { responseType: 'arraybuffer' }]
+        );
+      }
+      expect(axiosSpy.mock.calls).toEqual(mockCalls);
     } else {
       expect(axiosSpy.mock.calls).toEqual(sources.map(s => [s, { responseType: 'arraybuffer' }]));
     }
@@ -124,7 +128,7 @@ describe('#loadDependency()', () => {
               hints: 202,
               version: '4.0.0',
               tool: '4.1.0 (3)',
-              repo: 'HL7Imposter/US-Core-R4/branches/oldbranch/qa.json'
+              repo: 'HL7Imposter/US-Core-R4/branches/main/qa.json'
             },
             {
               url: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core.r4-4.0.0',
@@ -137,7 +141,7 @@ describe('#loadDependency()', () => {
               hints: 228,
               version: '4.0.0',
               tool: '4.1.0 (3)',
-              repo: 'HL7/US-Core-R4/branches/newbranch/qa.json'
+              repo: 'HL7/US-Core-R4/branches/main/qa.json'
             },
             {
               url: 'http://hl7.org/fhir/sushi-test-no-download/ImplementationGuide/sushi-test-no-download-0.1.0',
@@ -159,6 +163,13 @@ describe('#loadDependency()', () => {
               'package-id': 'sushi-test',
               'ig-ver': '0.1.0',
               repo: 'sushi/sushi-test/branches/master/qa.json'
+            },
+            {
+              url: 'http://hl7.org/fhir/sushi-no-main/ImplementationGuide/sushi-no-main-0.1.0',
+              name: 'sushi-no-main',
+              'package-id': 'sushi-no-main',
+              'ig-ver': '0.1.0',
+              repo: 'sushi/sushi-no-main/branches/feature/qa.json'
             }
           ]
         };
@@ -351,6 +362,18 @@ describe('#loadDependency()', () => {
       true
     );
     expect(removeSpy.mock.calls[0][0]).toBe(path.join(cachePath, 'sushi-test-old#current'));
+  });
+
+  it('should not try to load the latest package from build.fhir.org from a branch that is not main/master', async () => {
+    await expect(loadDependency('sushi-no-main', 'current', defs, cachePath)).rejects.toThrow(
+      'The package sushi-no-main#current is not available on https://build.fhir.org/ig/qas.json, so no current version can be loaded'
+    );
+    expectDownloadSequence(
+      'https://build.fhir.org/ig/sushi/sushi-no-main/package.tgz',
+      null,
+      true,
+      false
+    );
   });
 
   it('should try to load the latest FHIR R5 package from build.fhir.org when it is not locally cached', async () => {


### PR DESCRIPTION
This PR fixes SUSHI issue #1017.  It supports only downloading current packages from `main` or `master` branches by filtering out the `qas.json` entries that are not from those branches.