### PR TITLE
Avoid assigning duplicate values on sliced elements

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -33,7 +33,7 @@ import {
 } from '../fshtypes';
 import { FSHTank } from '../import';
 import { Type, Fishable } from '../utils/Fishable';
-import { logger, parseFSHPath } from '../utils';
+import { logger } from '../utils';
 
 export function splitOnPathPeriods(path: string): string[] {
   return path.split(/\.(?![^\[]*\])/g); // match a period that isn't within square brackets


### PR DESCRIPTION
Fixes #1008 and completes task [CIMPL-881](https://standardhealthrecord.atlassian.net/browse/CIMPL-881).

When there are required slices on an element, the sliced element's minimum cardinality is at least the sum of the slice minimums. If the minimum cardinality is greater than the sum of slice minimums, additional elements should be added on Instances in order to satisfy the minimum cardinality. However, if the slices provide enough elements to satisfy the element's minimum cardinality, there is no need to add extra elements. Previously, when assigning implied values on an Instance, the "must-satisfy-minimum" elements were added before any named slices, resulting in more elements being present than expected. By adding the named slices first, those unnecessary elements are not added.

The strategy for ensuring that named slices are added before trying to pad out the sliced element is to reorder the rules on the Instance's `InstanceOf` profile so that the following conditions hold:
- if there is a rule on a sliced element and on a named slice of that element, the named slice rule should come first. The first new test addresses this case.
- if there is a rule on an element and a descendant of that element, the descendant rule should come first. The second new test addresses this case.

Because the rule path ordering should be preserved apart from these conditions, my solution was to build a tree out of the element paths. This is more reliable than using the built-in sort with a comparator, because the correct order of two paths cannot always be determined by paths alone if one path's ancestor is in the set of paths, and that ancestor is the other path's sibling. For example, `Resource.cookie` and `Resource.cake.frosting` cannot be ordered without knowing whether `Resource.cake` is also in the set of paths, and where it would exist in the ordering. The tree implementation handles this scenario without any trouble. Also, if you read this all the way to the end, please treat yourself to a cookie and/or cake in any order.