### PR TITLE
Extension setting on ValueSets and CodeSystems

### DIFF
--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -1,7 +1,6 @@
 import { FSHTank } from '../import/FSHTank';
 import { CodeSystem, CodeSystemConcept, StructureDefinition } from '../fhirtypes';
 import {
-  setPropertyOnInstance,
   setPropertyOnDefinitionInstance,
   applyInsertRules,
   cleanResource
@@ -79,7 +78,7 @@ export class CodeSystemExporter {
       try {
         rule.path = this.findConceptPath(codeSystem, rule.pathArray);
         successfulRules.push(rule);
-        if (rule.path && rule.path !== '.') {
+        if (rule.path) {
           rule.isCodeCaretRule = true;
         }
       } catch (e) {
@@ -89,16 +88,12 @@ export class CodeSystemExporter {
     resolveSoftIndexing(successfulRules);
     for (const rule of successfulRules) {
       try {
-        const { assignedValue, pathParts } = csStructureDefinition.validateValueAtPath(
+        setPropertyOnDefinitionInstance(
+          codeSystem,
           rule.path.length > 1 ? `${rule.path}.${rule.caretPath}` : rule.caretPath,
           rule.value,
           this.fisher
         );
-        if (rule.isCodeCaretRule) {
-          setPropertyOnInstance(codeSystem, pathParts, assignedValue, this.fisher);
-        } else {
-          setPropertyOnDefinitionInstance(codeSystem, rule.caretPath, rule.value, this.fisher);
-        }
       } catch (e) {
         logger.error(e.message, rule.sourceInfo);
       }

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -1,9 +1,4 @@
-import {
-  ValueSet,
-  ValueSetComposeIncludeOrExclude,
-  ValueSetComposeConcept,
-  StructureDefinition
-} from '../fhirtypes';
+import { ValueSet, ValueSetComposeIncludeOrExclude, ValueSetComposeConcept } from '../fhirtypes';
 import { FSHTank } from '../import/FSHTank';
 import { FshValueSet, FshCode, ValueSetFilterValue, FshCodeSystem, Instance } from '../fshtypes';
 import { logger } from '../utils/FSHLogger';
@@ -170,9 +165,6 @@ export class ValueSetExporter {
   }
 
   private setCaretRules(valueSet: ValueSet, rules: CaretValueRule[]) {
-    const vsStructureDefinition = StructureDefinition.fromJSON(
-      this.fisher.fishForFHIR('ValueSet', Type.Resource)
-    );
     resolveSoftIndexing(rules);
     for (const rule of rules) {
       try {

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -177,12 +177,7 @@ export class ValueSetExporter {
     for (const rule of rules) {
       try {
         if (rule instanceof CaretValueRule) {
-          const { assignedValue, pathParts } = vsStructureDefinition.validateValueAtPath(
-            rule.caretPath,
-            rule.value,
-            this.fisher
-          );
-          setPropertyOnDefinitionInstance(valueSet, rule.caretPath, assignedValue, this.fisher);
+          setPropertyOnDefinitionInstance(valueSet, rule.caretPath, rule.value, this.fisher);
         }
       } catch (e) {
         logger.error(e.message, rule.sourceInfo);

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -17,9 +17,10 @@ import {
   ValueSetFilterComponentRule
 } from '../fshtypes/rules';
 import {
-  setPropertyOnInstance,
   applyInsertRules,
-  listUndefinedLocalCodes
+  listUndefinedLocalCodes,
+  setPropertyOnDefinitionInstance,
+  cleanResource
 } from '../fhirtypes/common';
 import { isUri } from 'valid-url';
 import { flatMap } from 'lodash';
@@ -181,7 +182,7 @@ export class ValueSetExporter {
             rule.value,
             this.fisher
           );
-          setPropertyOnInstance(valueSet, pathParts, assignedValue, this.fisher);
+          setPropertyOnDefinitionInstance(valueSet, rule.caretPath, assignedValue, this.fisher);
         }
       } catch (e) {
         logger.error(e.message, rule.sourceInfo);
@@ -245,6 +246,7 @@ export class ValueSetExporter {
       );
     }
 
+    cleanResource(vs, (prop: string) => ['_sliceName', '_primitive'].includes(prop));
     this.pkg.valueSets.push(vs);
     return vs;
   }

--- a/src/fhirtypes/CodeSystem.ts
+++ b/src/fhirtypes/CodeSystem.ts
@@ -6,6 +6,8 @@ import { Narrative, Resource, Identifier, CodeableConcept, Coding } from './data
 import { ContactDetail, UsageContext } from './metaDataTypes';
 import { HasName, HasId } from './mixins';
 import { applyMixins } from '../utils/Mixin';
+import { StructureDefinition } from './StructureDefinition';
+import { Fishable, Type } from '../utils';
 
 /**
  * Class representing a FHIR R4 CodeSystem
@@ -47,6 +49,15 @@ export class CodeSystem {
   filter?: CodeSystemFilter[];
   property?: CodeSystemProperty[];
   concept?: CodeSystemConcept[];
+
+  /**
+   * Get the Structure Definition for Code System
+   * @param {Fishable} fisher - A fishable implementation for finding definitions and metadata
+   * @returns {StructureDefinition} the StructureDefinition of Code System
+   */
+  getOwnStructureDefinition(fisher: Fishable): StructureDefinition {
+    return StructureDefinition.fromJSON(fisher.fishForFHIR('CodeSystem', Type.Resource));
+  }
 
   /**
    * Get the file name for serializing to disk.

--- a/src/fhirtypes/CodeSystem.ts
+++ b/src/fhirtypes/CodeSystem.ts
@@ -102,6 +102,7 @@ export type CodeSystemConcept = {
   designation?: CodeSystemConceptDesignation[];
   property?: CodeSystemConceptProperty[];
   concept?: CodeSystemConcept[];
+  extension?: Extension[];
 };
 
 export type CodeSystemConceptDesignation = {

--- a/src/fhirtypes/ValueSet.ts
+++ b/src/fhirtypes/ValueSet.ts
@@ -6,6 +6,8 @@ import { ContactDetail, UsageContext } from './metaDataTypes';
 import { cloneDeep } from 'lodash';
 import { HasName, HasId } from './mixins';
 import { applyMixins } from '../utils/Mixin';
+import { StructureDefinition } from './StructureDefinition';
+import { Fishable, Type } from '../utils';
 
 /**
  * Class representing a FHIR R4 ValueSet.
@@ -40,6 +42,15 @@ export class ValueSet {
   purpose: string;
   copyright: string;
   compose: ValueSetCompose;
+
+  /**
+   * Get the Structure Definition for ValueSet
+   * @param {Fishable} fisher - A fishable implementation for finding definitions and metadata
+   * @returns {StructureDefinition} the StructureDefinition of ValueSet
+   */
+  getOwnStructureDefinition(fisher: Fishable): StructureDefinition {
+    return StructureDefinition.fromJSON(fisher.fishForFHIR('ValueSet', Type.Resource));
+  }
 
   /**
    * Get the file name for serializing to disk.

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -40,14 +40,14 @@ export function splitOnPathPeriods(path: string): string[] {
 }
 
 /**
- * This function sets an instance property of an SD or ED if possible
- * @param {StructureDefinition | ElementDefinition} instance - The instance to assign a value on
+ * This function sets an instance property of a resource if possible
+ * @param {StructureDefinition | ElementDefinition | CodeSystem | ValueSet} instance - The instance to assign a value on
  * @param {string} path - The path to assign a value at
  * @param {any} value - The value to assign
  * @param {Fishable} fisher - A fishable implementation for finding definitions and metadata
  */
 export function setPropertyOnDefinitionInstance(
-  instance: StructureDefinition | ElementDefinition,
+  instance: StructureDefinition | ElementDefinition | CodeSystem | ValueSet,
   path: string,
   value: any,
   fisher: Fishable
@@ -59,7 +59,7 @@ export function setPropertyOnDefinitionInstance(
 }
 
 export function setImpliedPropertiesOnInstance(
-  instanceDef: StructureDefinition | ElementDefinition | InstanceDefinition,
+  instanceDef: StructureDefinition | ElementDefinition | InstanceDefinition | CodeSystem | ValueSet,
   instanceOfStructureDefinition: StructureDefinition,
   paths: string[],
   fisher: Fishable
@@ -436,11 +436,11 @@ export function replaceField(
 
 /**
  * Cleans up temporary properties that were added to the resource definition during processing
- * @param {StructureDefinition | InstanceDefinition} resourceDef - The resource definition to clean
+ * @param {StructureDefinition | InstanceDefinition | CodeSystem | ValueSet} resourceDef - The resource definition to clean
  * @param {string => boolean} skipFn - A function that returns true if a property should not be traversed
  */
 export function cleanResource(
-  resourceDef: StructureDefinition | InstanceDefinition,
+  resourceDef: StructureDefinition | InstanceDefinition | CodeSystem | ValueSet,
   skipFn: (prop: string) => boolean = () => false
 ): void {
   // Remove all _sliceName fields

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -370,22 +370,6 @@ describe('CodeSystemExporter', () => {
     expect(loggerSpy.getLastMessage('warn')).toMatch(warning);
     expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
   });
-  it('should export a code system with an extension', () => {
-    const codeSystem = new FshCodeSystem('Strange.Code.System')
-      .withFile('Strange.fsh')
-      .withLocation([3, 4, 8, 24]);
-    const extensionRule = new CaretValueRule('');
-    extensionRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
-    extensionRule.value = 1;
-    codeSystem.rules.push(extensionRule);
-    doc.codeSystems.set(codeSystem.name, codeSystem);
-    const exported = exporter.export().codeSystems;
-    expect(exported.length).toBe(1);
-    expect(exported[0].extension).toContainEqual({
-      url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
-      valueInteger: 1
-    });
-  });
   it('should log an error when multiple code systems have the same id', () => {
     const firstCodeSystem = new FshCodeSystem('FirstCodeSystem')
       .withFile('CodeSystems.fsh')
@@ -600,6 +584,23 @@ describe('CodeSystemExporter', () => {
           ]
         }
       ]
+    });
+  });
+
+  it('should export a code system with an extension', () => {
+    const codeSystem = new FshCodeSystem('Strange.Code.System')
+      .withFile('Strange.fsh')
+      .withLocation([3, 4, 8, 24]);
+    const extensionRule = new CaretValueRule('');
+    extensionRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
+    extensionRule.value = 1;
+    codeSystem.rules.push(extensionRule);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export().codeSystems;
+    expect(exported.length).toBe(1);
+    expect(exported[0].extension).toContainEqual({
+      url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
+      valueInteger: 1
     });
   });
 

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -587,20 +587,29 @@ describe('CodeSystemExporter', () => {
     });
   });
 
-  it('should export a code system with an extension', () => {
+  it('should export a code system with extensions', () => {
     const codeSystem = new FshCodeSystem('Strange.Code.System')
       .withFile('Strange.fsh')
       .withLocation([3, 4, 8, 24]);
     const extensionRule = new CaretValueRule('');
     extensionRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
     extensionRule.value = 1;
-    codeSystem.rules.push(extensionRule);
+    const conceptRule = new ConceptRule('bar', 'Bar', 'Bar');
+    const conceptExtensionRule = new CaretValueRule('bar');
+    conceptExtensionRule.pathArray = ['bar'];
+    conceptExtensionRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
+    conceptExtensionRule.value = 2;
+    codeSystem.rules.push(extensionRule, conceptRule, conceptExtensionRule);
     doc.codeSystems.set(codeSystem.name, codeSystem);
     const exported = exporter.export().codeSystems;
     expect(exported.length).toBe(1);
     expect(exported[0].extension).toContainEqual({
       url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
       valueInteger: 1
+    });
+    expect(exported[0].concept[0].extension).toContainEqual({
+      url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
+      valueInteger: 2
     });
   });
 

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -370,6 +370,22 @@ describe('CodeSystemExporter', () => {
     expect(loggerSpy.getLastMessage('warn')).toMatch(warning);
     expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
   });
+  it('should export a code system with an extension', () => {
+    const codeSystem = new FshCodeSystem('Strange.Code.System')
+      .withFile('Strange.fsh')
+      .withLocation([3, 4, 8, 24]);
+    const extensionRule = new CaretValueRule('');
+    extensionRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
+    extensionRule.value = 1;
+    codeSystem.rules.push(extensionRule);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export().codeSystems;
+    expect(exported.length).toBe(1);
+    expect(exported[0].extension).toContainEqual({
+      url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
+      valueInteger: 1
+    });
+  });
   it('should log an error when multiple code systems have the same id', () => {
     const firstCodeSystem = new FshCodeSystem('FirstCodeSystem')
       .withFile('CodeSystems.fsh')

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -249,21 +249,6 @@ describe('ValueSetExporter', () => {
     expect(loggerSpy.getLastMessage('warn')).toMatch(warning);
     expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
   });
-  it('should export a value set with an extension', () => {
-    const valueSet = new FshValueSet('BreakfastVS');
-    valueSet.title = 'Breakfast Values';
-    const extensionRule = new CaretValueRule('');
-    extensionRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
-    extensionRule.value = 1;
-    valueSet.rules.push(extensionRule);
-    doc.valueSets.set(valueSet.name, valueSet);
-    const exported = exporter.export().valueSets;
-    expect(exported.length).toBe(1);
-    expect(exported[0].extension).toContainEqual({
-      url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
-      valueInteger: 1
-    });
-  });
   it('should log an error when multiple value sets have the same id', () => {
     const firstValueSet = new FshValueSet('FirstVS')
       .withFile('ValueSets.fsh')
@@ -1633,6 +1618,22 @@ describe('ValueSetExporter', () => {
           ]
         }
       ]
+    });
+  });
+  
+  it('should export a value set with an extension', () => {
+    const valueSet = new FshValueSet('BreakfastVS');
+    valueSet.title = 'Breakfast Values';
+    const extensionRule = new CaretValueRule('');
+    extensionRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
+    extensionRule.value = 1;
+    valueSet.rules.push(extensionRule);
+    doc.valueSets.set(valueSet.name, valueSet);
+    const exported = exporter.export().valueSets;
+    expect(exported.length).toBe(1);
+    expect(exported[0].extension).toContainEqual({
+      url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
+      valueInteger: 1
     });
   });
 

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -249,6 +249,21 @@ describe('ValueSetExporter', () => {
     expect(loggerSpy.getLastMessage('warn')).toMatch(warning);
     expect(loggerSpy.getLastMessage('warn')).toMatch(/File: Wrong\.fsh.*Line: 2 - 5\D*/s);
   });
+  it('should export a value set with an extension', () => {
+    const valueSet = new FshValueSet('BreakfastVS');
+    valueSet.title = 'Breakfast Values';
+    const extensionRule = new CaretValueRule('');
+    extensionRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
+    extensionRule.value = 1;
+    valueSet.rules.push(extensionRule);
+    doc.valueSets.set(valueSet.name, valueSet);
+    const exported = exporter.export().valueSets;
+    expect(exported.length).toBe(1);
+    expect(exported[0].extension).toContainEqual({
+      url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
+      valueInteger: 1
+    });
+  });
   it('should log an error when multiple value sets have the same id', () => {
     const firstValueSet = new FshValueSet('FirstVS')
       .withFile('ValueSets.fsh')

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -1620,7 +1620,7 @@ describe('ValueSetExporter', () => {
       ]
     });
   });
-  
+
   it('should export a value set with an extension', () => {
     const valueSet = new FshValueSet('BreakfastVS');
     valueSet.title = 'Breakfast Values';

--- a/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-fmm.json
+++ b/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-fmm.json
@@ -1,0 +1,276 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "structuredefinition-fmm",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+      "valueCode": "fhir"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+      "valueInteger": 1
+    }
+  ],
+  "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+  "version": "4.6.0",
+  "name": "fmm",
+  "status": "draft",
+  "date": "2014-01-31",
+  "publisher": "Health Level Seven, Inc. - [WG Name] WG",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.org/special/committees/FHIR"
+        }
+      ]
+    }
+  ],
+  "description": "The FMM level assigned to the artifact.",
+  "fhirVersion": "4.6.0",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "Element"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "snapshot": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "FMM Level",
+        "definition": "The FMM level assigned to the artifact.",
+        "comment": "Though this is defined for resources, it can be used for any artifact.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Extension",
+          "min": 0,
+          "max": "*"
+        },
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          },
+          {
+            "key": "ext-1",
+            "severity": "error",
+            "human": "Must have either extensions or value[x], not both",
+            "expression": "extension.exists() != value.exists()",
+            "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+            "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+          }
+        ],
+        "isModifier": false
+      },
+      {
+        "id": "Extension.id",
+        "path": "Extension.id",
+        "representation": [
+          "xmlAttr"
+        ],
+        "short": "Unique id for inter-element referencing",
+        "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Element.id",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                "valueUrl": "string"
+              }
+            ],
+            "code": "http://hl7.org/fhirpath/System.String"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "n/a"
+          }
+        ]
+      },
+      {
+        "id": "Extension.extension",
+        "path": "Extension.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "description": "Extensions are always sliced by (at least) url",
+          "rules": "open"
+        },
+        "short": "Extension",
+        "definition": "An Extension",
+        "min": 0,
+        "max": "0",
+        "base": {
+          "path": "Element.extension",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          },
+          {
+            "key": "ext-1",
+            "severity": "error",
+            "human": "Must have either extensions or value[x], not both",
+            "expression": "extension.exists() != value.exists()",
+            "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+            "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "representation": [
+          "xmlAttr"
+        ],
+        "short": "identifies the meaning of the extension",
+        "definition": "Source of the definition for the extension code - a logical name or a URL.",
+        "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Extension.url",
+          "min": 1,
+          "max": "1"
+        },
+        "type": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                "valueUrl": "uri"
+              }
+            ],
+            "code": "http://hl7.org/fhirpath/System.String"
+          }
+        ],
+        "fixedUri": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "N/A"
+          }
+        ]
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "short": "Value of extension",
+        "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Extension.value[x]",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "integer"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "N/A"
+          }
+        ]
+      }
+    ]
+  },
+  "differential": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "FMM Level",
+        "definition": "The FMM level assigned to the artifact.",
+        "comment": "Though this is defined for resources, it can be used for any artifact.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Extension.extension",
+        "path": "Extension.extension",
+        "max": "0"
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "fixedUri": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "integer"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #1069, allowing for extensions to be set on `CodeSystem` and `ValueSet` resources. This [FSH Online link](https://fshschool.org/FSHOnline/#/share/3jZbrHQ) provides relevant test cases.