### PR TITLE
Honor ENV variable for NPM_CONFIG_REGISTRY when checking sushi version

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -98,7 +98,7 @@ async function app() {
   }
   logger.info(`  ${path.resolve(input || '.')}`);
 
-  const sushiVersions = await checkSushiVersion();
+  const sushiVersions = checkSushiVersion();
   if (
     program.requireLatest &&
     (sushiVersions.latest == null || sushiVersions.latest !== sushiVersions.current)

--- a/src/app.ts
+++ b/src/app.ts
@@ -98,7 +98,7 @@ async function app() {
   }
   logger.info(`  ${path.resolve(input || '.')}`);
 
-  const sushiVersions = checkSushiVersion();
+  const sushiVersions = await checkSushiVersion();
   if (
     program.requireLatest &&
     (sushiVersions.latest == null || sushiVersions.latest !== sushiVersions.current)

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -560,13 +560,14 @@ export function getLocalSushiVersion(): string {
 }
 
 async function getLatestSushiVersionFallback(): Promise<string> {
+  logger.info('Attempting fallback to determine version of sushi.');
   try {
     const res = await axiosGet('https://registry.npmjs.org/fsh-sushi');
     const latestVer = res.data['dist-tags'].latest;
-    if (latestVer == null) {
-      logger.warn('Unable to determine the latest version of sushi.');
-    } else {
+    if (latestVer.match(/^[0-9\.]*$/)) {
       return latestVer;
+    } else {
+      logger.warn('Unable to determine the latest version of sushi.');
     }
   } catch (e) {
     logger.warn(`Unable to determine the latest version of sushi: ${e.message}`);
@@ -579,18 +580,11 @@ export async function getLatestSushiVersion(): Promise<string | undefined> {
   const getRegistryCmd = 'npm view fsh-sushi version';
   try {
     const execResult = execSync(getRegistryCmd)?.toString()?.replace(/\s*$/, '');
-
     if (execResult.match(/^[0-9\.]*$/)) {
       latestVer = execResult;
-    } else {
-      logger.warn(
-        'Unable to determine the latest version of sushi: ' +
-          `command "${getRegistryCmd}" returned "${execResult}", ` +
-          'which does not look like a semver.'
-      );
     }
   } catch (e) {
-    logger.warn(`Unable to determine the latest version of sushi: ${e.message}`);
+    logger.info(`Unable to determine the latest version of sushi: ${e.message}`);
   }
 
   if (latestVer === undefined) {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -571,7 +571,7 @@ export function getLatestSushiVersion(): string | undefined {
     if (execResult.match(/^[0-9\.]*$/)) {
       latestVer = execResult;
     } else {
-      throw new Error(`command "${getRegistryCmd}" returned "${execResult}", which does not look like a semver.`)
+      throw new Error(`command "${getRegistryCmd}" returned "${execResult}", which does not look like a semver.`);
     }
   } catch (e) {
     logger.warn(`Unable to determine the latest version of sushi: ${e.message}`);

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -1314,7 +1314,7 @@ describe('Processing', () => {
         data: {
           name: 'fsh-sushi',
           'dist-tags': {
-            latest: '2.2.6',
+            latest: '2.1.6',
             beta: '2.0.0-beta.3',
             'pre-1.0': '0.16.1',
             internal: '2.0.0-beta.1-fshonline-hotfix'
@@ -1323,7 +1323,7 @@ describe('Processing', () => {
       };
       mockedAxios.get.mockImplementationOnce(() => Promise.resolve(data));
 
-      await expect(getLatestSushiVersion()).resolves.toEqual('2.2.6');
+      await expect(getLatestSushiVersion()).resolves.toEqual('2.1.6');
     });
 
     it("unsuccessfully fetches data if it doesn't look like a semver is not found", async () => {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -1287,7 +1287,7 @@ describe('Processing', () => {
     beforeAll(() => {
       jest.mock('child_process');
       mockedChildProcess = child_process as jest.Mocked<typeof child_process>;
-      mockedChildProcess.execSync = jest.fn()
+      mockedChildProcess.execSync = jest.fn();
     });
 
     beforeEach(() => {
@@ -1295,15 +1295,16 @@ describe('Processing', () => {
     });
 
     it('successfully fetches data', async () => {
+      // eslint-disable-next-line quotes
       mockedChildProcess.execSync.mockImplementationOnce(() => Buffer.from("2.2.6\n"));
       expect(getLatestSushiVersion()).toEqual('2.2.6');
 
-      mockedChildProcess.execSync.mockImplementationOnce(() => Buffer.from("2.2.6"));
+      mockedChildProcess.execSync.mockImplementationOnce(() => Buffer.from('2.2.6'));
       expect(getLatestSushiVersion()).toEqual('2.2.6');
     });
 
     it("unsuccessfully fetches data if it doesn't look like a semver is not found", async () => {
-      mockedChildProcess.execSync.mockImplementationOnce(() => Buffer.from("npm ERR! code E404"));
+      mockedChildProcess.execSync.mockImplementationOnce(() => Buffer.from('npm ERR! code E404'));
       expect(getLatestSushiVersion()).toBeUndefined;
       expect(loggerSpy.getLastMessage('warn')).toMatch(
         'Unable to determine the latest version of sushi: '
@@ -1319,7 +1320,7 @@ describe('Processing', () => {
     beforeAll(() => {
       jest.mock('child_process');
       mockedChildProcess = child_process as jest.Mocked<typeof child_process>;
-      mockedChildProcess.execSync = jest.fn()
+      mockedChildProcess.execSync = jest.fn();
     });
 
     it('returns an object with the latest and current sushi verisons', async () => {
@@ -1335,6 +1336,7 @@ describe('Processing', () => {
     it('should return an object with an undefined latest value when latest is not present', async () => {
       const localVersion = getLocalSushiVersion();
 
+      // eslint-disable-next-line quotes
       mockedChildProcess.execSync.mockImplementationOnce(() => Buffer.from("zsh: command not found: npm\n"));
       const versionObj = await checkSushiVersion();
       expect(versionObj).toHaveProperty('latest');


### PR DESCRIPTION
For large organizations it is common to have a local mirror of npmjs.org, and even go so far as disallowing installing NPM packages directly or blocking requests to registry.npmjs.org. This patch will honor the ENV setting to allow sushi to work in these situations -- preventing the sushi command from always failing.

This problem emerged after https://github.com/FHIR/sushi/pull/1036 was merged.