### PR TITLE
Invoke registered functions from plugins

### DIFF
--- a/src/utils/PluginManager.ts
+++ b/src/utils/PluginManager.ts
@@ -134,4 +134,16 @@ export class PluginManager {
       throw new InvalidHookError(hook, AVAILABLE_HOOKS);
     }
   }
+
+  static async callHook(hook: string, ...hookArgs: any[]): Promise<void> {
+    if (AVAILABLE_HOOKS.includes(hook)) {
+      for (const registeredFunction of PluginManager.hooks.get(hook) ?? []) {
+        try {
+          await registeredFunction(...hookArgs);
+        } catch (err) {
+          logger.error(`Error in plugin function at ${hook} hook: ${err.message}`);
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Completes the implementation portion of [INT-1177](https://standardhealthrecord.atlassian.net/browse/INT-1177).

The four hook points provided by PluginManager will call each registered function. The functions are called in the order that they were registered. If a function throws an error, the functions registered after it will still be called.