### PR TITLE
Avoid bogus error when constraining types on choice elements involving semi-matching slice names

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -804,9 +804,15 @@ export class StructureDefinition {
 
   findObsoleteChoices(baseElement: ElementDefinition, oldTypes: ElementDefinitionType[]): string[] {
     // first, find all the elements representing choices for the same choice element
-    const parentId = baseElement.parent().id;
+    const parentSlice = baseElement.parent()?.sliceName;
     const choiceElements = this.elements.filter(e => {
-      return e.path === baseElement.path && e.id.startsWith(parentId);
+      const eParentSlice = e.parent()?.sliceName;
+      return (
+        e.path === baseElement.path &&
+        (parentSlice == null ||
+          parentSlice === eParentSlice ||
+          eParentSlice?.startsWith(`${parentSlice}/`))
+      );
     });
     const matchedThings: ElementDefinition[] = [];
     const desiredSliceName = baseElement.path

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -3644,6 +3644,52 @@ describe('StructureDefinitionExporter R4', () => {
       expect(loggerSpy.getAllLogs()).toHaveLength(0);
     });
 
+    it('should not log an error when a type constraint is applied to a slice with a name that is the prefix of another slice', () => {
+      loggerSpy.reset();
+      const profile = new Profile('ConstrainedObservation');
+      profile.parent = 'Observation';
+      // * component ^slicing.discriminator[0].type = #pattern
+      // * component ^slicing.discriminator[0].path = "code"
+      // * component ^slicing.rules = #open
+      // * component contains GoodSlice and GoodSliceAgain
+      // * component[GoodSliceAgain].value[x] only Quantity
+      // * component[GoodSliceAgain].valueQuantity 1..1
+      // * component[GoodSlice].value[x] only string
+      const slicingType = new CaretValueRule('component');
+      slicingType.caretPath = 'slicing.discriminator[0].type';
+      slicingType.value = new FshCode('pattern');
+      const slicingPath = new CaretValueRule('component');
+      slicingPath.caretPath = 'slicing.discriminator[0].path';
+      slicingPath.value = 'code';
+      const slicingRules = new CaretValueRule('component');
+      slicingRules.caretPath = 'slicing.rules';
+      slicingRules.value = new FshCode('open');
+      const componentSlices = new ContainsRule('component');
+      componentSlices.items = [{ name: 'GoodSlice' }, { name: 'GoodSliceAgain' }];
+      const againType = new OnlyRule('component[GoodSliceAgain].value[x]');
+      againType.types = [{ type: 'Quantity' }];
+      const againCard = new CardRule('component[GoodSliceAgain].valueQuantity');
+      againCard.min = 1;
+      againCard.max = '1';
+      const goodType = new OnlyRule('component[GoodSlice].value[x]');
+      goodType.types = [{ type: 'string' }];
+
+      profile.rules.push(
+        slicingType,
+        slicingPath,
+        slicingRules,
+        componentSlices,
+        againType,
+        againCard,
+        goodType
+      );
+
+      exporter.exportStructDef(profile);
+      const sd = pkg.profiles[0];
+      expect(sd).toBeTruthy();
+      expect(loggerSpy.getAllLogs()).toHaveLength(0);
+    });
+
     it('should log an error when extension is constrained with a modifier extension', () => {
       const extension = new Extension('StrangeExtension');
       const modifier = new FlagRule('.');


### PR DESCRIPTION
Fixes #1061 and completes task [CIMPL-947](https://standardhealthrecord.atlassian.net/browse/CIMPL-947).

When checking for choices that are made obsolete as the result of type constraints, you have to be careful when checking slice names. If the element being constrained has no slice name, then any slice of it could contain a matching choice element. If the element being constrained has a slice name, then only that slice and its reslices can contain a matching choice element.