### PR TITLE
Restores ability to run sushi without arguments

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -94,7 +94,7 @@ async function app() {
   if (program.out) {
     logger.info(`  --out ${path.resolve(program.out)}`);
   }
-  logger.info(`  ${path.resolve(input)}`);
+  logger.info(`  ${path.resolve(input || '.')}`);
 
   const sushiVersions = await checkSushiVersion();
   if (


### PR DESCRIPTION
Fixes #1092, allowing sushi to be run without arguments (with the current directory assumed to be the FSH project). 

To test, checkout this branch and run `npm pack`. Then run `sudo npm install -g fsh-sushi-2.5.0.tgz` and attempt to use the sushi command without any arguments from the root of a FSH project. 