### PR TITLE
Don't slice single-type choices (unless already sliced)

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -16,7 +16,7 @@ import {
 import { InstanceOfNotDefinedError } from '../errors/InstanceOfNotDefinedError';
 import { InstanceOfLogicalProfileError } from '../errors/InstanceOfLogicalProfileError';
 import { Package } from '.';
-import { cloneDeep, merge, uniq } from 'lodash';
+import { cloneDeep, merge, uniq, upperFirst } from 'lodash';
 import { AssignmentRule } from '../fshtypes/rules';
 
 export class InstanceExporter implements Fishable {
@@ -276,6 +276,17 @@ export class InstanceExporter implements Fishable {
                 `Element ${child.id} has its cardinality satisfied by a rule that does not include the slice name. Use slice names in rule paths when possible.`
               );
               child = choiceSlice;
+              break;
+            }
+          }
+        }
+        // If we still haven't found it, it's possible that a type slice just wasn't created. In that case, there would
+        // be a type in the choice element's type array that would be a match if it were type-sliced.
+        if (instanceChild == null) {
+          for (const type of child.type) {
+            const name = childPathEnd.replace(/\[x\]$/, upperFirst(type.code));
+            instanceChild = instance[`_${name}`] ?? instance[name];
+            if (instanceChild != null) {
               break;
             }
           }

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -716,17 +716,29 @@ export class StructureDefinition {
    */
   private sliceMatchingValueX(fhirPath: string, elements: ElementDefinition[]): ElementDefinition {
     let matchingType: ElementDefinitionType;
-    const matchingXElements = elements.filter(e => {
-      if (e.path.endsWith('[x]')) {
-        for (const t of e.type ?? []) {
-          if (`${e.path.slice(0, -3)}${upperFirst(t.code)}` === fhirPath) {
-            matchingType = t;
-            return true;
-          }
+    const xElements = elements.filter(e => e.path.endsWith('[x]'));
+    const matchingXElements = xElements.filter(e => {
+      for (const t of e.type ?? []) {
+        if (`${e.path.slice(0, -3)}${upperFirst(t.code)}` === fhirPath) {
+          matchingType = t;
+          return true;
         }
       }
     });
-    if (matchingXElements.length > 0) {
+    // If the only match is the choice[x] element itself, and it's already been restricted
+    // to just a single type, and there are no existing slices (for this type or otherwise),
+    // just return that instead of creating an unnecessary slice.
+    // See: https://chat.fhir.org/#narrow/stream/215610-shorthand/topic/Type.20Slices.20on.20Choices.20w.2F.20a.20Single.20Type/near/282241129
+    if (
+      matchingXElements.length === 1 &&
+      matchingXElements[0].sliceName == null &&
+      matchingXElements[0].type?.length === 1 &&
+      xElements.filter(e => e.path === matchingXElements[0].path).length === 1
+    ) {
+      return matchingXElements[0];
+    }
+    // Otherwise we want a slice representing the specific type
+    else if (matchingXElements.length > 0) {
       const sliceName = fhirPath.slice(fhirPath.lastIndexOf('.') + 1);
       const matchingSlice = matchingXElements.find(c => c.sliceName === sliceName);
       // if we have already have a matching slice, we want to return it


### PR DESCRIPTION
If a user refers to a specific choice type (e.g., valueQuantity), but the choice (e.g., value[x]) only allows one type anyway, then don't create a type slicing and slice, because they're not necessary.

On the other hand, if the choice has already been sliced, then go ahead and create the slice for consistency.

To test, you can use the example in #1088:
```
Profile: MyObservation
Parent: Observation
* value[x] only CodeableConcept
* valueCodeableConcept from http://example.org/foo
```

On `next`, it will slice `value[x]` and create a `valueCodeableConcept` slice.  On this branch, it will apply the binding directly to `value[x]` instead.

If you're curious, I'm attaching the regression reports here (I filtered it to just html and log files): 
[regression-output.zip](https://github.com/FHIR/sushi/files/9049900/regression-output.zip)

Fixes #1088