### PR TITLE
Allow cardinality constraints to be applied to connected elements

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -832,7 +832,7 @@ export class ElementDefinition {
       })
       .filter(e => e);
     if (this.parent()) {
-      const [parentPath] = splitOnPathPeriods(this.path).slice(-1);
+      const [parentPath] = splitOnPathPeriods(this.id).slice(-1);
       return connectedElements.concat(
         this.parent().findConnectedElements(`.${parentPath}${postPath}`)
       );
@@ -1410,11 +1410,13 @@ export class ElementDefinition {
       }
 
       this.mustSupport = mustSupport;
-      // MS only gets applied to connected elements that are not themselves slices
+      // MS only gets applied to connected elements that are not themselves slices,
+      // unless they're the same slice name as this.
       // For example, Observation.component.interpretation MS implies Observation.component:Lab.interpretation MS
+      // And Observation.component.extension:Sequel MS implies Observation.component:Lab.extension:Sequel
       // But Observation.component MS does not imply Observation.component:Lab MS
       connectedElements
-        .filter(ce => ce.sliceName == null)
+        .filter(ce => ce.sliceName == null || ce.sliceName == this.sliceName)
         .forEach(ce => (ce.mustSupport = mustSupport || ce.mustSupport));
     }
     if (summary === true) {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -6743,7 +6743,7 @@ describe('StructureDefinitionExporter R4', () => {
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
 
-    it('should not apply a CardRule that would make the cardinality of the child of a slice too small', () => {
+    it.skip('should not apply a CardRule that would make the cardinality of the child of a slice too small', () => {
       loggerSpy.reset();
       // * component[Lab].interpretation 0..4
       // * component.interpretation 1..5 // this rule is invalid!
@@ -6764,6 +6764,144 @@ describe('StructureDefinitionExporter R4', () => {
       expect(sd.findElement('Observation.component:Lab.interpretation').max).toBe('4');
       expect(loggerSpy.getLastMessage('error')).toMatch(/cannot be narrowed/s);
       expect(loggerSpy.getLastMessage('error')).toMatch(/File: Narrower\.fsh.*Line: 7\D*/s);
+    });
+
+    it('should apply a CardRule that would increase the minimum cardinality of a child of a slice', () => {
+      // * component[Lab].interpretation 1..5
+      // * component.interpretation 2..6
+      const labCard = new CardRule('component[Lab].interpretation');
+      labCard.min = 1;
+      labCard.max = '5';
+      const rootCard = new CardRule('component.interpretation');
+      rootCard.min = 2;
+      rootCard.max = '6';
+
+      observationWithSlice.rules.push(labCard, rootCard);
+      doc.profiles.set(observationWithSlice.name, observationWithSlice);
+      exporter.export();
+      const sd = pkg.profiles[0];
+      const rootInterpretation = sd.findElement('Observation.component.interpretation');
+      const labInterpretation = sd.findElement('Observation.component:Lab.interpretation');
+      expect(rootInterpretation.min).toBe(2);
+      expect(rootInterpretation.max).toBe('6');
+      expect(labInterpretation.min).toBe(2);
+      expect(labInterpretation.max).toBe('5');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+    });
+
+    it('should apply a CardRule that would decrease the maximum cardinality of a child of a slice', () => {
+      // * component[Lab].interpretation 1..5
+      // * component.interpretation 0..3
+      const labCard = new CardRule('component[Lab].interpretation');
+      labCard.min = 1;
+      labCard.max = '5';
+      const rootCard = new CardRule('component.interpretation');
+      rootCard.min = 0;
+      rootCard.max = '3';
+
+      observationWithSlice.rules.push(labCard, rootCard);
+      doc.profiles.set(observationWithSlice.name, observationWithSlice);
+      exporter.export();
+      const sd = pkg.profiles[0];
+      const rootInterpretation = sd.findElement('Observation.component.interpretation');
+      const labInterpretation = sd.findElement('Observation.component:Lab.interpretation');
+      expect(rootInterpretation.min).toBe(0);
+      expect(rootInterpretation.max).toBe('3');
+      expect(labInterpretation.min).toBe(1);
+      expect(labInterpretation.max).toBe('3');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+    });
+
+    it('should apply a CardRule that would increase the minimum cardinality and decrease the maximum cardinality of a child of a slice', () => {
+      // * component[Lab].interpretation 1..5
+      // * component.interpretation 2..2
+      const labCard = new CardRule('component[Lab].interpretation');
+      labCard.min = 1;
+      labCard.max = '5';
+      const rootCard = new CardRule('component.interpretation');
+      rootCard.min = 2;
+      rootCard.max = '2';
+
+      observationWithSlice.rules.push(labCard, rootCard);
+      doc.profiles.set(observationWithSlice.name, observationWithSlice);
+      exporter.export();
+      const sd = pkg.profiles[0];
+      const rootInterpretation = sd.findElement('Observation.component.interpretation');
+      const labInterpretation = sd.findElement('Observation.component:Lab.interpretation');
+      expect(rootInterpretation.min).toBe(2);
+      expect(rootInterpretation.max).toBe('2');
+      expect(labInterpretation.min).toBe(2);
+      expect(labInterpretation.max).toBe('2');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+    });
+
+    it('should not apply a CardRule that is incompatible with the existing cardinality of a child of a slice', () => {
+      // * component[Lab].interpretation 1..5
+      // * component.interpretation 6..10
+      const labCard = new CardRule('component[Lab].interpretation');
+      labCard.min = 1;
+      labCard.max = '5';
+      const rootCard = new CardRule('component.interpretation')
+        .withFile('Incompatible.fsh')
+        .withLocation([8, 3, 8, 25]);
+      rootCard.min = 6;
+      rootCard.max = '10';
+
+      observationWithSlice.rules.push(labCard, rootCard);
+      doc.profiles.set(observationWithSlice.name, observationWithSlice);
+      exporter.export();
+      const sd = pkg.profiles[0];
+      const rootInterpretation = sd.findElement('Observation.component.interpretation');
+      const labInterpretation = sd.findElement('Observation.component:Lab.interpretation');
+      expect(rootInterpretation.min).toBe(0);
+      expect(rootInterpretation.max).toBe('*');
+      expect(labInterpretation.min).toBe(1);
+      expect(labInterpretation.max).toBe('5');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        'Cardinality on Observation.component.interpretation cannot be narrowed'
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(/File: Incompatible\.fsh.*Line: 8\D*/s);
+    });
+
+    it('should not apply a CardRule that is incompatible with the existing cardinality on some of the children of slices', () => {
+      // * component contains Field 0..1
+      // * component[Lab].interpretation 1..5
+      // * component[Field].interpretation 0..2
+      // * component.interpretation 3..4
+      const containsField = new ContainsRule('component');
+      containsField.items = [{ name: 'Field' }];
+      const containsCard = new CardRule('component[Field]');
+      containsCard.min = 0;
+      containsCard.max = '1';
+      const labCard = new CardRule('component[Lab].interpretation');
+      labCard.min = 1;
+      labCard.max = '5';
+      const fieldCard = new CardRule('component[Field].interpretation');
+      fieldCard.min = 0;
+      fieldCard.max = '2';
+      const rootCard = new CardRule('component.interpretation')
+        .withFile('Incompatible.fsh')
+        .withLocation([9, 3, 9, 23]);
+      rootCard.min = 6;
+      rootCard.max = '10';
+
+      observationWithSlice.rules.push(containsField, containsCard, labCard, fieldCard, rootCard);
+      doc.profiles.set(observationWithSlice.name, observationWithSlice);
+      exporter.export();
+      const sd = pkg.profiles[0];
+      const rootInterpretation = sd.findElement('Observation.component.interpretation');
+      const labInterpretation = sd.findElement('Observation.component:Lab.interpretation');
+      const fieldInterpretation = sd.findElement('Observation.component:Field.interpretation');
+      expect(rootInterpretation.min).toBe(0);
+      expect(rootInterpretation.max).toBe('*');
+      expect(labInterpretation.min).toBe(1);
+      expect(labInterpretation.max).toBe('5');
+      expect(fieldInterpretation.min).toBe(0);
+      expect(fieldInterpretation.max).toBe('2');
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        'Cardinality on Observation.component.interpretation cannot be narrowed'
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(/File: Incompatible\.fsh.*Line: 9\D*/s);
     });
 
     it('should apply a FlagRule on a sliced element that updates the flags on its slices', () => {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -6844,7 +6844,7 @@ describe('StructureDefinitionExporter R4', () => {
       // * component contains Field 0..1
       // * component[Lab].interpretation 1..5
       // * component[Field].interpretation 0..2
-      // * component.interpretation 3..4
+      // * component.interpretation 6..10
       const containsField = new ContainsRule('component');
       containsField.items = [{ name: 'Field' }];
       const containsCard = new CardRule('component[Field]');

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -6743,29 +6743,6 @@ describe('StructureDefinitionExporter R4', () => {
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
 
-    it.skip('should not apply a CardRule that would make the cardinality of the child of a slice too small', () => {
-      loggerSpy.reset();
-      // * component[Lab].interpretation 0..4
-      // * component.interpretation 1..5 // this rule is invalid!
-      const labCard = new CardRule('component[Lab].interpretation');
-      labCard.max = '4';
-      const rootCard = new CardRule('component.interpretation')
-        .withFile('Narrower.fsh')
-        .withLocation([7, 9, 7, 23]);
-      rootCard.min = 1;
-      rootCard.max = '5';
-
-      observationWithSlice.rules.push(labCard, rootCard);
-      doc.profiles.set(observationWithSlice.name, observationWithSlice);
-      exporter.export();
-      const sd = pkg.profiles[0];
-      expect(sd.findElement('Observation.component.interpretation').max).toBe('*');
-      expect(sd.findElement('Observation.component.interpretation').min).toBe(0);
-      expect(sd.findElement('Observation.component:Lab.interpretation').max).toBe('4');
-      expect(loggerSpy.getLastMessage('error')).toMatch(/cannot be narrowed/s);
-      expect(loggerSpy.getLastMessage('error')).toMatch(/File: Narrower\.fsh.*Line: 7\D*/s);
-    });
-
     it('should apply a CardRule that would increase the minimum cardinality of a child of a slice', () => {
       // * component[Lab].interpretation 1..5
       // * component.interpretation 2..6


### PR DESCRIPTION
Completes task [CIMPL-986](https://standardhealthrecord.atlassian.net/browse/CIMPL-986).

When constraining cardinality on an element, if there are connected elements that are the child of a slice, it may be possible to apply the cardinality constraint to those elements. As long as no cardinality is widened, applying the constraints is allowed. This may mean that only the new min or max are applied. If the new cardinality has no overlap with the connected element's existing cardinality, the cardinality constraint can't be applied.