### PR TITLE
Avoid duplicate elements on resliced elements

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -166,8 +166,7 @@ export function setImpliedPropertiesOnInstance(
               return part;
             });
             result.push(parts.pop()); // Get the last path part that we sliced off when building result
-            const newPath = assembleFSHPath(result);
-            return newPath;
+            return assembleFSHPath(result);
           });
 
           newAndImprovedAllPaths.forEach(ip => {

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -1,14 +1,4 @@
-import {
-  isEmpty,
-  cloneDeep,
-  upperFirst,
-  remove,
-  isEqual,
-  sumBy,
-  zip,
-  zipWith,
-  slice
-} from 'lodash';
+import { isEmpty, cloneDeep, upperFirst, remove, isEqual, sumBy, zip, zipWith } from 'lodash';
 import {
   StructureDefinition,
   PathPart,
@@ -126,8 +116,6 @@ export function setImpliedPropertiesOnInstance(
           );
           const allPaths = [finalPath, ...impliedPaths];
           // Transform paths such that any required reslices may be satisfied by existing slices
-          // const elementWithSlices = associatedEl.slicedElement() ?? associatedEl;
-          // const allSlices = elementWithSlices.getSlices();
           const parents = associatedEl.getAllParents().slice(0, -1).reverse(); // [oldest ancestor, ... grandparent, parent]
           const allRequiredSlices = parents.map(parent => {
             const elementWithSlices = parent.slicedElement() ?? parent;
@@ -145,7 +133,6 @@ export function setImpliedPropertiesOnInstance(
               sliceName: a.sliceName,
               min: b
             }));
-            // TODO sort slicesWithMins so that ex. Bread/Wheat comes before Bread ??
             return slicesWithMins;
           });
 
@@ -154,12 +141,12 @@ export function setImpliedPropertiesOnInstance(
             // for each part in parts, check if it has any required slices
             // if it does, check my slice name and numeric index (if my index doesn't exist, it's 0)
             // see if i need to turn into something with a different slice name
-            // IMPORTANT reslices should get priority over their base slice. so Bread/Rye comes before Bread
+            // IMPORTANT reslices should get priority over their base slice. so Bread/Rye is used before Bread
             // i promise to be nice
             // Anything we need to do applying to the last path part is handled by getAllImpliedPaths
             const result = zip(parts.slice(0, -1), allRequiredSlices).map(([part, sliceFacts]) => {
               if (sliceFacts.length > 0) {
-                const mySliceName = part.slices ? getSliceName(part) : ''; //.slices?.join('/') ?? '';
+                const mySliceName = part.slices ? getSliceName(part) : '';
                 let myNumericIndex = getArrayIndex(part) ?? 0;
                 for (const fact of sliceFacts) {
                   if (fact.sliceName.startsWith(mySliceName) && fact.min > myNumericIndex) {

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -786,45 +786,12 @@ export function getAllImpliedPaths(element: ElementDefinition, path: string): st
     parentPaths.push('');
   }
   const pathEnd = splitOnPathPeriods(path).slice(-1)[0];
-  const pathEnds = [];
+  const pathEnds = [pathEnd];
   if (element.max === '*' || parseInt(element.max) > 1) {
-    // Check for any required slices or reslices
-    const elementWithSlices = element.slicedElement() ?? element;
-    const allSlices = elementWithSlices.getSlices();
-    let usefulSlices: ElementDefinition[];
-    if (element.sliceName == null) {
-      usefulSlices = allSlices;
-    } else {
-      usefulSlices = allSlices.filter(s => s.sliceName.startsWith(`${element.sliceName}/`));
-    }
-    const reslicePathEnds: string[] = [];
-    usefulSlices.forEach(reslice => {
-      const resliceParts = reslice.sliceName
-        .split('/')
-        .slice(1)
-        .map(reslicePart => `[${reslicePart}]`)
-        .join('');
-      if (reslice.min > 0) {
-        reslicePathEnds.push(`${pathEnd}${resliceParts}`);
-      }
-      for (let i = 1; i < reslice.min; i++) {
-        reslicePathEnds.push(`${pathEnd}${resliceParts}[${i}]`);
-      }
-    });
-
-    // If there are no required reslices, we want a path with no index for index 0
-    if (reslicePathEnds.length === 0) {
-      pathEnds.push(pathEnd);
-    }
-    // Add other required elements that are not required named slices/reslices first
     // Index 0 element doesn't need index, since it is implied
-    for (let i = 1; i < element.min - reslicePathEnds.length; i++) {
+    for (let i = 1; i < element.min; i++) {
       pathEnds.push(`${pathEnd}[${i}]`);
     }
-    // Add any required named slice/reslice paths
-    pathEnds.push(...reslicePathEnds);
-  } else {
-    pathEnds.push(pathEnd);
   }
   const finalPaths = [];
   for (const parentPath of parentPaths) {

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -4065,9 +4065,6 @@ describe('InstanceExporter', () => {
         valueString: 'Wheat'
       });
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
-      // expect component.length to be 2
-      // check the values on each element of component, to be extra sure
-      // expect no errors
     });
 
     it('should create the correct number of required elements on a resliced element when required slices are greater than required reslices', () => {
@@ -4202,9 +4199,6 @@ describe('InstanceExporter', () => {
         valueString: 'Wheat'
       });
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
-      // expect component.length to be 5
-      // check the values on each element of component, to be extra sure
-      // expect no errors
     });
 
     it('should create the correct number of required elements on a resliced element when required elements are greater than required slices and reslices', () => {
@@ -4357,9 +4351,6 @@ describe('InstanceExporter', () => {
         }
       });
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
-      // expect component.length to be 4
-      // check the values on each element of component, to be extra sure
-      // expect no errors
     });
 
     it('should not assign a value which violates a closed child slicing', () => {

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -3945,6 +3945,11 @@ describe('InstanceExporter', () => {
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
 
+    // Potential additional test cases:
+    // breadCard.min = 5 and ryeCard.min = 2 => length 5, in order Bread, Bread, Rye, Rye, Wheat
+    // breadCard.min = 2 and ryeCard.min = 0, wheatCard.min = 0 => Bread, Bread
+    // component.min = 7 breadCard.min = 5 and ryeCard.min = 2 component[5].code = #5 component[6].code = #6 =>
+
     it('should create the correct number of required elements on a resliced element', () => {
       // Profile: BreadObservation
       // Parent: Observation

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -4041,6 +4041,8 @@ describe('InstanceExporter', () => {
       instanceStatus.value = new FshCode('final');
       const instanceCode = new AssignmentRule('code');
       instanceCode.value = new FshCode('bread');
+      breadInstance.rules.push(instanceStatus, instanceCode);
+      doc.instances.set(breadInstance.name, breadInstance);
 
       const result = exportInstance(breadInstance);
       expect(result.component).toHaveLength(2);


### PR DESCRIPTION
Fixes #1117

Co-authored with @mint-thompson!

Previously, when an element was sliced and then had required reslices, the reslices were not being considered when creating the elements on an instance. In this PR, required reslices now count toward fulfilling a slice's minimum cardinality.

For example, if a component had a slice `Bread` and then was resliced to have two reslices `Bread/Rye` and `Bread/Wheat` and both reslices had a `min` of `1`, SUSHI correctly calculated that `Bread` has an effective `min` of `2`. However, when creating the instance, SUSHI would add two elements for the effective min of `Bread`, one element for the min of `Bread/Rye`, and one element for the min of `Bread/Wheat` for a total of _four_ elements. On this branch, it correctly satisfies the min of `Bread` with the two elements for the two reslices and does not add any `Bread` elements, so the final array only has _two_ elements as expected.

The tests added also demonstrate this, as well as the example linked in the issue.