### PR TITLE
Create markdown file with resource links

### DIFF
--- a/src/fhirtypes/ImplementationGuide.ts
+++ b/src/fhirtypes/ImplementationGuide.ts
@@ -74,6 +74,7 @@ export type ImplementationGuideDefinitionResource = {
   profile?: string[]; // R5 added this property to replace exampleCanonical
   groupingId?: string;
   extension?: Extension[];
+  _linkRef?: string;
 };
 
 export type ImplementationGuideDefinitionPage = {

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -102,6 +102,7 @@ export class IGExporter {
     this.sortResources();
     this.addConfiguredGroups();
     this.addIndex(outPath);
+    this.addLinkReferences(outPath);
     if (!this.config.pages?.length) {
       this.addOtherPageContent();
     } else {
@@ -420,6 +421,23 @@ export class IGExporter {
         generation
       });
     }
+  }
+
+  addLinkReferences(igPath: string): void {
+    // no need to make this file if there are no resources
+    if (!this.ig.definition?.resource.length) {
+      return;
+    }
+    const linkReferencesDir = path.join(igPath, 'fsh-generated', 'includes');
+    const linkReferencesExportPath = path.join(linkReferencesDir, 'markdown-link-references.md');
+    ensureDirSync(linkReferencesDir);
+    const content = this.ig.definition.resource.map(igResource => {
+      // a configured resource may lack a name
+      // in that case, try to build a useful name from the reference
+      const linkName = igResource.name ?? igResource.reference?.reference?.replace(/^[^\/]*\//, '');
+      return `[${linkName}]: ${igResource.reference?.reference?.replace('/', '-')}.html`;
+    });
+    outputFileSync(linkReferencesExportPath, content.join('\n'));
   }
 
   /**

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -432,9 +432,15 @@ export class IGExporter {
     const linkReferencesExportPath = path.join(linkReferencesDir, 'markdown-link-references.md');
     ensureDirSync(linkReferencesDir);
     const content = this.ig.definition.resource.map(igResource => {
+      // FSH resources and predefined resources will have a _linkRef
       // a configured resource may lack a name
       // in that case, try to build a useful name from the reference
-      const linkName = igResource.name ?? igResource.reference?.reference?.replace(/^[^\/]*\//, '');
+      const linkName =
+        igResource._linkRef ??
+        igResource.name ??
+        igResource.reference?.reference?.replace(/^[^\/]*\//, '');
+      // delete the _linkRef now that we've used it
+      delete igResource._linkRef;
       return `[${linkName}]: ${igResource.reference?.reference?.replace('/', '-')}.html`;
     });
     outputFileSync(linkReferencesExportPath, content.join('\n'));
@@ -1001,6 +1007,7 @@ export class IGExporter {
               if (path.basename(dirPath) === 'examples') {
                 newResource.name =
                   configResource?.name ?? metaExtensionName ?? existingName ?? resourceJSON.id;
+                newResource._linkRef = resourceJSON.id;
                 // set exampleCanonical or exampleBoolean, preferring configured values
                 if (configResource?.exampleCanonical) {
                   newResource.exampleCanonical = configResource.exampleCanonical;
@@ -1036,6 +1043,7 @@ export class IGExporter {
                   title ??
                   name ??
                   resourceJSON.id;
+                newResource._linkRef = name ?? resourceJSON.id;
               }
               if (configResource?.extension?.length) {
                 newResource.extension = configResource.extension;

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -856,10 +856,12 @@ export class IGExporter {
         configResource?.name ?? pkgResource._instanceMeta.title ?? pkgResource._instanceMeta.name;
       newResource.description =
         configResource?.description ?? pkgResource._instanceMeta.description;
+      newResource._linkRef = pkgResource.id;
     } else {
       newResource.name =
         configResource?.name ?? pkgResource.title ?? pkgResource.name ?? pkgResource.id;
       newResource.description = configResource?.description ?? pkgResource.description;
+      newResource._linkRef = pkgResource.name;
     }
     if (configResource?.fhirVersion?.length) {
       newResource.fhirVersion = configResource.fhirVersion;

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -429,7 +429,7 @@ export class IGExporter {
       return;
     }
     const linkReferencesDir = path.join(igPath, 'fsh-generated', 'includes');
-    const linkReferencesExportPath = path.join(linkReferencesDir, 'markdown-link-references.md');
+    const linkReferencesExportPath = path.join(linkReferencesDir, 'fsh-link-references.md');
     ensureDirSync(linkReferencesDir);
     const content = this.ig.definition.resource.map(igResource => {
       // FSH resources and predefined resources will have a _linkRef

--- a/test/ig/IGExporter.link-references.test.ts
+++ b/test/ig/IGExporter.link-references.test.ts
@@ -1,0 +1,107 @@
+import fs from 'fs-extra';
+import path from 'path';
+import temp from 'temp';
+import { Package } from '../../src/export';
+import { IGExporter } from '../../src/ig';
+import { FHIRDefinitions, loadCustomResources } from '../../src/fhirdefs';
+import { loggerSpy } from '../testhelpers/loggerSpy';
+import { minimalConfig } from '../utils/minimalConfig';
+import { CodeSystem } from '../../src/fhirtypes';
+
+describe('IGExporter', () => {
+  temp.track();
+
+  describe('#link-references', () => {
+    let pkg: Package;
+    let exporter: IGExporter;
+    let defs: FHIRDefinitions;
+    let tempOut: string;
+
+    beforeEach(() => {
+      tempOut = temp.mkdirSync('sushi-test');
+      defs = new FHIRDefinitions();
+      loadCustomResources(
+        path.resolve(__dirname, 'fixtures', 'customized-ig-with-resources', 'input'),
+        undefined,
+        undefined,
+        defs
+      );
+      loggerSpy.reset();
+    });
+
+    afterEach(() => {
+      temp.cleanupSync();
+    });
+
+    it('should create links for each resource in the IG', () => {
+      pkg = new Package({
+        ...minimalConfig,
+        resources: [
+          {
+            reference: { reference: 'ValueSet/unique-vs' },
+            name: 'UniqueVS'
+          },
+          {
+            reference: { reference: 'CodeSystem/nameless-cs' }
+          }
+        ]
+      });
+      // make a little codesystem to add to the package
+      const littleCodeSystem = new CodeSystem();
+      littleCodeSystem.id = 'little-cs';
+      littleCodeSystem.name = 'LittleCodeSystem';
+      littleCodeSystem.description = 'A rather small code system';
+      pkg.codeSystems.push(littleCodeSystem);
+      const igDataPath = path.resolve(__dirname, 'fixtures', 'customized-ig-with-resources');
+      exporter = new IGExporter(pkg, defs, igDataPath);
+      exporter.export(tempOut);
+      const linkReferencesPath = path.join(
+        tempOut,
+        'fsh-generated',
+        'includes',
+        'markdown-link-references.md'
+      );
+      expect(fs.existsSync(linkReferencesPath)).toBeTrue();
+      const content = fs.readFileSync(linkReferencesPath, 'utf-8');
+      // we should have links from resources in the package,
+      expect(content).toMatch(/^\[LittleCodeSystem\]: CodeSystem-little-cs\.html$/m);
+      // predefined resources,
+      expect(content).toMatch(/^\[MyPatient\]: StructureDefinition-MyPatient\.html$/m);
+      // and config-only resources,
+      expect(content).toMatch(/^\[UniqueVS\]: ValueSet-unique-vs\.html$/m);
+      // even when the config doesn't give it a name
+      expect(content).toMatch(/^\[nameless-cs\]: CodeSystem-nameless-cs\.html$/m);
+    });
+
+    it('should not create a file if there are no resources in the IG', () => {
+      // reset defs so we have no predefined resources
+      defs = new FHIRDefinitions();
+      // configure the little codesystem to be omitted from the IG
+      pkg = new Package({
+        ...minimalConfig,
+        resources: [
+          {
+            reference: { reference: 'CodeSystem/little-cs' },
+            omit: true
+          }
+        ]
+      });
+      // make a little codesystem to add to the package
+      const littleCodeSystem = new CodeSystem();
+      littleCodeSystem.id = 'little-cs';
+      littleCodeSystem.name = 'LittleCodeSystem';
+      littleCodeSystem.description = 'A rather small code system';
+      pkg.codeSystems.push(littleCodeSystem);
+      const igDataPath = path.resolve(__dirname, 'fixtures', 'customized-ig-with-resources');
+      exporter = new IGExporter(pkg, defs, igDataPath);
+      exporter.export(tempOut);
+      const linkReferencesPath = path.join(
+        tempOut,
+        'fsh-generated',
+        'includes',
+        'markdown-link-references.md'
+      );
+      expect(fs.existsSync(linkReferencesPath)).toBeFalse();
+    });
+  });
+});

--- a/test/ig/IGExporter.link-references.test.ts
+++ b/test/ig/IGExporter.link-references.test.ts
@@ -60,7 +60,7 @@ describe('IGExporter', () => {
         tempOut,
         'fsh-generated',
         'includes',
-        'markdown-link-references.md'
+        'fsh-link-references.md'
       );
       expect(fs.existsSync(linkReferencesPath)).toBeTrue();
       const content = fs.readFileSync(linkReferencesPath, 'utf-8');
@@ -101,7 +101,7 @@ describe('IGExporter', () => {
         tempOut,
         'fsh-generated',
         'includes',
-        'markdown-link-references.md'
+        'fsh-link-references.md'
       );
       expect(fs.existsSync(linkReferencesPath)).toBeFalse();
     });

--- a/test/ig/IGExporter.link-references.test.ts
+++ b/test/ig/IGExporter.link-references.test.ts
@@ -50,6 +50,7 @@ describe('IGExporter', () => {
       const littleCodeSystem = new CodeSystem();
       littleCodeSystem.id = 'little-cs';
       littleCodeSystem.name = 'LittleCodeSystem';
+      littleCodeSystem.title = 'Little Code System';
       littleCodeSystem.description = 'A rather small code system';
       pkg.codeSystems.push(littleCodeSystem);
       const igDataPath = path.resolve(__dirname, 'fixtures', 'customized-ig-with-resources');
@@ -67,6 +68,7 @@ describe('IGExporter', () => {
       expect(content).toMatch(/^\[LittleCodeSystem\]: CodeSystem-little-cs\.html$/m);
       // predefined resources,
       expect(content).toMatch(/^\[MyPatient\]: StructureDefinition-MyPatient\.html$/m);
+      expect(content).toMatch(/^\[birthPlace\]: StructureDefinition-patient-birthPlace\.html$/m);
       // and config-only resources,
       expect(content).toMatch(/^\[UniqueVS\]: ValueSet-unique-vs\.html$/m);
       // even when the config doesn't give it a name


### PR DESCRIPTION
Completes task [CIMPL-931](https://standardhealthrecord.atlassian.net/browse/CIMPL-931).

When authoring an IG, it is frequently useful for the narrative text to include links to various resources within the IG. Generate file with easy-to-use links to the page for each resource in the IG.

The name of each link is the name of the IG resource. For example, a profile named `MyProfile` with id `my-profile` would appear like this in the resource links file: `[MyProfile]: StructureDefinition-my-profile.html`. If the IG resource lacks a name, SUSHI tries to build a usable name from the resource reference key.

As part of reviewing this, please try running SUSHI against a small test project and see what kind of `markdown-link-references.md` file is produced.