### PR TITLE
Add command-line option to update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ $ sushi --help
 Usage: sushi [path-to-fsh-project] [options]
 
 Options:
-  -o, --out <out>       the path to the output folder
-  -d, --debug           output extra debugging information
-  -p, --preprocessed    output FSH produced by preprocessing steps
-  -s, --snapshot        generate snapshot in Structure Definition output (default: false)
-  -r, --require-latest  exit with error if this is not the latest version of SUSHI (default: false)
-  -i, --init            initialize a SUSHI project
-  -v, --version         print SUSHI version
-  -h, --help            output usage information
+  -o, --out <out>            the path to the output folder
+  -d, --debug                output extra debugging information
+  -p, --preprocessed         output FSH produced by preprocessing steps
+  -s, --snapshot             generate snapshot in Structure Definition output (default: false)
+  -r, --require-latest       exit with error if this is not the latest version of SUSHI (default: false)
+  -i, --init                 initialize a SUSHI project
+  -u, --update-dependencies  update FHIR packages in project configuration
+  -v, --version              print SUSHI version
+  -h, --help                 display help for command
 
 Additional information:
   [path-to-fsh-project]

--- a/src/app.ts
+++ b/src/app.ts
@@ -29,6 +29,7 @@ import {
   findInputDir,
   ensureOutputDir,
   readConfig,
+  updateExternalDependencies,
   loadExternalDependencies,
   fillTank,
   writeFHIRResources,
@@ -64,6 +65,7 @@ async function app() {
       false
     )
     .option('-i, --init', 'initialize a SUSHI project')
+    .option('-u, --update-dependencies', 'update FHIR packages in project configuration')
     .version(getVersion(), '-v, --version', 'print SUSHI version')
     .on('--help', () => {
       console.log('');
@@ -183,6 +185,14 @@ async function app() {
       logger.error(`An unexpected error occurred: ${e.message ?? e}`);
     }
     process.exit(1);
+  }
+
+  // Update dependencies
+  if (program.updateDependencies) {
+    const updateResult = await updateExternalDependencies(config);
+    if (!updateResult) {
+      process.exit(0);
+    }
   }
 
   // Load dependencies

--- a/src/app.ts
+++ b/src/app.ts
@@ -163,6 +163,13 @@ async function app() {
   let tank: FSHTank;
   let config: Configuration;
 
+  // Update dependencies
+  if (program.updateDependencies) {
+    config = readConfig(originalInput);
+    await updateExternalDependencies(config);
+    process.exit(0);
+  }
+
   try {
     let rawFSH: RawFSH[];
     if (!fs.existsSync(input)) {
@@ -173,7 +180,13 @@ async function app() {
     } else {
       rawFSH = getRawFSHes(input);
     }
-    if (rawFSH.length === 0 && !fs.existsSync(path.join(originalInput, 'sushi-config.yaml'))) {
+    if (
+      rawFSH.length === 0 &&
+      !(
+        fs.existsSync(path.join(originalInput, 'sushi-config.yaml')) ||
+        fs.existsSync(path.join(originalInput, 'sushi-config.yml'))
+      )
+    ) {
       logger.info('No FSH files or sushi-config.yaml present.');
       process.exit(0);
     }
@@ -185,14 +198,6 @@ async function app() {
       logger.error(`An unexpected error occurred: ${e.message ?? e}`);
     }
     process.exit(1);
-  }
-
-  // Update dependencies
-  if (program.updateDependencies) {
-    const updateResult = await updateExternalDependencies(config);
-    if (!updateResult) {
-      process.exit(0);
-    }
   }
 
   // Load dependencies

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -185,10 +185,10 @@ export async function updateExternalDependencies(config: Configuration): Promise
         latestVersion = res?.data?.['dist-tags']?.latest;
       } catch (e) {
         try {
-          res = await axiosGet(`https://packages2.fhir.org/${dep.packageId}`);
+          res = await axiosGet(`https://packages2.fhir.org/packages/${dep.packageId}`);
           latestVersion = res?.data?.['dist-tags']?.latest;
         } catch (e) {
-          logger.info(`Could not get version info for package ${dep.packageId}`);
+          logger.warn(`Could not get version info for package ${dep.packageId}`);
           return;
         }
       }
@@ -198,14 +198,14 @@ export async function updateExternalDependencies(config: Configuration): Promise
           changedVersions.set(dep.packageId, dep.version);
         }
       } else {
-        logger.info(`Could not determine latest version for package ${dep.packageId}`);
+        logger.warn(`Could not determine latest version for package ${dep.packageId}`);
       }
     }
   });
   await Promise.all(promises);
   if (changedVersions.size > 0) {
     // before changing the file, check with the user
-    const continuationChoice = readlineSync.keyInYN(
+    const continuationChoice = readlineSync.keyInYNStrict(
       [
         'Updates to dependency versions detected:',
         ...Array.from(changedVersions.entries()).map(
@@ -216,12 +216,8 @@ export async function updateExternalDependencies(config: Configuration): Promise
         'Do you want to apply these updates?',
         '- [Y]es, apply updates to sushi-config.yaml',
         '- [N]o, quit without applying updates',
-        'Choose one [Y,N]: '
-      ].join('\n'),
-      {
-        limit: 'AQ',
-        cancel: false
-      }
+        'Choose one: '
+      ].join('\n')
     );
     if (continuationChoice === true) {
       const configText = fs.readFileSync(config.filePath, 'utf8');

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -518,6 +518,13 @@ describe('Processing', () => {
       expect(result).toBe(true);
       expect(keyInSpy).toHaveBeenCalledTimes(0);
     });
+
+    it('should return true without requiring input if there are no dependencies in the configuration', async () => {
+      config.dependencies = [];
+      const result = await updateExternalDependencies(config);
+      expect(result).toBe(true);
+      expect(keyInSpy).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('#loadExternalDependencies()', () => {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -360,7 +360,7 @@ describe('Processing', () => {
       mockedAxios = axios as jest.Mocked<typeof axios>;
       mockedAxios.get = jest.fn();
       mockedAxios.get.mockImplementation((url: string) => {
-        if (url.endsWith('/hl7.fhir.us.core')) {
+        if (url === 'https://packages.fhir.org/hl7.fhir.us.core') {
           return Promise.resolve({
             data: {
               name: 'hl7.fhir.us.core',
@@ -370,7 +370,7 @@ describe('Processing', () => {
               }
             }
           });
-        } else if (url.endsWith('/hl7.fhir.uv.genomics-reporting')) {
+        } else if (url === 'https://packages2.fhir.org/hl7.fhir.uv.genomics-reporting') {
           return Promise.resolve({
             data: {
               name: 'hl7.fhir.uv.genomics-reporting',
@@ -379,7 +379,7 @@ describe('Processing', () => {
               }
             }
           });
-        } else if (url.endsWith('/hl7.fhir.us.mcode')) {
+        } else if (url === 'https://packages.fhir.org/hl7.fhir.us.mcode') {
           return Promise.resolve({
             data: {
               name: 'hl7.fhir.us.mcode',
@@ -403,7 +403,7 @@ describe('Processing', () => {
       );
       fs.copyFileSync(originalInput, path.join(tempRoot, 'sushi-config.yaml'));
       config = readConfig(tempRoot);
-      keyInSpy = jest.spyOn(readlineSync, 'keyIn');
+      keyInSpy = jest.spyOn(readlineSync, 'keyInYN');
     });
 
     afterEach(() => {
@@ -415,7 +415,7 @@ describe('Processing', () => {
     });
 
     it('should update versioned dependencies in the configuration', async () => {
-      keyInSpy.mockReturnValueOnce('a');
+      keyInSpy.mockReturnValueOnce(true);
       const result = await updateExternalDependencies(config);
       expect(result).toBe(true);
       const updatedDependencies = [
@@ -433,6 +433,8 @@ describe('Processing', () => {
         },
         {
           packageId: 'hl7.fhir.us.mcode',
+          id: 'mcode',
+          uri: 'http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode',
           version: '2.1.1'
         },
         {
@@ -446,7 +448,7 @@ describe('Processing', () => {
     });
 
     it('should display a list of the available version updates', async () => {
-      keyInSpy.mockReturnValueOnce('a');
+      keyInSpy.mockReturnValueOnce(true);
       const result = await updateExternalDependencies(config);
       expect(result).toBe(true);
       const displayedMessage = keyInSpy.mock.calls[0][0] as string;
@@ -459,7 +461,7 @@ describe('Processing', () => {
     });
 
     it('should not update dependencies if the user quits without applying updates', async () => {
-      keyInSpy.mockReturnValueOnce('q');
+      keyInSpy.mockReturnValueOnce(false);
       const result = await updateExternalDependencies(config);
       expect(result).toBe(false);
       const originalDependencies = [
@@ -477,6 +479,8 @@ describe('Processing', () => {
         },
         {
           packageId: 'hl7.fhir.us.mcode',
+          id: 'mcode',
+          uri: 'http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode',
           version: '2.0.1'
         },
         {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -370,7 +370,7 @@ describe('Processing', () => {
               }
             }
           });
-        } else if (url === 'https://packages2.fhir.org/hl7.fhir.uv.genomics-reporting') {
+        } else if (url === 'https://packages2.fhir.org/packages/hl7.fhir.uv.genomics-reporting') {
           return Promise.resolve({
             data: {
               name: 'hl7.fhir.uv.genomics-reporting',
@@ -403,7 +403,7 @@ describe('Processing', () => {
       );
       fs.copyFileSync(originalInput, path.join(tempRoot, 'sushi-config.yaml'));
       config = readConfig(tempRoot);
-      keyInSpy = jest.spyOn(readlineSync, 'keyInYN');
+      keyInSpy = jest.spyOn(readlineSync, 'keyInYNStrict');
     });
 
     afterEach(() => {

--- a/test/utils/fixtures/extra-dependencies/sushi-config.yaml
+++ b/test/utils/fixtures/extra-dependencies/sushi-config.yaml
@@ -26,5 +26,8 @@ dependencies:
   hl7.fhir.us.core: 3.1.0
   hl7.fhir.uv.vhdir: current
   hl7.fhir.uv.genomics-reporting: 2.0.0
-  hl7.fhir.us.mcode: 2.0.1
+  hl7.fhir.us.mcode:
+    id: mcode
+    uri: http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode
+    version: 2.0.1
   hl7.fhir.us.davinci-pas: dev

--- a/test/utils/fixtures/extra-dependencies/sushi-config.yaml
+++ b/test/utils/fixtures/extra-dependencies/sushi-config.yaml
@@ -1,0 +1,30 @@
+# ╭──────────────────────────────ImplementationGuide-sushi-test.json───────────────────────────────╮
+# │  The properties below are used to create the ImplementationGuide resource. For a list of       │
+# │  supported properties, see:                                                                    │
+# │  http://build.fhir.org/ig/HL7/fhir-shorthand/branches/beta/sushi.html#ig-development           │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+id: sushi-test
+canonical: http://hl7.org/fhir/sushi-test
+version: 0.1.0
+name: FSHTestIG
+title: FSH Test IG
+status: active
+copyrightYear: 2020
+releaseLabel: CI Build
+publisher: James Tuna
+contact:
+  - name: Bill Cod
+    telecom:
+      - system: url
+        value: https://capecodfishermen.org/
+      - system: email
+        value: cod@reef.gov
+description: Provides a simple example of how FSH can be used to create an IG
+license: CC0-1.0
+fhirVersion: 4.0.1
+dependencies:
+  hl7.fhir.us.core: 3.1.0
+  hl7.fhir.uv.vhdir: current
+  hl7.fhir.uv.genomics-reporting: 2.0.0
+  hl7.fhir.us.mcode: 2.0.1
+  hl7.fhir.us.davinci-pas: dev


### PR DESCRIPTION
Completes task [CIMPL-995](https://standardhealthrecord.atlassian.net/browse/CIMPL-995).

When this option is provided, SUSHI will attempt to update the dependencies listed in the FSH project's configuration file. Dependencies listed with a version of "current" or "dev" will not be modified. The user is prompted before any updates are made and is shown a list of all of the updates that will be applied. If the configuration was not imported from a sushi-config file, this option does nothing.

If the user provides this flag and applies updates, the project's sushi-config file will be rewritten with the updated version information. This may also result in some formatting changes to the configuration file, but all other file contents (including comments) will be preserved.