### PR TITLE
Escape Characters in menu.xml

### DIFF
--- a/test/ig/fixtures/menuXMLContent.ts
+++ b/test/ig/fixtures/menuXMLContent.ts
@@ -76,3 +76,26 @@ export const subMenuWithWarningXMLContent = `
     </ul>
   </li>
 </ul>`;
+
+export const menuWithEscapedCharacters = `
+<ul xmlns="http://www.w3.org/1999/xhtml" class="nav navbar-nav">
+  <li>
+    <a href="animals.html">Animals &lt;3</a>
+  </li>
+  <li class="dropdown">
+    <a data-toggle="dropdown" href="#" class="dropdown-toggle">Plants &gt;:)
+      <b class="caret"></b>
+    </a>
+    <ul class="dropdown-menu">
+      <li>
+        <a href="trees.html">Trees and &quot;Leaves&quot;</a>
+      </li>
+      <li>
+        <a href="buds.html">Flowers&apos; Blossoms</a>
+      </li>
+      <li>
+        <a target="_blank" href="prickly.com">Cacti &amp; Succulents</a>
+      </li>
+    </ul>
+  </li>
+</ul>`;


### PR DESCRIPTION
This PR supports encoding the five characters that need to escaped in XML. To do this, because there are only five and they are defined in XML, I just encoded each character when it is in any menu item in a `menu.xml` that we generated from the `sushi-config.yaml`. This also checks to make sure we don't double encode any character if the user has already encoded it. For example, if the user has written `Profile &amp; Extensions`, we want to just leave that `&` character and not try to re-encoded it.

Also, based on the suggestion on the issue, if SUSHI detects that there are any escaped characters provided by the user in the configuration, SUSHI will output a warning letting them know we will handle that now and they can replace their character with the un-encoded version, which will be easier to read in the config file.

To test this, you can include both encoded and unencoded characters in a menu.xml file, run SUSHI and check that it properly encodes characters that need to be encoded and warns about characters that are already encoded.

You can also run the IG Publisher to see how the menu works. If you run `master` or the current SUSHI release with a configuration that includes a character that needs to be escaped, the menu will not render correctly in the IG. If you run this branch with the same configuration, you should see that the menu generated by the IG Publisher renders and works as expected. I tested the IG Publisher with menu items with each of the characters that need to be encoded in XML, and it actually works fine with `<`, `>`, `"`, and `'` and only breaks when an `&` is used in the name. However, the IG Publisher correctly handles when they all are escaped as well and two places I read online said it's safer to just always escape all five characters, so that's what I went with.

This PR fixes #1097.