### PR TITLE
Warn on empty strings

### DIFF
--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -22,6 +22,14 @@ export class CodeSystemExporter {
   private setMetadata(codeSystem: CodeSystem, fshDefinition: FshCodeSystem): void {
     codeSystem.setName(fshDefinition);
     codeSystem.setId(fshDefinition);
+    if (fshDefinition.title == '') {
+      logger.warn(`Code system ${fshDefinition.name} has a title field that should not be empty.`);
+    }
+    if (fshDefinition.description == '') {
+      logger.warn(
+        `Code system ${fshDefinition.name} has a description field that should not be empty.`
+      );
+    }
     if (fshDefinition.title) codeSystem.title = fshDefinition.title;
     if (fshDefinition.description) codeSystem.description = fshDefinition.description;
     // Version is set to value provided in config, will be overriden if reset by rules

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -476,6 +476,14 @@ export class InstanceExporter implements Fishable {
     const instanceOfStructureDefinition = StructureDefinition.fromJSON(json);
     let instanceDef = new InstanceDefinition();
     instanceDef._instanceMeta.name = fshDefinition.id; // This is name of the instance in the FSH
+    if (fshDefinition.title == '') {
+      logger.warn(`Instance ${fshDefinition.name} has a title field that should not be empty.`);
+    }
+    if (fshDefinition.description == '') {
+      logger.warn(
+        `Instance ${fshDefinition.name} has a description field that should not be empty.`
+      );
+    }
     if (fshDefinition.title) {
       instanceDef._instanceMeta.title = fshDefinition.title;
     }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -300,13 +300,15 @@ export class StructureDefinitionExporter implements Fishable {
     structDef.version = this.tank.config.version; // can be overridden using a rule
     structDef.setName(fshDefinition);
     if (fshDefinition.title == '') {
+      if (fshDefinition instanceof Profile) {
+      }
       logger.warn(
-        `Structure definition ${fshDefinition.name} has a title field that should not be empty.`
+        `${fshDefinition.constructorName} ${fshDefinition.name} has a title field that should not be empty.`
       );
     }
     if (fshDefinition.description == '') {
       logger.warn(
-        `Structure definition ${fshDefinition.name} has a description field that should not be empty.`
+        `${fshDefinition.constructorName} ${fshDefinition.name} has a description field that should not be empty.`
       );
     }
     if (fshDefinition.title) {

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -299,6 +299,16 @@ export class StructureDefinitionExporter implements Fishable {
     delete structDef.identifier;
     structDef.version = this.tank.config.version; // can be overridden using a rule
     structDef.setName(fshDefinition);
+    if (fshDefinition.title == '') {
+      logger.warn(
+        `Structure definition ${fshDefinition.name} has a title field that should not be empty.`
+      );
+    }
+    if (fshDefinition.description == '') {
+      logger.warn(
+        `Structure definition ${fshDefinition.name} has a description field that should not be empty.`
+      );
+    }
     if (fshDefinition.title) {
       structDef.title = fshDefinition.title;
       if (

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -26,6 +26,14 @@ export class ValueSetExporter {
   private setMetadata(valueSet: ValueSet, fshDefinition: FshValueSet): void {
     valueSet.setName(fshDefinition);
     valueSet.setId(fshDefinition);
+    if (fshDefinition.title == '') {
+      logger.warn(`Value set ${fshDefinition.name} has a title field that should not be empty.`);
+    }
+    if (fshDefinition.description == '') {
+      logger.warn(
+        `Value set ${fshDefinition.name} has a description field that should not be empty.`
+      );
+    }
     if (fshDefinition.title) {
       valueSet.title = fshDefinition.title;
     }

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -214,6 +214,23 @@ describe('CodeSystemExporter', () => {
     });
   });
 
+  it('should warn when title and/or description is an empty string', () => {
+    const codeSystem = new FshCodeSystem('MyCodeSystem');
+    codeSystem.title = '';
+    codeSystem.description = '';
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export().codeSystems;
+    expect(exported.length).toBe(1);
+
+    expect(loggerSpy.getAllMessages('warn').length).toBe(2);
+    expect(loggerSpy.getFirstMessage('warn')).toMatch(
+      'Code system MyCodeSystem has a title field that should not be empty.'
+    );
+    expect(loggerSpy.getLastMessage('warn')).toMatch(
+      'Code system MyCodeSystem has a description field that should not be empty.'
+    );
+  });
+
   it('should log a message when the code system has an invalid id', () => {
     const codeSystem = new FshCodeSystem('StrangeSystem')
       .withFile('Strange.fsh')

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -109,6 +109,25 @@ describe('InstanceExporter', () => {
     expect(loggerSpy.getLastMessage('error')).toMatch(/File: Incorrect\.fsh.*Line: 15 - 18\D*/s);
   });
 
+  it('should warn when title and/or description is an empty string', () => {
+    const instance = new Instance('MyInstance');
+    instance.instanceOf = 'Patient';
+    instance.title = '';
+    instance.description = '';
+    doc.instances.set(instance.name, instance);
+    const exported = exporter.export().instances;
+
+    expect(exported.length).toBe(1);
+
+    expect(loggerSpy.getAllMessages('warn').length).toBe(2);
+    expect(loggerSpy.getFirstMessage('warn')).toMatch(
+      'Instance MyInstance has a title field that should not be empty.'
+    );
+    expect(loggerSpy.getLastMessage('warn')).toMatch(
+      'Instance MyInstance has a description field that should not be empty.'
+    );
+  });
+
   it('should export instances with InstanceOf FSHy profile', () => {
     const profileFoo = new Profile('Foo');
     profileFoo.parent = 'Patient';

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -82,7 +82,7 @@ describe('StructureDefinitionExporter R4', () => {
       expect(pkg.extensions.length).toBe(1);
     });
 
-    it('should warn when the structDef is a profile title and/or description is an empty string', () => {
+    it('should warn when the structDef is a profile and title and/or description is an empty string', () => {
       const profile = new Profile('Foo');
       profile.parent = 'Patient';
       profile.title = '';

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -147,7 +147,7 @@ describe('StructureDefinitionExporter R4', () => {
       doc.resources.set(resource.name, resource);
       exporter.exportStructDef(resource);
 
-      //expect(loggerSpy.getAllMessages('warn').length).toBe(2);
+      expect(loggerSpy.getAllMessages('warn').length).toBe(2);
       expect(loggerSpy.getFirstMessage('warn')).toMatch(
         'Resource SpidermanBarFromHome has a title field that should not be empty.'
       );

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -82,6 +82,24 @@ describe('StructureDefinitionExporter R4', () => {
       expect(pkg.extensions.length).toBe(1);
     });
 
+    it('should warn when title and/or description is an empty string', () => {
+      const profile = new Profile('Foo');
+      profile.parent = 'Patient';
+      profile.title = '';
+      profile.description = '';
+      doc.profiles.set(profile.name, profile);
+      const exported = exporter.export();
+      expect(exported.profiles.length).toBe(1);
+
+      expect(loggerSpy.getAllMessages('warn').length).toBe(2);
+      expect(loggerSpy.getFirstMessage('warn')).toMatch(
+        'Structure definition Foo has a title field that should not be empty.'
+      );
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        'Structure definition Foo has a description field that should not be empty.'
+      );
+    });
+
     it('should log a message when the structure definition has an invalid id', () => {
       const profile = new Profile('Wrong').withFile('Wrong.fsh').withLocation([1, 8, 4, 18]);
       profile.id = 'will?not?work';

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -82,7 +82,7 @@ describe('StructureDefinitionExporter R4', () => {
       expect(pkg.extensions.length).toBe(1);
     });
 
-    it('should warn when title and/or description is an empty string', () => {
+    it('should warn when the structDef is a profile title and/or description is an empty string', () => {
       const profile = new Profile('Foo');
       profile.parent = 'Patient';
       profile.title = '';
@@ -93,10 +93,66 @@ describe('StructureDefinitionExporter R4', () => {
 
       expect(loggerSpy.getAllMessages('warn').length).toBe(2);
       expect(loggerSpy.getFirstMessage('warn')).toMatch(
-        'Structure definition Foo has a title field that should not be empty.'
+        'Profile Foo has a title field that should not be empty.'
       );
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        'Structure definition Foo has a description field that should not be empty.'
+        'Profile Foo has a description field that should not be empty.'
+      );
+    });
+
+    it('should warn when the structDef is an extension and title and/or description is an empty string', () => {
+      const extension = new Extension('Bar');
+      extension.parent = 'Extension';
+      extension.title = '';
+      extension.description = '';
+      doc.extensions.set(extension.name, extension);
+      const exported = exporter.export();
+
+      expect(exported.extensions.length).toBe(1);
+
+      expect(loggerSpy.getAllMessages('warn').length).toBe(2);
+      expect(loggerSpy.getFirstMessage('warn')).toMatch(
+        'Extension Bar has a title field that should not be empty.'
+      );
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        'Extension Bar has a description field that should not be empty.'
+      );
+    });
+
+    it('should warn when the structDef is a logical and title and/or description is an empty string', () => {
+      const logical = new Logical('BackFooTheFuture');
+      logical.parent = 'Element';
+      logical.title = '';
+      logical.description = '';
+      doc.logicals.set(logical.name, logical);
+      const exported = exporter.export();
+
+      expect(exported.logicals.length).toBe(1);
+
+      expect(loggerSpy.getAllMessages('warn').length).toBe(2);
+      expect(loggerSpy.getFirstMessage('warn')).toMatch(
+        'Logical BackFooTheFuture has a title field that should not be empty.'
+      );
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        'Logical BackFooTheFuture has a description field that should not be empty.'
+      );
+    });
+
+    it('should warn when the structDef is a resource and title and/or description is an empty string', () => {
+      const resource = new Resource('SpidermanBarFromHome');
+      resource.parent = 'Resource';
+      resource.id = 'PatientResource';
+      resource.title = '';
+      resource.description = '';
+      doc.resources.set(resource.name, resource);
+      exporter.exportStructDef(resource);
+
+      //expect(loggerSpy.getAllMessages('warn').length).toBe(2);
+      expect(loggerSpy.getFirstMessage('warn')).toMatch(
+        'Resource SpidermanBarFromHome has a title field that should not be empty.'
+      );
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        'Resource SpidermanBarFromHome has a description field that should not be empty.'
       );
     });
 

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -91,6 +91,23 @@ describe('ValueSetExporter', () => {
     });
   });
 
+  it('should warn when title and/or description is an empty string', () => {
+    const valueSet = new FshValueSet('BreakfastVS');
+    valueSet.title = '';
+    valueSet.description = '';
+    doc.valueSets.set(valueSet.name, valueSet);
+    const exported = exporter.export().valueSets;
+    expect(exported.length).toBe(1);
+
+    expect(loggerSpy.getAllMessages('warn').length).toBe(2);
+    expect(loggerSpy.getFirstMessage('warn')).toMatch(
+      'Value set BreakfastVS has a title field that should not be empty.'
+    );
+    expect(loggerSpy.getLastMessage('warn')).toMatch(
+      'Value set BreakfastVS has a description field that should not be empty.'
+    );
+  });
+
   it('should log a message when the value set has an invalid id', () => {
     const valueSet = new FshValueSet('BreakfastVS')
       .withFile('Breakfast.fsh')


### PR DESCRIPTION
Fixes #1087 

Adds warnings whenever the user makes their Title or Description an empty string within their Instance, Code System, Structure Definition, or Value Set. 

Testers would most likely want to test situations where Title or Description within these types exist but are empty strings. 

Thanks for reviewing!