### PR TITLE
Updated Command Structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @jafeltra @cmoesel @julianxcarter @mint-thompson @guhanthuran
+*   @jafeltra @cmoesel @mint-thompson @guhanthuran

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install -g fsh-sushi
 
 After installation, the `sushi` commandline will be available on your path:
 
-```
+```text
 $ sushi help
 
 Usage: sushi [options] [command]
@@ -39,7 +39,7 @@ Commands:
 
 To build a SUSHI project, use the `build` command:
 
-```
+```text
 $ sushi build --help
 
 Usage: sushi build [options] [path-to-fsh-project]
@@ -47,11 +47,11 @@ Usage: sushi build [options] [path-to-fsh-project]
 build a SUSHI project
 
 Options:
-  -o, --out <out>       the path to the output folder
   -d, --debug           output extra debugging information
+  -o, --out <out>       the path to the output folder
   -p, --preprocessed    output FSH produced by preprocessing steps
-  -s, --snapshot        generate snapshot in Structure Definition output (default: false)
   -r, --require-latest  exit with error if this is not the latest version of SUSHI (default: false)
+  -s, --snapshot        generate snapshot in Structure Definition output (default: false)
   -h, --help            display help for command
 
 Additional information:

--- a/README.md
+++ b/README.md
@@ -21,27 +21,44 @@ $ npm install -g fsh-sushi
 
 After installation, the `sushi` commandline will be available on your path:
 
-```sh
-$ sushi --help
-Usage: sushi [path-to-fsh-project] [options]
+```
+$ sushi help
+
+Usage: sushi [options] [command]
 
 Options:
-  -o, --out <out>            the path to the output folder
-  -d, --debug                output extra debugging information
-  -p, --preprocessed         output FSH produced by preprocessing steps
-  -s, --snapshot             generate snapshot in Structure Definition output (default: false)
-  -r, --require-latest       exit with error if this is not the latest version of SUSHI (default: false)
-  -i, --init                 initialize a SUSHI project
-  -u, --update-dependencies  update FHIR packages in project configuration
-  -v, --version              print SUSHI version
-  -h, --help                 display help for command
+  -v, --version                              print SUSHI version
+  -h, --help                                 display help for command
+
+Commands:
+  build [options] [path-to-fsh-project]      build a SUSHI project
+  init                                       initialize a SUSHI project
+  update-dependencies [path-to-fsh-project]  update FHIR packages in project configuration
+  help [command]                             display help for command
+```
+
+To build a SUSHI project, use the `build` command:
+
+```
+$ sushi build --help
+
+Usage: sushi build [options] [path-to-fsh-project]
+
+build a SUSHI project
+
+Options:
+  -o, --out <out>       the path to the output folder
+  -d, --debug           output extra debugging information
+  -p, --preprocessed    output FSH produced by preprocessing steps
+  -s, --snapshot        generate snapshot in Structure Definition output (default: false)
+  -r, --require-latest  exit with error if this is not the latest version of SUSHI (default: false)
+  -h, --help            display help for command
 
 Additional information:
   [path-to-fsh-project]
     Default: "."
   -o, --out <out>
     Default: "fsh-generated"
-
 ```
 
 See the [SUSHI documentation](https://fshschool.org/docs/sushi/) for detailed information on using SUSHI.

--- a/src/app.ts
+++ b/src/app.ts
@@ -59,15 +59,15 @@ async function app() {
     .command('build', { isDefault: true })
     .description('build a SUSHI project')
     .argument('[path-to-fsh-project]')
-    .option('-o, --out <out>', 'the path to the output folder')
     .option('-d, --debug', 'output extra debugging information')
+    .option('-o, --out <out>', 'the path to the output folder')
     .option('-p, --preprocessed', 'output FSH produced by preprocessing steps')
-    .option('-s, --snapshot', 'generate snapshot in Structure Definition output', false)
     .option(
       '-r, --require-latest',
       'exit with error if this is not the latest version of SUSHI',
       false
     )
+    .option('-s, --snapshot', 'generate snapshot in Structure Definition output', false)
     .action(async function (projectPath, options) {
       await runBuild(projectPath, options);
     })

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,7 +58,7 @@ async function app() {
 
   program
     .command('build')
-    .description('export a FSH project into a FHIR IG')
+    .description('build a SUSHI project')
     .argument('[path-to-fsh-project]')
     .option('-o, --out <out>', 'the path to the output folder')
     .option('-d, --debug', 'output extra debugging information')

--- a/src/app.ts
+++ b/src/app.ts
@@ -115,7 +115,7 @@ async function app() {
       console.log(
         'The --init option has been moved to a separate command. Instead, run the following command: sushi init'
       );
-      process.exit(0);
+      process.exit(1);
     } else if (process.argv.length === 2 || process.argv.slice(2).some(a => fs.existsSync(a))) {
       // If the old command structure was used, treat it as the build command
       // This includes support for things like `sushi` (no file path), `sushi [path-to-fsh-project]`,

--- a/src/app.ts
+++ b/src/app.ts
@@ -82,6 +82,14 @@ async function app() {
     });
 
   program
+    .command('init')
+    .description('initialize a SUSHI project')
+    .action(async function () {
+      await init();
+      process.exit(0);
+    });
+
+  program
     .command('update-dependencies')
     .description('update FHIR packages in project configuration')
     .argument('[path-to-fsh-project]')
@@ -96,14 +104,6 @@ async function app() {
       console.log('Additional information:');
       console.log('  [path-to-fsh-project]');
       console.log('    Default: "."');
-    });
-
-  program
-    .command('init')
-    .description('initialize a SUSHI project')
-    .action(async function () {
-      await init();
-      process.exit(0);
     });
 
   // Maintain backwards compatibility with prior SUSHI command structure

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,7 +43,7 @@ import {
 } from './utils';
 
 const FSH_VERSION = '2.0.0';
-const SUPPORTED_COMMANDS = ['build', 'updateDependencies', 'init', '-h', '--help', 'help'];
+const SUPPORTED_COMMANDS = ['build', 'update-dependencies', 'init', '-h', '--help', 'help'];
 
 app().catch(e => {
   logger.error(`SUSHI encountered the following unexpected error: ${e.message}`);
@@ -82,8 +82,9 @@ async function app() {
     });
 
   program
-    .command('updateDependencies [path-to-fsh-project]')
+    .command('update-dependencies')
     .description('update FHIR packages in project configuration')
+    .argument('[path-to-fsh-project]')
     .action(async function (projectPath) {
       const input = ensureInputDir(projectPath);
       const config: Configuration = readConfig(input);
@@ -202,13 +203,6 @@ async function runBuild(input: string, program: OptionValues) {
 
   let tank: FSHTank;
   let config: Configuration;
-
-  // Update dependencies
-  if (program.updateDependencies) {
-    config = readConfig(originalInput);
-    await updateExternalDependencies(config);
-    process.exit(0);
-  }
 
   try {
     let rawFSH: RawFSH[];

--- a/src/app.ts
+++ b/src/app.ts
@@ -129,16 +129,12 @@ async function runUpdateDependencies(projectPath: string) {
 }
 
 async function runBuild(input: string, program: OptionValues, helpText: string) {
-  // NOTE: This is included to provide nicer handling for the previous CLI structure for building FSH projects
-  // Before doing anything else, we do our best to decide if the legacy SUSHI command structure was used
-  // (i.e. sushi . or sushi -d . or sushi -d or sushi)
-  const isLegacyBuildCommand =
-    !process.argv.includes('build') &&
-    (process.argv.slice(2).some(a => fs.existsSync(a)) ||
-      process.argv.slice(2).every(a => a.startsWith('-')));
-  if (!isLegacyBuildCommand) {
-    // This was probably an error (maybe a typo of a real command),
-    // not someone trying to use the old syntax, so exit
+  // NOTE: This is included to provide nicer handling for the previous CLI structure for building FSH projects.
+  // Check the first argument passed into sushi. If it is not "build", then this is a legacy build,
+  // in which case we should make sure that the first argument is a flag or a valid path.
+  const arg = process.argv[2];
+  if (arg != null && arg !== 'build' && !arg.startsWith('-') && !fs.existsSync(arg)) {
+    // It's not a flag or a path, so it's probably a typo of an existing command
     console.log(helpText);
     process.exit(1);
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,7 +43,7 @@ import {
 } from './utils';
 
 const FSH_VERSION = '2.0.0';
-const SUPPORTED_COMMANDS = ['build', 'updateDependencies', 'init', '--help'];
+const SUPPORTED_COMMANDS = ['build', 'updateDependencies', 'init', '-h', '--help'];
 
 app().catch(e => {
   logger.error(`SUSHI encountered the following unexpected error: ${e.message}`);
@@ -105,11 +105,7 @@ async function app() {
     });
 
   // Maintain backwards compatability with prior SUSHI command structure by defaulting to build
-  if (
-    process.argv.length >= 2 &&
-    !SUPPORTED_COMMANDS.includes(process.argv[2]) &&
-    fs.existsSync(process.argv[2])
-  ) {
+  if (process.argv.length >= 2 && !SUPPORTED_COMMANDS.includes(process.argv[2])) {
     process.argv = [...process.argv.slice(0, 2), 'build', ...process.argv.slice(2)];
   }
   program.showHelpAfterError().parse(process.argv).opts();

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,6 +48,7 @@ function logUnexpectedError(e: Error) {
   logger.error(`SUSHI encountered the following unexpected error: ${e.message}`);
   process.exit(1);
 }
+
 app().catch(logUnexpectedError);
 
 async function app() {


### PR DESCRIPTION
Updates SUSHI's command structure to make use of commands rather than flags. SUSHI now takes the following commands:

1. `build` which builds an IG. This takes a path to a FSH Project as an argument and also supports the following flags (`-o, --out <out>`, `-d, --debug`, `-p, --preprocessed`, `-s, --snapshot`, `-r, --require-latest`). Similar to before, `sushi build` can be run with either `.` as an input directory or with no input directory specified at all, in which case the input is assumed to be the current working directory. 
2. `updateDependencies` which updates FHIR dependencies in a user's configuration file. This takes a path to a FSH Project as an argument and also has the same default behavior for the path argument (`.` and no path argument both default to current working directory.
3. `init` which goes through our initialize project workflow. This takes no arguments.

All three commands also support the `-h`/`--help` flag independently, meaning you can run `sushi build -h` for instance and get the options that are specific to that command. 

SUSHI is still backwards compatible with our old command structure and can still be run the same way as before (e.g. with `sushi .`). This is done by inserting `build` into the arguments array when we detect that the third element is a file path. I think it's possible to add the options and a separate action to the `Command` object and handle it that way, but I didn't want to do that because then users would see those options when running `sushi --help`. Basically I thought that backwards compatibility was a goal, but continuing to highlight usage of the Old Ways™ was not what we wanted to do.