### PR TITLE
Update the IG parameters link

### DIFF
--- a/src/fshtypes/Configuration.ts
+++ b/src/fshtypes/Configuration.ts
@@ -101,8 +101,9 @@ export type Configuration = {
   // will be inferred from the file name extension.
   pages?: ImplementationGuideDefinitionPage[];
 
-  // The parameters property represents IG.definition.parameter. For a partial list of allowed
-  // parameters see: https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+  // The parameters property represents IG.definition.parameter. For parameters defined by core FHIR
+  // see: http://build.fhir.org/codesystem-guide-parameter-code.html. For parameters defined by the FHIR
+  // Tools IG see: http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
   parameters?: ImplementationGuideDefinitionParameter[];
 
   // The templates property corresponds 1:1 with IG.definition.template. Note that plural templates

--- a/src/import/YAMLConfiguration.ts
+++ b/src/import/YAMLConfiguration.ts
@@ -133,8 +133,9 @@ export type YAMLConfiguration = {
 
   // The parameters property represents IG.definition.parameter. Rather than a list of code/value
   // pairs (as in the ImplementationGuide resource), the code is the YAML key. If a parameter allows
-  // repeating values, the value in the YAML should be a sequence/array. For a partial list of
-  // allowed parameters see: https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+  // repeating values, the value in the YAML should be a sequence/array. For parameters defined by core FHIR
+  // see: http://build.fhir.org/codesystem-guide-parameter-code.html. For parameters defined by the FHIR
+  // Tools IG see: http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
   parameters?: YAMLConfigurationParameterMap;
 
   // The templates property corresponds 1:1 with IG.definition.template. The templates value can be

--- a/src/utils/init-project/sushi-config.yaml
+++ b/src/utils/init-project/sushi-config.yaml
@@ -56,9 +56,11 @@ publisher:
 # The parameters property represents IG.definition.parameter. Rather
 # than a list of code/value pairs (as in the ImplementationGuide
 # resource), the code is the YAML key. If a parameter allows repeating
-# values, the value in the YAML should be a sequence/array. For a
-# partial list of allowed parameters see:
-# https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+# values, the value in the YAML should be a sequence/array.
+# For parameters defined by core FHIR see:
+# http://build.fhir.org/codesystem-guide-parameter-code.html
+# For parameters defined by the FHIR Tools IG see:
+# http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
 #
 # parameters:
 #   excludettl: true

--- a/test/import/fixtures/example-config.yaml
+++ b/test/import/fixtures/example-config.yaml
@@ -191,9 +191,11 @@ menu:
 # The parameters property represents IG.definition.parameter. Rather
 # than a list of code/value pairs (as in the ImplementationGuide
 # resource), the code is the YAML key. If a parameter allows repeating
-# values, the value in the YAML should be a sequence/array. For a
-# partial list of allowed parameters see:
-# https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+# values, the value in the YAML should be a sequence/array.
+# For parameters defined by core FHIR see:
+# http://build.fhir.org/codesystem-guide-parameter-code.html
+# For parameters defined by the FHIR Tools IG see:
+# http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
 parameters:
   excludettl: true
   validation: [allow-any-extensions, no-broken-links]

--- a/test/utils/fixtures/init-config/default-config.yaml
+++ b/test/utils/fixtures/init-config/default-config.yaml
@@ -56,7 +56,7 @@ publisher:
 # The parameters property represents IG.definition.parameter. Rather
 # than a list of code/value pairs (as in the ImplementationGuide
 # resource), the code is the YAML key. If a parameter allows repeating
-# values, the value in the YAML should be a sequence/array. 
+# values, the value in the YAML should be a sequence/array.
 # For parameters defined by core FHIR see:
 # http://build.fhir.org/codesystem-guide-parameter-code.html
 # For parameters defined by the FHIR Tools IG see:

--- a/test/utils/fixtures/init-config/default-config.yaml
+++ b/test/utils/fixtures/init-config/default-config.yaml
@@ -56,9 +56,11 @@ publisher:
 # The parameters property represents IG.definition.parameter. Rather
 # than a list of code/value pairs (as in the ImplementationGuide
 # resource), the code is the YAML key. If a parameter allows repeating
-# values, the value in the YAML should be a sequence/array. For a
-# partial list of allowed parameters see:
-# https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+# values, the value in the YAML should be a sequence/array. 
+# For parameters defined by core FHIR see:
+# http://build.fhir.org/codesystem-guide-parameter-code.html
+# For parameters defined by the FHIR Tools IG see:
+# http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
 #
 # parameters:
 #   excludettl: true

--- a/test/utils/fixtures/init-config/user-input-config.yaml
+++ b/test/utils/fixtures/init-config/user-input-config.yaml
@@ -56,9 +56,11 @@ publisher:
 # The parameters property represents IG.definition.parameter. Rather
 # than a list of code/value pairs (as in the ImplementationGuide
 # resource), the code is the YAML key. If a parameter allows repeating
-# values, the value in the YAML should be a sequence/array. For a
-# partial list of allowed parameters see:
-# https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+# values, the value in the YAML should be a sequence/array.
+# For parameters defined by core FHIR see:
+# http://build.fhir.org/codesystem-guide-parameter-code.html
+# For parameters defined by the FHIR Tools IG see:
+# http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
 #
 # parameters:
 #   excludettl: true


### PR DESCRIPTION
The link https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters now redirects to http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html.