### PR TITLE
Support fishing for profiles with a version

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -2278,13 +2278,25 @@ export class ElementDefinition {
       if (newElements.length === 0) {
         // If we have exactly one profile to use, use that, otherwise use the code
         const type = profileToUse ?? this.type[0].code;
-        const json = fisher.fishForFHIR(
-          type,
+        // There could possibly be a |version appended to the type, so don't include it while fishing
+        const typeWithoutVersion = type.split('|', 2)[0];
+        let json = fisher.fishForFHIR(
+          typeWithoutVersion,
           Type.Resource,
           Type.Type,
           Type.Profile,
           Type.Extension
         );
+        if (!json && profileToUse) {
+          // If we tried to fish based on a profile and didn't find anything, fall back to the type
+          json = fisher.fishForFHIR(
+            this.type[0].code,
+            Type.Resource,
+            Type.Type,
+            Type.Profile,
+            Type.Extension
+          );
+        }
         if (json) {
           const def = StructureDefinition.fromJSON(json);
           if (def.inProgress) {

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -733,6 +733,32 @@ describe('ElementDefinition', () => {
       );
       expect(fooSliceExtensionTest.calculateDiff().type).toEqual(extensionSlice.type);
     });
+
+    it('should unfold an element with a profile that includes a version', () => {
+      const referenceRange = observation.elements.find(
+        e => e.id === 'Observation.referenceRange.low'
+      ) as ElementDefinition; // The element will exist based on the test fixtures
+
+      // Set type with a profile that has a version number
+      referenceRange.type[0].profile = [
+        'http://hl7.org/fhir/StructureDefinition/SimpleQuantity|1.0.0'
+      ];
+
+      const newElements = referenceRange.unfold(fisher);
+      expect(newElements).toHaveLength(7); // It should unfold elements on referenceRange.low
+    });
+
+    it('should fall back to the type if a profile cannot be fished while unfolding', () => {
+      const referenceRange = observation.elements.find(
+        e => e.id === 'Observation.referenceRange.low'
+      ) as ElementDefinition; // The element will exist based on the test fixtures
+
+      // Set type with a profile that doesn't exist in our test definitions
+      referenceRange.type[0].profile = ['http://hl7.org/fhir/StructureDefinition/FakeQuantity'];
+
+      const newElements = referenceRange.unfold(fisher);
+      expect(newElements).toHaveLength(7); // It should unfold elements on referenceRange.low
+    });
   });
 
   describe('#clone', () => {


### PR DESCRIPTION
Fixes #1156.

This PR updates how we unfold elements when we are trying to unfold based on a profile. If an element has a `type` with one `profile` defined, we try to fish for the profile when unfolding. However, if that profile's URL includes a `|version` at the end, we would not successfully fish for the profile. For example, the original bug was trying to find a profile like this:

```json
{
  "id": "Patient.identifier:reisepassnummer",
  ... some stuff that doesn't really matter here ...
  "type": [
    {
      "code": "Identifier",
      "profile": [
        "https://fhir.kbv.de/StructureDefinition/KBV_PR_Base_Identifier_Reisepassnummer|1.3.0"
      ]
    }
  ]
}
```

This PR supports ignoring that `version` (`1.3.0`) when fishing for the profile, which is similar to what we do in other places when canonicals have version.

This PR also supports falling back to the `type.code` if the profile cannot be found, even after removing the version.

The tests demonstrate these two cases as well.