### PR TITLE
Include default type slicing in differential

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -426,22 +426,7 @@ export class StructureDefinition {
       // we need to make sure the root element is included in the differential.
       if (e.hasDiff() || (this.derivation === 'specialization' && idx === 0)) {
         const diff = e.calculateDiff().toJSON();
-        const isTypeSlicingChoiceDiff =
-          diff.id.endsWith('[x]') &&
-          Object.keys(diff).length === 3 &&
-          diff.id &&
-          diff.path &&
-          diff.slicing?.discriminator?.length === 1 &&
-          diff.slicing.discriminator[0].type === 'type' &&
-          diff.slicing.discriminator[0].path === '$this' &&
-          diff.slicing.rules === 'open' &&
-          (diff.slicing.ordered == null || diff.slicing.ordered === false);
-
-        // choice[x] elements that differ only by the standard type slicing definition don't need to go in the
-        // differential, as they are inferred. See: https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/
-        if (!isTypeSlicingChoiceDiff) {
-          j.differential.element.push(diff);
-        }
+        j.differential.element.push(diff);
       }
     });
 

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -303,19 +303,27 @@ describe('StructureDefinition', () => {
       expect(valueStringSnapshot.sliceName).toEqual('valueString');
       expect(valueStringSnapshot.short).toBe('the string choice');
       // then check the differential
-      expect(json.differential.element).toHaveLength(2);
-      const valueQuantityDiff = json.differential.element[0];
+      expect(json.differential.element).toHaveLength(3);
+      const valueXDiff = json.differential.element[0];
+      expect(valueXDiff.id).toBe('Observation.value[x]');
+      expect(valueXDiff.path).toBe('Observation.value[x]');
+      expect(valueXDiff.slicing).toEqual({
+        discriminator: [{ type: 'type', path: '$this' }],
+        ordered: false,
+        rules: 'open'
+      });
+      const valueQuantityDiff = json.differential.element[1];
       expect(valueQuantityDiff.id).toBe('Observation.value[x]:valueQuantity');
       expect(valueQuantityDiff.path).toBe('Observation.value[x]');
       expect(valueQuantityDiff.type).toEqual([{ code: 'Quantity' }]);
       expect(valueQuantityDiff.sliceName).toBe('valueQuantity');
-      expect(valueQuantitySnapshot.short).toBe('the quantity choice');
-      const valueStringDiff = json.differential.element[1];
+      expect(valueQuantityDiff.short).toBe('the quantity choice');
+      const valueStringDiff = json.differential.element[2];
       expect(valueStringDiff.id).toBe('Observation.value[x]:valueString');
       expect(valueStringDiff.path).toBe('Observation.value[x]');
       expect(valueStringDiff.type).toEqual([{ code: 'string' }]);
       expect(valueStringDiff.sliceName).toBe('valueString');
-      expect(valueStringSnapshot.short).toBe('the string choice');
+      expect(valueStringDiff.short).toBe('the string choice');
     });
 
     it('should properly serialize snapshot and differential for choice type with non-type constraint and with constraints on specific choices', () => {


### PR DESCRIPTION
Fixes #1160 and completes task [CIMPL-1033](https://standardhealthrecord.atlassian.net/browse/CIMPL-1033).

If a choice element is sliced, include the slicing in the differential, even if the slicing is the default choice-type slicing and this is the only difference on the element.