### PR TITLE
Keep parent's fixedUri on Extension.url

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @jafeltra @cmoesel @julianxcarter @mint-thompson @guhanthuran
+*   @jafeltra @cmoesel @mint-thompson

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -362,9 +362,11 @@ export class StructureDefinitionExporter implements Fishable {
       // Keep context, assuming context is still valid for child extensions.
       // Keep contextInvariant, assuming context is still valid for child extensions.
 
-      // Automatically set url.fixedUri on Extensions
+      // Automatically set url.fixedUri on Extensions unless it is already set
       const url = structDef.findElement('Extension.url');
-      url.fixedUri = structDef.url;
+      if (url.fixedUri == null) {
+        url.fixedUri = structDef.url;
+      }
       if (structDef.context == null) {
         // Set context to everything by default, but users can override w/ rules, e.g.
         // ^context[0].type = #element

--- a/test/export/StructureDefinition.ExtensionExporter.test.ts
+++ b/test/export/StructureDefinition.ExtensionExporter.test.ts
@@ -87,7 +87,10 @@ describe('ExtensionExporter', () => {
     expect(exported.length).toBe(2);
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
-    expect(exported[1].baseDefinition === exported[0].url);
+    expect(exported[1].baseDefinition).toBe(exported[0].url);
+    const parentFixedUri = exported[0].findElement('Extension.url').fixedUri;
+    const childFixedUri = exported[1].findElement('Extension.url').fixedUri;
+    expect(parentFixedUri).toBe(childFixedUri);
   });
 
   it('should export extensions with the same FSHy parents', () => {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1160,8 +1160,9 @@ describe('StructureDefinitionExporter R4', () => {
       expect(exported.derivation).toBe('constraint'); // always constraint
 
       // Check that Extension.url is correctly assigned
+      // Since the parent fixed this value, it should be the same as the parent
       expect(exported.elements.find(e => e.id === 'Extension.url').fixedUri).toBe(
-        'http://hl7.org/fhir/us/minimal/StructureDefinition/Foo'
+        'http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName'
       );
     });
 


### PR DESCRIPTION
Fixes #1178 and completes task [CIMPL-1042](https://standardhealthrecord.atlassian.net/browse/CIMPL-1042).

When an Extension's parent is another Extension (as opposed to the base Extension type), the Extension.url element will have a fixedUri set on the parent. To be valid FHIR, the child Extension should keep that same fixedUri.