### PR TITLE
Automatically load hl7.fhir.uv.tools dependency

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -224,7 +224,7 @@ export function loadAutomaticDependencies(
       return Promise.resolve();
     } else {
       return loadDependency(dep.packageId, dep.version, defs).catch(e => {
-        let message = `Failed to load ${dep.packageId}#${dep.version}: ${e.message}`;
+        let message = `Failed to load automatically-provided ${dep.packageId}#${dep.version}: ${e.message}`;
         if (/certificate/.test(e.message)) {
           message += CERTIFICATE_MESSAGE;
         }

--- a/test/testhelpers/asserts.ts
+++ b/test/testhelpers/asserts.ts
@@ -22,6 +22,7 @@ import {
 } from '../../src/fshtypes/rules';
 import { FshCode, ValueSetFilter } from '../../src/fshtypes';
 import { splitOnPathPeriods } from '../../src/fhirtypes/common';
+import { AUTOMATIC_DEPENDENCIES } from '../../src/utils';
 
 export function assertCardRule(rule: Rule, path: string, min: number, max: number | string): void {
   expect(rule).toBeInstanceOf(CardRule);
@@ -287,4 +288,10 @@ export function assertConceptRule(
   if (hierarchy !== undefined) {
     expect(conceptRule.hierarchy).toEqual(hierarchy);
   }
+}
+
+export function assertAutomaticDependencies(packages: string[]) {
+  AUTOMATIC_DEPENDENCIES.forEach(dep => {
+    expect(packages).toContain(`${dep.packageId}#${dep.version}`);
+  });
 }

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -7,12 +7,14 @@ import { minimalConfig } from './minimalConfig';
 import { loggerSpy } from '../testhelpers/loggerSpy';
 import readlineSync from 'readline-sync';
 import {
+  AUTOMATIC_DEPENDENCIES,
   isSupportedFHIRVersion,
   ensureInputDir,
   findInputDir,
   ensureOutputDir,
   readConfig,
   loadExternalDependencies,
+  loadAutomaticDependencies,
   getRawFSHes,
   hasFshFiles,
   writeFHIRResources,
@@ -328,7 +330,11 @@ describe('Processing', () => {
         .mockImplementation(
           async (packageName: string, version: string, FHIRDefs: FHIRDefinitions) => {
             // the mock loader can find hl7.fhir.(r2|r3|r4|r5|us).core
-            if (/^hl7.fhir.(r2|r3|r4|r4b|r5|us).core$/.test(packageName)) {
+            // it can also find automatic dependencies
+            if (
+              /^hl7.fhir.(r2|r3|r4|r4b|r5|us).core$/.test(packageName) ||
+              AUTOMATIC_DEPENDENCIES.some(dep => dep.packageId === packageName)
+            ) {
               FHIRDefs.packages.push(`${packageName}#${version}`);
               return Promise.resolve(FHIRDefs);
             } else if (/^self-signed.package$/.test(packageName)) {
@@ -348,9 +354,10 @@ describe('Processing', () => {
       usCoreDependencyConfig.dependencies = [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, usCoreDependencyConfig).then(() => {
-        expect(defs.packages.length).toBe(2);
+        expect(defs.packages.length).toBe(3);
         expect(defs.packages).toContain('hl7.fhir.r4.core#4.0.1');
         expect(defs.packages).toContain('hl7.fhir.us.core#3.1.0');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       });
     });
@@ -360,7 +367,8 @@ describe('Processing', () => {
       config.fhirVersion = ['4.1.0'];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, config).then(() => {
-        expect(defs.packages).toEqual(['hl7.fhir.r4b.core#4.1.0']);
+        expect(defs.packages).toContain('hl7.fhir.r4b.core#4.1.0');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /support for pre-release versions of FHIR is experimental/s
         );
@@ -372,7 +380,8 @@ describe('Processing', () => {
       config.fhirVersion = ['4.3.0-snapshot1'];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, config).then(() => {
-        expect(defs.packages).toEqual(['hl7.fhir.r4b.core#4.3.0-snapshot1']);
+        expect(defs.packages).toContain('hl7.fhir.r4b.core#4.3.0-snapshot1');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /support for pre-release versions of FHIR is experimental/s
         );
@@ -384,7 +393,8 @@ describe('Processing', () => {
       config.fhirVersion = ['4.3.0'];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, config).then(() => {
-        expect(defs.packages).toEqual(['hl7.fhir.r4b.core#4.3.0']);
+        expect(defs.packages).toContain('hl7.fhir.r4b.core#4.3.0');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       });
     });
@@ -394,7 +404,8 @@ describe('Processing', () => {
       config.fhirVersion = ['4.5.0'];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, config).then(() => {
-        expect(defs.packages).toEqual(['hl7.fhir.r5.core#4.5.0']);
+        expect(defs.packages).toContain('hl7.fhir.r5.core#4.5.0');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /support for pre-release versions of FHIR is experimental/s
         );
@@ -406,7 +417,8 @@ describe('Processing', () => {
       config.fhirVersion = ['5.0.0-snapshot1'];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, config).then(() => {
-        expect(defs.packages).toEqual(['hl7.fhir.r5.core#5.0.0-snapshot1']);
+        expect(defs.packages).toContain('hl7.fhir.r5.core#5.0.0-snapshot1');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /support for pre-release versions of FHIR is experimental/s
         );
@@ -418,7 +430,8 @@ describe('Processing', () => {
       config.fhirVersion = ['5.0.0'];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, config).then(() => {
-        expect(defs.packages).toEqual(['hl7.fhir.r5.core#5.0.0']);
+        expect(defs.packages).toContain('hl7.fhir.r5.core#5.0.0');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       });
     });
@@ -428,7 +441,8 @@ describe('Processing', () => {
       config.fhirVersion = ['current'];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, config).then(() => {
-        expect(defs.packages).toEqual(['hl7.fhir.r5.core#current']);
+        expect(defs.packages).toContain('hl7.fhir.r5.core#current');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /support for pre-release versions of FHIR is experimental/s
         );
@@ -449,8 +463,9 @@ describe('Processing', () => {
         virtualExtensionsConfig.dependencies = [{ packageId: extId, version: fhirVersion }];
         const defs = new FHIRDefinitions();
         return loadExternalDependencies(defs, virtualExtensionsConfig).then(() => {
-          expect(defs.packages.length).toBe(1);
+          expect(defs.packages.length).toBe(2);
           expect(defs.packages).toContain(`${fhirId}#${fhirVersion}`);
+          expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
           expect(defs.supplementalFHIRPackages).toEqual([`${suppFhirId}#${suppFhirVersion}`]);
           expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
         });
@@ -495,8 +510,9 @@ describe('Processing', () => {
       ];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, virtualExtensionsConfig).then(() => {
-        expect(defs.packages.length).toBe(1);
+        expect(defs.packages.length).toBe(2);
         expect(defs.packages).toContain('hl7.fhir.r4.core#4.0.1');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(defs.supplementalFHIRPackages).toEqual(['hl7.fhir.r2.core#1.0.2']);
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /Incorrect package version: hl7\.fhir\.extensions\.r2#1\.0\.2\./
@@ -510,8 +526,9 @@ describe('Processing', () => {
       badDependencyConfig.dependencies = [{ packageId: 'hl7.does.not.exist', version: 'current' }];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, badDependencyConfig).then(() => {
-        expect(defs.packages.length).toBe(1);
+        expect(defs.packages.length).toBe(2);
         expect(defs.packages).toContain('hl7.fhir.r4.core#4.0.1');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getLastMessage('error')).toMatch(
           /Failed to load hl7\.does\.not\.exist#current/s
         );
@@ -527,8 +544,9 @@ describe('Processing', () => {
       ];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, selfSignedDependencyConfig).then(() => {
-        expect(defs.packages.length).toBe(1);
+        expect(defs.packages.length).toBe(2);
         expect(defs.packages).toContain('hl7.fhir.r4.core#4.0.1');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getLastMessage('error')).toMatch(
           /Failed to load self-signed\.package#1\.0\.0/s
         );
@@ -544,13 +562,106 @@ describe('Processing', () => {
       badDependencyConfig.dependencies = [{ packageId: 'hl7.fhir.r4.core' }];
       const defs = new FHIRDefinitions();
       return loadExternalDependencies(defs, badDependencyConfig).then(() => {
-        expect(defs.packages.length).toBe(1);
+        expect(defs.packages.length).toBe(2);
         expect(defs.packages).toContain('hl7.fhir.r4.core#4.0.1');
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
         expect(loggerSpy.getLastMessage('error')).toMatch(
           /Failed to load hl7\.fhir\.r4\.core: No version specified\./s
         );
         // But don't log the error w/ details about proxies
         expect(loggerSpy.getLastMessage('error')).not.toMatch(/SSL/s);
+      });
+    });
+  });
+
+  describe('#loadAutomaticDependencies', () => {
+    let loadDependencySpy: jest.SpyInstance;
+
+    beforeAll(() => {
+      loadDependencySpy = jest.spyOn(loadModule, 'loadDependency');
+    });
+
+    beforeEach(() => {
+      loggerSpy.reset();
+      loadDependencySpy.mockReset();
+    });
+
+    afterAll(() => {
+      loadDependencySpy.mockRestore();
+    });
+
+    it('should load each automatic dependency', () => {
+      loadDependencySpy.mockImplementation(
+        async (packageName: string, version: string, FHIRDefs: FHIRDefinitions) => {
+          FHIRDefs.packages.push(`${packageName}#${version}`);
+          return Promise.resolve(FHIRDefs);
+        }
+      );
+      const config = cloneDeep(minimalConfig);
+      config.dependencies = [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }];
+      const defs = new FHIRDefinitions();
+      return Promise.all(loadAutomaticDependencies(config.dependencies, defs)).then(() => {
+        expect(defs.packages).toHaveLength(1);
+        expect(defs.packages).toContain('hl7.fhir.uv.tools#current');
+        expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+        expect(loadDependencySpy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should not load dependencies that are present in the config', () => {
+      loadDependencySpy.mockImplementation(
+        async (packageName: string, version: string, FHIRDefs: FHIRDefinitions) => {
+          FHIRDefs.packages.push(`${packageName}#${version}`);
+          return Promise.resolve(FHIRDefs);
+        }
+      );
+      const config = cloneDeep(minimalConfig);
+      config.dependencies = [{ packageId: 'hl7.fhir.uv.tools', version: '2.2.0' }];
+      const defs = new FHIRDefinitions();
+      return Promise.all(loadAutomaticDependencies(config.dependencies, defs)).then(() => {
+        expect(defs.packages).toHaveLength(0);
+        expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+        expect(loadDependencySpy).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    it('should log a warning when it fails to load an automatic dependency', () => {
+      loadDependencySpy.mockImplementation(async (packageName: string, version: string) => {
+        throw new PackageLoadError(`${packageName}#${version}`);
+      });
+      const config = cloneDeep(minimalConfig);
+      config.dependencies = [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }];
+      const defs = new FHIRDefinitions();
+      return Promise.all(loadAutomaticDependencies(config.dependencies, defs)).then(() => {
+        expect(defs.packages).toHaveLength(0);
+        expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+        expect(loadDependencySpy).toHaveBeenCalledTimes(1);
+        expect(loggerSpy.getLastMessage('warn')).toMatch(
+          /Failed to load hl7\.fhir\.uv\.tools#current/s
+        );
+        // But don't log the warning w/ details about proxies
+        expect(loggerSpy.getLastMessage('warn')).not.toMatch(/SSL/s);
+      });
+    });
+
+    it('should log a more detailed warning when it fails to load an automatic dependency due to certificate issue', () => {
+      loadDependencySpy.mockImplementation(async () => {
+        throw new Error('self signed certificate in certificate chain');
+      });
+      const config = cloneDeep(minimalConfig);
+      config.dependencies = [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }];
+      const defs = new FHIRDefinitions();
+      return Promise.all(loadAutomaticDependencies(config.dependencies, defs)).then(() => {
+        expect(defs.packages).toHaveLength(0);
+        expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+        expect(loadDependencySpy).toHaveBeenCalledTimes(1);
+        expect(loggerSpy.getLastMessage('warn')).toMatch(
+          /Failed to load hl7\.fhir\.uv\.tools#current/s
+        );
+        // AND it should log the detailed message about SSL
+        expect(loggerSpy.getLastMessage('warn')).toMatch(
+          /Sometimes this error occurs in corporate or educational environments that use proxies and\/or SSL inspection/s
+        );
       });
     });
   });


### PR DESCRIPTION
Fixes #1166 and completes task [CIMPL-1036](https://standardhealthrecord.atlassian.net/browse/CIMPL-1036).

The current version of this package will always be loaded, even if it is not configured as a dependency. If it is configured as a dependency, use the configured version. When it fails to load, log a warning instead of an error if it was not a configured dependency.

My strategy for implementing this was to consider loading dependencies in two groups: automatic dependencies and configured dependencies. Hopefully, this makes it straightforward to add more automatic dependencies later. There are changes to a lot of the tests for `loadExternalDependencies`, since there's now an additional package that shows up every time. A lot of those tests are really testing `loadConfiguredDependencies`, though, so it may be worthwhile to adjust the tests accordingly. Please let me know if you think that would be useful.