### PR TITLE
Update Github workflow badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/fhir/sushi/Lint%20and%20Test)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/fhir/sushi/ci-workflow.yml?branch=master)
 ![npm](https://img.shields.io/npm/v/fsh-sushi)
 
 # SUSHI


### PR DESCRIPTION
I just noticed the "build" badge on this repo has an error. It is due to a change in the workflow badges, so I updated the URL, which should hopefully fix the issue once this is merged. Documentation of the badge URL changes are [here](https://github.com/badges/shields/issues/8671).