### PR TITLE
Allow Logical Models and Resources to constrain inherited elements

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -454,7 +454,6 @@ export class StructureDefinitionExporter implements Fishable {
     fshDefinition: Profile | Extension | Logical | Resource
   ): void {
     resolveSoftIndexing(fshDefinition.rules);
-    const addElementRules = fshDefinition.rules.filter(rule => rule instanceof AddElementRule);
     for (const rule of fshDefinition.rules) {
       // Specific rules are permitted for each structure definition type
       // (i.e., Profile, Logical, etc.). Log an error for disallowed rules
@@ -479,28 +478,6 @@ export class StructureDefinitionExporter implements Fishable {
       }
 
       const element = structDef.findElementByPath(rule.path, this);
-
-      if (element && (fshDefinition instanceof Logical || fshDefinition instanceof Resource)) {
-        // The FHIR spec prohibits constraining any parent element in a 'specialization'
-        // (i.e., logical model and resource), therefore log an error if that is attempted
-        // and continue to the next rule.
-        if (
-          rule.path &&
-          rule.path !== '.' &&
-          !addElementRules.some(
-            rule =>
-              element.path === `${element.structDef.pathType}.${rule.path}` ||
-              element.path.startsWith(`${element.structDef.pathType}.${rule.path}.`)
-          )
-        ) {
-          logger.error(
-            `FHIR prohibits logical models and resources from constraining parent elements. Skipping '${rule.constructorName}' at path '${rule.path}' for '${fshDefinition.name}'.`,
-            rule.sourceInfo
-          );
-          continue;
-        }
-      }
-
       if (element) {
         try {
           if (rule instanceof CardRule) {

--- a/src/fshtypes/AllowedRules.ts
+++ b/src/fshtypes/AllowedRules.ts
@@ -75,11 +75,31 @@ const allowedRulesMap = new Map<any, any[]>([
   ],
   [
     'Logical',
-    [AddElementRule, CardRule, CaretValueRule, FlagRule, ObeysRule, OnlyRule, BindingRule]
+    [
+      AddElementRule,
+      CardRule,
+      CaretValueRule,
+      // NO ContainsRule!
+      AssignmentRule,
+      FlagRule,
+      ObeysRule,
+      OnlyRule,
+      BindingRule
+    ]
   ],
   [
     'Resource',
-    [AddElementRule, CardRule, CaretValueRule, FlagRule, ObeysRule, OnlyRule, BindingRule]
+    [
+      AddElementRule,
+      CardRule,
+      CaretValueRule,
+      // NO ContainsRule!
+      AssignmentRule,
+      FlagRule,
+      ObeysRule,
+      OnlyRule,
+      BindingRule
+    ]
   ]
 ]);
 

--- a/test/export/StructureDefinition.LogicalExporter.test.ts
+++ b/test/export/StructureDefinition.LogicalExporter.test.ts
@@ -2,16 +2,20 @@ import path from 'path';
 import { StructureDefinitionExporter, Package } from '../../src/export';
 import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, loadFromPath } from '../../src/fhirdefs';
-import { Logical } from '../../src/fshtypes';
+import { Logical, Profile, FshValueSet, Invariant, FshCode } from '../../src/fshtypes';
 import { loggerSpy } from '../testhelpers/loggerSpy';
 import { TestFisher } from '../testhelpers';
 import { minimalConfig } from '../utils/minimalConfig';
 import {
   AddElementRule,
+  AssignmentRule,
+  BindingRule,
   CardRule,
   CaretValueRule,
   ContainsRule,
-  FlagRule
+  FlagRule,
+  ObeysRule,
+  OnlyRule
 } from '../../src/fshtypes/rules';
 
 describe('LogicalExporter', () => {
@@ -521,9 +525,9 @@ describe('LogicalExporter', () => {
     expect(logs).toHaveLength(0);
   });
 
-  it('should log an error when constraining a parent element', () => {
+  it('should allow constraints on inherited elements', () => {
     const logical = new Logical('MyTestModel');
-    logical.parent = 'AlternateIdentification';
+    logical.parent = 'ELTSSServiceModel';
     logical.id = 'MyModel';
 
     const addElementRule1 = new AddElementRule('backboneProp');
@@ -547,18 +551,53 @@ describe('LogicalExporter', () => {
     addElementRule3.short = 'short of backboneProp.address';
     logical.rules.push(addElementRule3);
 
-    const flagRule1 = new FlagRule('effectiveTime')
-      .withFile('ConstrainParent.fsh')
-      .withLocation([6, 1, 6, 16]);
+    // FlagRule
+    const flagRule1 = new FlagRule('fundingSource');
     flagRule1.summary = true;
     logical.rules.push(flagRule1);
 
-    const cardRule1 = new CardRule('effectiveTime')
-      .withFile('ConstrainParent.fsh')
-      .withLocation([7, 1, 7, 18]);
+    // CardRule
+    const cardRule1 = new CardRule('fundingSource');
     cardRule1.min = 1;
     cardRule1.max = '1';
     logical.rules.push(cardRule1);
+
+    // OnlyRule
+    const profiledString = new Profile('MyStringProfile');
+    profiledString.parent = 'string';
+    doc.profiles.set(profiledString.name, profiledString);
+    const onlyRule = new OnlyRule('deliveryAddress');
+    onlyRule.types = [{ type: profiledString.name }];
+    logical.rules.push(onlyRule);
+
+    // BindingRule
+    const myValueSet = new FshValueSet('MyValueSet');
+    doc.valueSets.set(myValueSet.name, myValueSet);
+    const bindingRule = new BindingRule('unitType');
+    bindingRule.valueSet = myValueSet.name;
+    bindingRule.strength = 'required';
+    logical.rules.push(bindingRule);
+
+    // AssignmentRule
+    const assignmentRule = new AssignmentRule('name');
+    assignmentRule.value = 'pet-sitting';
+    assignmentRule.exactly = false;
+    logical.rules.push(assignmentRule);
+
+    // ObeysRule
+    const myInvariant = new Invariant('MyInvariant');
+    myInvariant.severity = new FshCode('error');
+    myInvariant.description = 'Is after 1900';
+    doc.invariants.set(myInvariant.name, myInvariant);
+    const obeysRule = new ObeysRule('startDate');
+    obeysRule.invariant = myInvariant.name;
+    logical.rules.push(obeysRule);
+
+    // CaretValueRule
+    const caretRule = new CaretValueRule('startDate');
+    caretRule.caretPath = 'comment';
+    caretRule.value = 'Approximate is OK';
+    logical.rules.push(caretRule);
 
     const flagRule2 = new FlagRule('backboneProp.address');
     flagRule2.summary = true;
@@ -573,20 +612,69 @@ describe('LogicalExporter', () => {
 
     const exported = exporter.export().logicals[0];
 
-    const logs = loggerSpy.getAllMessages('error');
-    expect(logs).toHaveLength(2);
-    logs.forEach(log => {
-      expect(log).toMatch(
-        /FHIR prohibits logical models and resources from constraining parent elements. Skipping.*at path 'effectiveTime'.*File: ConstrainParent\.fsh.*Line:\D*/s
-      );
-    });
+    expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
 
     expect(exported.name).toBe('MyTestModel');
     expect(exported.id).toBe('MyModel');
     expect(exported.type).toBe('http://hl7.org/fhir/us/minimal/StructureDefinition/MyModel');
     expect(exported.baseDefinition).toBe(
-      'http://hl7.org/fhir/cda/StructureDefinition/AlternateIdentification'
+      'http://hl7.org/fhir/us/eltss/StructureDefinition/eLTSSServiceModel'
     );
-    expect(exported.elements).toHaveLength(9); // 6 AlternateIdentification elements + 3 added elements
+
+    // FlagRule
+    const fundingSource = exported.findElement('MyModel.fundingSource');
+    expect(fundingSource.isSummary).toBeTrue();
+
+    // CardRule
+    expect(fundingSource.min).toBe(1);
+    expect(fundingSource.max).toBe('1');
+
+    // OnlyRule
+    const deliveryAddress = exported.findElement('MyModel.deliveryAddress');
+    expect(deliveryAddress.type[0].code).toBe('string');
+    expect(deliveryAddress.type[0].profile).toEqual([
+      'http://hl7.org/fhir/us/minimal/StructureDefinition/MyStringProfile'
+    ]);
+
+    // BindingRule
+    const unitType = exported.findElement('MyModel.unitType');
+    expect(unitType.binding.valueSet).toBe('http://hl7.org/fhir/us/minimal/ValueSet/MyValueSet');
+    expect(unitType.binding.strength).toBe('required');
+
+    // AssignmentRule
+    const name = exported.findElement('MyModel.name');
+    expect(name.patternString).toBe('pet-sitting');
+
+    // ObeysRule
+    const startDate = exported.findElement('MyModel.startDate');
+    expect(startDate.constraint[0].key).toBe('MyInvariant');
+    expect(startDate.constraint[0].severity).toBe('error');
+    expect(startDate.constraint[0].human).toBe('Is after 1900');
+
+    // CaretValueRule
+    expect(startDate.comment).toBe('Approximate is OK');
+
+    expect(exported.elements).toHaveLength(20); // 17 ELTSSServiceModel elements + 3 added elements
+  });
+
+  it('should log an error when slicing an inherited element', () => {
+    const logical = new Logical('MyModel');
+    logical.parent = 'ELTSSServiceModel';
+    const containsRule = new ContainsRule('deliveryAddress')
+      .withFile('MyModel.fsh')
+      .withLocation([3, 8, 3, 25]);
+    containsRule.items.push({
+      name: 'home'
+    });
+    logical.rules.push(containsRule);
+    doc.logicals.set(logical.name, logical);
+    const exported = exporter.export().logicals[0];
+
+    expect(loggerSpy.getLastMessage('error')).toMatch(/File: MyModel\.fsh.*Line: 3\D*/s);
+    expect(loggerSpy.getLastMessage('error')).toMatch(
+      /Use of 'ContainsRule' is not permitted for 'Logical'/s
+    );
+    const deliveryAddress = exported.findElement('MyModel.deliveryAddress');
+    expect(deliveryAddress.slicing).toBeUndefined();
   });
 });

--- a/test/export/StructureDefinition.ResourceExporter.test.ts
+++ b/test/export/StructureDefinition.ResourceExporter.test.ts
@@ -2,16 +2,20 @@ import path from 'path';
 import { StructureDefinitionExporter, Package } from '../../src/export';
 import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, loadFromPath } from '../../src/fhirdefs';
-import { Resource } from '../../src/fshtypes';
+import { FshCode, FshValueSet, Invariant, Profile, Resource } from '../../src/fshtypes';
 import { loggerSpy } from '../testhelpers/loggerSpy';
 import { TestFisher } from '../testhelpers';
 import { minimalConfig } from '../utils/minimalConfig';
 import {
   AddElementRule,
+  AssignmentRule,
+  BindingRule,
   CardRule,
   CaretValueRule,
   ContainsRule,
-  FlagRule
+  FlagRule,
+  ObeysRule,
+  OnlyRule
 } from '../../src/fshtypes/rules';
 import { StructureDefinition } from '../../src/fhirtypes';
 
@@ -211,7 +215,7 @@ describe('ResourceExporter', () => {
     expect(logs).toHaveLength(0);
   });
 
-  it('should log an error when constraining a parent element', () => {
+  it('should allow constraints on inherited elements', () => {
     const resource = new Resource('MyTestResource');
     // Parent defaults to DomainResource
     resource.id = 'MyResource';
@@ -237,18 +241,53 @@ describe('ResourceExporter', () => {
     addElementRule3.short = 'short of backboneProp.address';
     resource.rules.push(addElementRule3);
 
-    const flagRule1 = new FlagRule('language')
-      .withFile('ConstrainParent.fsh')
-      .withLocation([6, 1, 6, 16]);
+    // FlagRule
+    const flagRule1 = new FlagRule('extension');
     flagRule1.summary = true;
     resource.rules.push(flagRule1);
 
-    const cardRule1 = new CardRule('language')
-      .withFile('ConstrainParent.fsh')
-      .withLocation([7, 1, 7, 18]);
+    // CardRule
+    const cardRule1 = new CardRule('extension');
     cardRule1.min = 1;
     cardRule1.max = '1';
     resource.rules.push(cardRule1);
+
+    // OnlyRule
+    const profiledMeta = new Profile('MyMetaProfile');
+    profiledMeta.parent = 'Meta';
+    doc.profiles.set(profiledMeta.name, profiledMeta);
+    const onlyRule = new OnlyRule('meta');
+    onlyRule.types = [{ type: profiledMeta.name }];
+    resource.rules.push(onlyRule);
+
+    // BindingRule
+    const myValueSet = new FshValueSet('MyValueSet');
+    doc.valueSets.set(myValueSet.name, myValueSet);
+    const bindingRule = new BindingRule('language');
+    bindingRule.valueSet = myValueSet.name;
+    bindingRule.strength = 'required';
+    resource.rules.push(bindingRule);
+
+    // AssignmentRule
+    const assignmentRule = new AssignmentRule('text.status');
+    assignmentRule.value = new FshCode('additional');
+    assignmentRule.exactly = true;
+    resource.rules.push(assignmentRule);
+
+    // ObeysRule
+    const myInvariant = new Invariant('MyInvariant');
+    myInvariant.severity = new FshCode('error');
+    myInvariant.description = 'Has a Patient';
+    doc.invariants.set(myInvariant.name, myInvariant);
+    const obeysRule = new ObeysRule('contained');
+    obeysRule.invariant = myInvariant.name;
+    resource.rules.push(obeysRule);
+
+    // CaretValueRule
+    const caretRule = new CaretValueRule('implicitRules');
+    caretRule.caretPath = 'comment';
+    caretRule.value = 'Not explicit';
+    resource.rules.push(caretRule);
 
     const flagRule2 = new FlagRule('backboneProp.address');
     flagRule2.summary = true;
@@ -263,19 +302,69 @@ describe('ResourceExporter', () => {
 
     const exported = exporter.export().resources[0];
 
-    const logs = loggerSpy.getAllMessages('error');
-    expect(logs).toHaveLength(2);
-    logs.forEach(log => {
-      expect(log).toMatch(
-        /FHIR prohibits logical models and resources from constraining parent elements. Skipping.*at path 'language'.*File: ConstrainParent\.fsh.*Line:\D*/s
-      );
-    });
+    expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
 
     expect(exported.name).toBe('MyTestResource');
     expect(exported.id).toBe('MyResource');
     expect(exported.type).toBe('MyResource');
     expect(exported.baseDefinition).toBe('http://hl7.org/fhir/StructureDefinition/DomainResource');
-    expect(exported.elements).toHaveLength(12); // 9 AlternateIdentification elements + 3 added elements
+
+    // FlagRule
+    const extension = exported.findElement('MyResource.extension');
+    expect(extension.isSummary).toBeTrue();
+
+    // CardRule
+    expect(extension.min).toBe(1);
+    expect(extension.max).toBe('1');
+
+    // OnlyRule
+    const meta = exported.findElement('MyResource.meta');
+    expect(meta.type[0].code).toBe('Meta');
+    expect(meta.type[0].profile).toEqual([
+      'http://hl7.org/fhir/us/minimal/StructureDefinition/MyMetaProfile'
+    ]);
+
+    // BindingRule
+    const language = exported.findElement('MyResource.language');
+    expect(language.binding.valueSet).toBe('http://hl7.org/fhir/us/minimal/ValueSet/MyValueSet');
+    expect(language.binding.strength).toBe('required');
+
+    // AssignmentRule
+    const textStatus = exported.findElement('MyResource.text.status');
+    expect(textStatus.fixedCode).toBe('additional');
+
+    // ObeysRule
+    const contained = exported.findElement('MyResource.contained');
+    expect(contained.constraint[0].key).toBe('MyInvariant');
+    expect(contained.constraint[0].severity).toBe('error');
+    expect(contained.constraint[0].human).toBe('Has a Patient');
+
+    // CaretValueRule
+    const implicitRules = exported.findElement('MyResource.implicitRules');
+    expect(implicitRules.comment).toBe('Not explicit');
+
+    expect(exported.elements).toHaveLength(16); // 9 DomainResource elements + + 4 expanded Narrative elements + 3 added elements
+  });
+
+  it('should log an error when slicing an inherited element', () => {
+    const resource = new Resource('MyResource');
+    // Parent defaults to DomainResource
+    const containsRule = new ContainsRule('contained')
+      .withFile('MyResource.fsh')
+      .withLocation([3, 8, 3, 25]);
+    containsRule.items.push({
+      name: 'conditions'
+    });
+    resource.rules.push(containsRule);
+    doc.resources.set(resource.name, resource);
+    const exported = exporter.export().resources[0];
+
+    expect(loggerSpy.getLastMessage('error')).toMatch(/File: MyResource\.fsh.*Line: 3\D*/s);
+    expect(loggerSpy.getLastMessage('error')).toMatch(
+      /Use of 'ContainsRule' is not permitted for 'Resource'/s
+    );
+    const contained = exported.findElement('MyResource.contained');
+    expect(contained.slicing).toBeUndefined();
   });
 
   it('should log an error when adding an element with the same path as an inherited element', () => {

--- a/test/fshtypes/AllowedRules.test.ts
+++ b/test/fshtypes/AllowedRules.test.ts
@@ -88,6 +88,7 @@ describe('isAllowedRule', () => {
       expect(isAllowedRule(l, new AddElementRule('foo'))).toBeTrue();
       expect(isAllowedRule(l, new CardRule('foo'))).toBeTrue();
       expect(isAllowedRule(l, new CaretValueRule('foo'))).toBeTrue();
+      expect(isAllowedRule(l, new AssignmentRule('foo'))).toBeTrue();
       expect(isAllowedRule(l, new FlagRule('foo'))).toBeTrue();
       expect(isAllowedRule(l, new ObeysRule('foo'))).toBeTrue();
       expect(isAllowedRule(l, new OnlyRule('foo'))).toBeTrue();
@@ -100,7 +101,6 @@ describe('isAllowedRule', () => {
       expect(isAllowedRule(l, new ValueSetComponentRule(true))).toBeFalse();
       expect(isAllowedRule(l, new ConceptRule('foo'))).toBeFalse();
       expect(isAllowedRule(l, new ContainsRule('foo'))).toBeFalse();
-      expect(isAllowedRule(l, new AssignmentRule('foo'))).toBeFalse();
     });
   });
 
@@ -114,6 +114,7 @@ describe('isAllowedRule', () => {
       expect(isAllowedRule(r, new AddElementRule('foo'))).toBeTrue();
       expect(isAllowedRule(r, new CardRule('foo'))).toBeTrue();
       expect(isAllowedRule(r, new CaretValueRule('foo'))).toBeTrue();
+      expect(isAllowedRule(r, new AssignmentRule('foo'))).toBeTrue();
       expect(isAllowedRule(r, new FlagRule('foo'))).toBeTrue();
       expect(isAllowedRule(r, new ObeysRule('foo'))).toBeTrue();
       expect(isAllowedRule(r, new OnlyRule('foo'))).toBeTrue();
@@ -126,7 +127,6 @@ describe('isAllowedRule', () => {
       expect(isAllowedRule(r, new ValueSetComponentRule(true))).toBeFalse();
       expect(isAllowedRule(r, new ConceptRule('foo'))).toBeFalse();
       expect(isAllowedRule(r, new ContainsRule('foo'))).toBeFalse();
-      expect(isAllowedRule(r, new AssignmentRule('foo'))).toBeFalse();
     });
   });
 

--- a/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-AlternateIdentification.json
+++ b/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-AlternateIdentification.json
@@ -1,1 +1,193 @@
-{"resourceType":"StructureDefinition","id":"AlternateIdentification","text":{"status":"generated","div":"<div xmlns=\"http://www.w3.org/1999/xhtml\">\n      <p>Alternate Identifier for a role</p>\n      <p>The id field SHALL match an id in the linked role.</p>\n    </div>"},"url":"http://hl7.org/fhir/cda/StructureDefinition/AlternateIdentification","version":"2.1.0","name":"AlternateIdentification","title":"AlternateIdentification (CDA Class)","status":"active","experimental":false,"date":"2021-03-11T17:00:55+00:00","publisher":"Health Level 7","description":"Alternate Identifier for a role","fhirVersion":"4.0.1","kind":"logical","abstract":true,"type":"AlternateIdentification","baseDefinition":"http://hl7.org/fhir/StructureDefinition/Base","derivation":"specialization","snapshot":{"element":[{"id":"AlternateIdentification","path":"AlternateIdentification","min":1,"max":"1","base":{"path":"Base","min":0,"max":"*"},"isModifier":false},{"id":"AlternateIdentification.classCode","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace","valueUri":"urn:hl7-org:v3"}],"path":"AlternateIdentification.classCode","representation":["xmlAttr"],"min":1,"max":"1","base":{"path":"AlternateIdentification.classCode","min":1,"max":"1"},"fixedCode":"IDENT","binding":{"strength":"required","valueSet":"http://terminology.hl7.org/ValueSet/v3-RoleClass"}},{"id":"AlternateIdentification.id","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace","valueUri":"urn:hl7-org:v3"}],"path":"AlternateIdentification.id","min":1,"max":"1","base":{"path":"AlternateIdentification.id","min":1,"max":"1"},"type":[{"code":"http://hl7.org/fhir/cda/StructureDefinition/II"}]},{"id":"AlternateIdentification.code","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace","valueUri":"urn:hl7-org:v3"}],"path":"AlternateIdentification.code","min":0,"max":"1","base":{"path":"AlternateIdentification.code","min":0,"max":"1"},"type":[{"code":"http://hl7.org/fhir/cda/StructureDefinition/CD"}]},{"id":"AlternateIdentification.statusCode","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace","valueUri":"urn:hl7-org:v3"}],"path":"AlternateIdentification.statusCode","min":0,"max":"1","base":{"path":"AlternateIdentification.statusCode","min":0,"max":"1"},"type":[{"code":"http://hl7.org/fhir/cda/StructureDefinition/CS"}],"binding":{"strength":"required","valueSet":"http://terminology.hl7.org/ValueSet/v3-ActStatus"}},{"id":"AlternateIdentification.effectiveTime","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace","valueUri":"urn:hl7-org:v3"}],"path":"AlternateIdentification.effectiveTime","min":0,"max":"1","base":{"path":"AlternateIdentification.effectiveTime","min":0,"max":"1"},"type":[{"code":"http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"}]}]},"differential":{"element":[{"id":"AlternateIdentification","path":"AlternateIdentification","min":1,"max":"1"},{"id":"AlternateIdentification.classCode","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace","valueUri":"urn:hl7-org:v3"}],"path":"AlternateIdentification.classCode","representation":["xmlAttr"],"min":1,"max":"1","fixedCode":"IDENT","binding":{"strength":"required","valueSet":"http://terminology.hl7.org/ValueSet/v3-RoleClass"}},{"id":"AlternateIdentification.id","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace","valueUri":"urn:hl7-org:v3"}],"path":"AlternateIdentification.id","min":1,"max":"1","type":[{"code":"http://hl7.org/fhir/cda/StructureDefinition/II"}]},{"id":"AlternateIdentification.code","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace","valueUri":"urn:hl7-org:v3"}],"path":"AlternateIdentification.code","min":0,"max":"1","type":[{"code":"http://hl7.org/fhir/cda/StructureDefinition/CD"}]},{"id":"AlternateIdentification.statusCode","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace","valueUri":"urn:hl7-org:v3"}],"path":"AlternateIdentification.statusCode","min":0,"max":"1","type":[{"code":"http://hl7.org/fhir/cda/StructureDefinition/CS"}],"binding":{"strength":"required","valueSet":"http://terminology.hl7.org/ValueSet/v3-ActStatus"}},{"id":"AlternateIdentification.effectiveTime","extension":[{"url":"http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace","valueUri":"urn:hl7-org:v3"}],"path":"AlternateIdentification.effectiveTime","min":0,"max":"1","type":[{"code":"http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"}]}]}}
+{
+  "resourceType": "StructureDefinition",
+  "id": "AlternateIdentification",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n      <p>Alternate Identifier for a role</p>\n      <p>The id field SHALL match an id in the linked role.</p>\n    </div>"
+  },
+  "url": "http://hl7.org/fhir/cda/StructureDefinition/AlternateIdentification",
+  "version": "2.1.0",
+  "name": "AlternateIdentification",
+  "title": "AlternateIdentification (CDA Class)",
+  "status": "active",
+  "experimental": false,
+  "date": "2021-03-11T17:00:55+00:00",
+  "publisher": "Health Level 7",
+  "description": "Alternate Identifier for a role",
+  "fhirVersion": "4.0.1",
+  "kind": "logical",
+  "abstract": true,
+  "type": "AlternateIdentification",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Base",
+  "derivation": "specialization",
+  "snapshot": {
+    "element": [
+      {
+        "id": "AlternateIdentification",
+        "path": "AlternateIdentification",
+        "min": 1,
+        "max": "1",
+        "base": { "path": "Base", "min": 0, "max": "*" },
+        "isModifier": false
+      },
+      {
+        "id": "AlternateIdentification.classCode",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace",
+            "valueUri": "urn:hl7-org:v3"
+          }
+        ],
+        "path": "AlternateIdentification.classCode",
+        "representation": ["xmlAttr"],
+        "min": 1,
+        "max": "1",
+        "base": { "path": "AlternateIdentification.classCode", "min": 1, "max": "1" },
+        "fixedCode": "IDENT",
+        "binding": {
+          "strength": "required",
+          "valueSet": "http://terminology.hl7.org/ValueSet/v3-RoleClass"
+        }
+      },
+      {
+        "id": "AlternateIdentification.id",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace",
+            "valueUri": "urn:hl7-org:v3"
+          }
+        ],
+        "path": "AlternateIdentification.id",
+        "min": 1,
+        "max": "1",
+        "base": { "path": "AlternateIdentification.id", "min": 1, "max": "1" },
+        "type": [{ "code": "http://hl7.org/fhir/cda/StructureDefinition/II" }]
+      },
+      {
+        "id": "AlternateIdentification.code",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace",
+            "valueUri": "urn:hl7-org:v3"
+          }
+        ],
+        "path": "AlternateIdentification.code",
+        "min": 0,
+        "max": "1",
+        "base": { "path": "AlternateIdentification.code", "min": 0, "max": "1" },
+        "type": [{ "code": "http://hl7.org/fhir/cda/StructureDefinition/CD" }]
+      },
+      {
+        "id": "AlternateIdentification.statusCode",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace",
+            "valueUri": "urn:hl7-org:v3"
+          }
+        ],
+        "path": "AlternateIdentification.statusCode",
+        "min": 0,
+        "max": "1",
+        "base": { "path": "AlternateIdentification.statusCode", "min": 0, "max": "1" },
+        "type": [{ "code": "http://hl7.org/fhir/cda/StructureDefinition/CS" }],
+        "binding": {
+          "strength": "required",
+          "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActStatus"
+        }
+      },
+      {
+        "id": "AlternateIdentification.effectiveTime",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace",
+            "valueUri": "urn:hl7-org:v3"
+          }
+        ],
+        "path": "AlternateIdentification.effectiveTime",
+        "min": 0,
+        "max": "1",
+        "base": { "path": "AlternateIdentification.effectiveTime", "min": 0, "max": "1" },
+        "type": [{ "code": "http://hl7.org/fhir/cda/StructureDefinition/IVL-TS" }]
+      }
+    ]
+  },
+  "differential": {
+    "element": [
+      { "id": "AlternateIdentification", "path": "AlternateIdentification", "min": 1, "max": "1" },
+      {
+        "id": "AlternateIdentification.classCode",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace",
+            "valueUri": "urn:hl7-org:v3"
+          }
+        ],
+        "path": "AlternateIdentification.classCode",
+        "representation": ["xmlAttr"],
+        "min": 1,
+        "max": "1",
+        "fixedCode": "IDENT",
+        "binding": {
+          "strength": "required",
+          "valueSet": "http://terminology.hl7.org/ValueSet/v3-RoleClass"
+        }
+      },
+      {
+        "id": "AlternateIdentification.id",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace",
+            "valueUri": "urn:hl7-org:v3"
+          }
+        ],
+        "path": "AlternateIdentification.id",
+        "min": 1,
+        "max": "1",
+        "type": [{ "code": "http://hl7.org/fhir/cda/StructureDefinition/II" }]
+      },
+      {
+        "id": "AlternateIdentification.code",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace",
+            "valueUri": "urn:hl7-org:v3"
+          }
+        ],
+        "path": "AlternateIdentification.code",
+        "min": 0,
+        "max": "1",
+        "type": [{ "code": "http://hl7.org/fhir/cda/StructureDefinition/CD" }]
+      },
+      {
+        "id": "AlternateIdentification.statusCode",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace",
+            "valueUri": "urn:hl7-org:v3"
+          }
+        ],
+        "path": "AlternateIdentification.statusCode",
+        "min": 0,
+        "max": "1",
+        "type": [{ "code": "http://hl7.org/fhir/cda/StructureDefinition/CS" }],
+        "binding": {
+          "strength": "required",
+          "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActStatus"
+        }
+      },
+      {
+        "id": "AlternateIdentification.effectiveTime",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace",
+            "valueUri": "urn:hl7-org:v3"
+          }
+        ],
+        "path": "AlternateIdentification.effectiveTime",
+        "min": 0,
+        "max": "1",
+        "type": [{ "code": "http://hl7.org/fhir/cda/StructureDefinition/IVL-TS" }]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #1195

The FHIR core team has indicated that constraining inherited elements is allowed in logical models and resources, with one exception: slicing is still not allowed.

This PR primarily removes the code that used to prohibit these constraints. It also adds `AssignmentRules` as an allowed constraint for logical models and resources.

The tests verify this behavior, but you can also try the following FSH project: [ConstrainedLMs.zip](https://github.com/FHIR/sushi/files/10686464/ConstrainedLMs.zip). On `master`, you'll get several errors. On this PR branch, you will not.