### PR TITLE
Fancy Characters for All!

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -298,34 +298,5 @@ function printResults(pkg: Package, sushiVersions: any) {
     );
   }
 
-  const convertChars = !supportsFancyCharacters();
-  results.forEach(r => {
-    if (convertChars) {
-      r = r
-        .replace(/[╔╝╚╗╠╣═]/g, '=')
-        .replace(/[╭╯╰╮]/g, ' ')
-        .replace(/[─┬┼┴]/g, '-')
-        .replace(/[║│├┤]/g, '|');
-    }
-    console.log(r);
-  });
-}
-
-function supportsFancyCharacters(): boolean {
-  // There is no sure-fire way, but we know that most problems are when running in the IG Publisher,
-  // so try to detect that situation (which is still actually pretty tricky and not guaranteed).
-
-  // 1. Many JVM will insert an environment variable indicating the main Java class being run.
-  //      E.g., JAVA_MAIN_CLASS_25538=org.hl7.fhir.igtools.publisher.Publisher
-  //    We won't check the actual class; we'll just assume that if it's run in Java, best not take chances.
-  if (Object.keys(process.env).some(k => /^JAVA_MAIN_CLASS/.test(k))) {
-    return false;
-  }
-  // 2. It appears that in a Java-launched process, certain aspects of stdout aren't available, so
-  //    use that to test if it's likely the fancy chars will be supported.
-  if (process.stdout.hasColors === undefined) {
-    return false;
-  }
-  // Otherwise, I guess (?) we're OK.  Worst case scenario: user gets rubbish characters in the summary
-  return true;
+  results.forEach(r => console.log(r));
 }


### PR DESCRIPTION
This PR replaces #1177. As @qligier pointed out, the IG Publisher seems to handle fancy characters better now. Rather than introduce a new env var to force fancy characters (as in #1177), we should just always use them if they really do always work.

I'd like @jafeltra and @mint-thompson to test this to ensure that things work well for them too (especially on Windows). Since IG publisher uses the globally installed SUSHI, you will probably need to:
1. `npm pack`
2. `npm install -g file:/path/to/packed/tgz`

Make sure you update to the latest IG Publisher and run it against any FSH project. When the IG Publisher runs SUSHI, you should see the nice box corners instead of the ugly ones.

If we find that there are still issues w/ IG Publisher in some cases, then we'll abandon this PR and take in #1177.

Many many thanks to @qligier for calling this to our attention!