### PR TITLE
Support dependencies on specific CI build branches

### DIFF
--- a/test/fhirdefs/fixtures/sushi-test#current$oldbranch/package/StructureDefinition-MyPatient.json
+++ b/test/fhirdefs/fixtures/sushi-test#current$oldbranch/package/StructureDefinition-MyPatient.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "MyPatient",
+  "url": "http://hl7.org/fhir/sushi-test/StructureDefinition/MyPatient",
+  "name": "MyPatient",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient.deceased[x]",
+        "path": "Patient.deceased[x]",
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fhirdefs/fixtures/sushi-test#current$oldbranch/package/package.json
+++ b/test/fhirdefs/fixtures/sushi-test#current$oldbranch/package/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "sushi-test",
+  "version" : "0.2.0",
+  "canonical" : "http://hl7.org/fhir/sushi-test",
+  "url" : "http://hl7.org/fhir/sushi-test",
+  "title" : "FSH Test IG",
+  "description": "Provides a simple example of how FSH can be used to create an IG",
+  "dependencies": {
+     "hl7.fhir.r4.core": "4.0.1",
+     "hl7.fhir.us.core": "3.1.0",
+     "hl7.fhir.uv.vhdir":"current"
+  },
+  "date": "20200412230227",
+  "language": "en",
+  "author": "James Tuna",
+  "maintainers": [
+    {
+      "name": "Bill Cod",
+      "email": "cod@reef.gov",
+      "url": "https://capecodfishermen.org/"
+    }
+  ],
+  "license": "CC0-1.0"
+ }

--- a/test/fhirdefs/fixtures/sushi-test#current$testbranch/package/StructureDefinition-MyPatient.json
+++ b/test/fhirdefs/fixtures/sushi-test#current$testbranch/package/StructureDefinition-MyPatient.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "MyPatient",
+  "url": "http://hl7.org/fhir/sushi-test/StructureDefinition/MyPatient",
+  "name": "MyPatient",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient.deceased[x]",
+        "path": "Patient.deceased[x]",
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fhirdefs/fixtures/sushi-test#current$testbranch/package/package.json
+++ b/test/fhirdefs/fixtures/sushi-test#current$testbranch/package/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "sushi-test",
+  "version" : "0.2.0",
+  "canonical" : "http://hl7.org/fhir/sushi-test",
+  "url" : "http://hl7.org/fhir/sushi-test",
+  "title" : "FSH Test IG",
+  "description": "Provides a simple example of how FSH can be used to create an IG",
+  "dependencies": {
+     "hl7.fhir.r4.core": "4.0.1",
+     "hl7.fhir.us.core": "3.1.0",
+     "hl7.fhir.uv.vhdir":"current"
+  },
+  "date": "20200413230227",
+  "language": "en",
+  "author": "James Tuna",
+  "maintainers": [
+    {
+      "name": "Bill Cod",
+      "email": "cod@reef.gov",
+      "url": "https://capecodfishermen.org/"
+    }
+  ],
+  "license": "CC0-1.0"
+ }


### PR DESCRIPTION
Add support for dependency versions that specify a current branch name. For example: `current$mybranchname`.

See: https://chat.fhir.org/#narrow/stream/179166-implementers/topic/Package.20cache.20-.20multiple.20dev.20versions/near/291131585

If you want to manually test this, add this dependency to a project:
```yaml
dependencies:
  hl7.fhir.be.mycarenet: current$issue-30
```

If you run SUSHI on the master branch, you'll get an error when it tries to download the dependency (assuming you don't have it cached locally).

If you run this PR branch, it will work. If you run SUSHI with `-d`, you'll see a debug message that the cached date matches the build date, so it will not download again.