### PR TITLE
Populate exampleCanonical regardless of meta.profile configuration

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -703,6 +703,8 @@ export class InstanceExporter implements Fishable {
         }
       }
     }
+    // regardless of what we did with meta.profile, we may need the instanceOfStructureDefinition url later
+    instanceDef._instanceMeta.instanceOfUrl = instanceOfStructureDefinition.url;
     instanceDef.validateId(fshDefinition);
     this.validateRequiredElements(
       instanceDef,

--- a/src/fhirtypes/InstanceDefinition.ts
+++ b/src/fhirtypes/InstanceDefinition.ts
@@ -99,6 +99,7 @@ type InstanceMeta = {
   description?: string;
   usage?: InstanceUsage;
   sdType?: string;
+  instanceOfUrl?: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -882,13 +882,18 @@ export class IGExporter {
       pkgResource instanceof InstanceDefinition &&
       pkgResource._instanceMeta.usage === 'Example'
     ) {
-      const exampleUrl = pkgResource.meta?.profile?.find(url => {
-        const [baseUrl, version] = url.split('|', 2);
-        const availableProfile = this.pkg.fish(baseUrl, Type.Profile);
-        return (
-          availableProfile != null && (version == null || version === availableProfile.version)
-        );
-      });
+      // so here's where we set exampleCanonical
+      // but we need to be able to set it without there being anything in meta.profile
+      const metaProfileUrls = pkgResource.meta?.profile ?? [];
+      const exampleUrl = [...metaProfileUrls, pkgResource._instanceMeta.instanceOfUrl ?? ''].find(
+        url => {
+          const [baseUrl, version] = url.split('|', 2);
+          const availableProfile = this.pkg.fish(baseUrl, Type.Profile);
+          return (
+            availableProfile != null && (version == null || version === availableProfile.version)
+          );
+        }
+      );
       if (exampleUrl) {
         newResource.exampleCanonical = exampleUrl.split('|', 1)[0];
       } else {

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -607,12 +607,20 @@ describe('InstanceExporter', () => {
       const spooky = new Instance('Skeleton');
       spooky.instanceOf = patient.id;
       spooky.usage = 'Inline';
-      expect(exportInstance(boo).meta).toEqual({
+      const booInstance = exportInstance(boo);
+      const spookyInstance = exportInstance(spooky);
+      expect(booInstance.meta).toEqual({
         profile: [`${tank.config.canonical}/StructureDefinition/${patient.id}`]
       });
-      expect(exportInstance(spooky).meta).toEqual({
+      expect(booInstance._instanceMeta.instanceOfUrl).toBe(
+        `${tank.config.canonical}/StructureDefinition/${patient.id}`
+      );
+      expect(spookyInstance.meta).toEqual({
         profile: [`${tank.config.canonical}/StructureDefinition/${patient.id}`]
       });
+      expect(spookyInstance._instanceMeta.instanceOfUrl).toBe(
+        `${tank.config.canonical}/StructureDefinition/${patient.id}`
+      );
     });
 
     it('should set meta.profile on all instances when setMetaProfile is not set', () => {
@@ -622,12 +630,20 @@ describe('InstanceExporter', () => {
       const spooky = new Instance('Skeleton');
       spooky.instanceOf = patient.id;
       spooky.usage = 'Inline';
-      expect(exportInstance(boo).meta).toEqual({
+      const booInstance = exportInstance(boo);
+      const spookyInstance = exportInstance(spooky);
+      expect(booInstance.meta).toEqual({
         profile: [`${tank.config.canonical}/StructureDefinition/${patient.id}`]
       });
-      expect(exportInstance(spooky).meta).toEqual({
+      expect(booInstance._instanceMeta.instanceOfUrl).toBe(
+        `${tank.config.canonical}/StructureDefinition/${patient.id}`
+      );
+      expect(spookyInstance.meta).toEqual({
         profile: [`${tank.config.canonical}/StructureDefinition/${patient.id}`]
       });
+      expect(spookyInstance._instanceMeta.instanceOfUrl).toBe(
+        `${tank.config.canonical}/StructureDefinition/${patient.id}`
+      );
     });
 
     it('should set meta.profile on no instances when setMetaProfile is never', () => {
@@ -637,8 +653,16 @@ describe('InstanceExporter', () => {
       const spooky = new Instance('Skeleton');
       spooky.instanceOf = patient.id;
       spooky.usage = 'Inline';
-      expect(exportInstance(boo).meta).toBeUndefined();
-      expect(exportInstance(spooky).meta).toBeUndefined();
+      const booInstance = exportInstance(boo);
+      const spookyInstance = exportInstance(spooky);
+      expect(booInstance.meta).toBeUndefined();
+      expect(booInstance._instanceMeta.instanceOfUrl).toBe(
+        `${tank.config.canonical}/StructureDefinition/${patient.id}`
+      );
+      expect(spookyInstance.meta).toBeUndefined();
+      expect(spookyInstance._instanceMeta.instanceOfUrl).toBe(
+        `${tank.config.canonical}/StructureDefinition/${patient.id}`
+      );
     });
 
     it('should set meta.profile on inline instances when setMetaProfile is inline-only', () => {
@@ -648,10 +672,18 @@ describe('InstanceExporter', () => {
       const spooky = new Instance('Skeleton');
       spooky.instanceOf = patient.id;
       spooky.usage = 'Inline';
-      expect(exportInstance(boo).meta).toBeUndefined();
-      expect(exportInstance(spooky).meta).toEqual({
+      const booInstance = exportInstance(boo);
+      const spookyInstance = exportInstance(spooky);
+      expect(booInstance.meta).toBeUndefined();
+      expect(booInstance._instanceMeta.instanceOfUrl).toBe(
+        `${tank.config.canonical}/StructureDefinition/${patient.id}`
+      );
+      expect(spookyInstance.meta).toEqual({
         profile: [`${tank.config.canonical}/StructureDefinition/${patient.id}`]
       });
+      expect(spookyInstance._instanceMeta.instanceOfUrl).toBe(
+        `${tank.config.canonical}/StructureDefinition/${patient.id}`
+      );
     });
 
     it('should set meta.profile on non-inline instances when setMetaProfile is standalone-only', () => {
@@ -661,10 +693,18 @@ describe('InstanceExporter', () => {
       const spooky = new Instance('Skeleton');
       spooky.instanceOf = patient.id;
       spooky.usage = 'Inline';
-      expect(exportInstance(boo).meta).toEqual({
+      const booInstance = exportInstance(boo);
+      const spookyInstance = exportInstance(spooky);
+      expect(booInstance.meta).toEqual({
         profile: [`${tank.config.canonical}/StructureDefinition/${patient.id}`]
       });
-      expect(exportInstance(spooky).meta).toBeUndefined();
+      expect(booInstance._instanceMeta.instanceOfUrl).toBe(
+        `${tank.config.canonical}/StructureDefinition/${patient.id}`
+      );
+      expect(spookyInstance.meta).toBeUndefined();
+      expect(spookyInstance._instanceMeta.instanceOfUrl).toBe(
+        `${tank.config.canonical}/StructureDefinition/${patient.id}`
+      );
     });
 
     it('should automatically set the URL property on definition instances', () => {

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -67,15 +67,21 @@ describe('IGExporter', () => {
             instanceDef._instanceMeta.title = 'Another Patient Example';
             instanceDef._instanceMeta.description = 'Another example of a Patient';
             instanceDef._instanceMeta.usage = 'Example';
+            instanceDef._instanceMeta.instanceOfUrl =
+              'http://hl7.org/fhir/sushi-test/StructureDefinition/sample-patient';
           }
           if (instanceDef.id === 'patient-example-three') {
             instanceDef._instanceMeta.usage = 'Inline';
+            instanceDef._instanceMeta.instanceOfUrl =
+              'http://hl7.org/fhir/sushi-test/StructureDefinition/sample-patient';
           }
           if (instanceDef.id === 'capability-statement-example') {
             instanceDef._instanceMeta.usage = 'Definition';
           }
           if (instanceDef.id === 'patient-example') {
             instanceDef._instanceMeta.usage = 'Example'; // Default would be set to example in import
+            instanceDef._instanceMeta.instanceOfUrl =
+              'http://hl7.org/fhir/sushi-test/StructureDefinition/sample-patient';
           }
           pkgInstances.push(instanceDef);
         }
@@ -240,7 +246,7 @@ describe('IGExporter', () => {
               },
               name: 'Another Patient Example',
               description: 'Another example of a Patient',
-              exampleBoolean: true // Usage set to Example sets this to true
+              exampleCanonical: 'http://hl7.org/fhir/sushi-test/StructureDefinition/sample-patient' // Usage set to Example sets this to InstanceOf url
             },
             {
               reference: {
@@ -261,7 +267,7 @@ describe('IGExporter', () => {
                   valueCode: 'text/plain'
                 }
               ],
-              exampleBoolean: true // No defined Usage on FSH file sets this to true
+              exampleCanonical: 'http://hl7.org/fhir/sushi-test/StructureDefinition/sample-patient' // No defined Usage on FSH file means this is an example
             },
             {
               reference: {
@@ -593,7 +599,7 @@ describe('IGExporter', () => {
             reference: 'Patient/patient-example'
           },
           name: 'Patient Example', // Name from config overrides _instanceMeta.name
-          exampleBoolean: true // No defined Usage on FSH file sets this to true
+          exampleCanonical: 'http://hl7.org/fhir/sushi-test/StructureDefinition/sample-patient' // No defined Usage on FSH file means this is an example
         },
         {
           reference: {
@@ -601,7 +607,7 @@ describe('IGExporter', () => {
           },
           name: 'Patient Example The Second',
           description: 'Another example of a Patient',
-          exampleBoolean: true // Usage set to Example sets this to true
+          exampleCanonical: 'http://hl7.org/fhir/sushi-test/StructureDefinition/sample-patient' // Usage set to Example sets this to InstanceOf url
         },
         {
           reference: {
@@ -837,7 +843,7 @@ describe('IGExporter', () => {
               valueCode: 'text/plain'
             }
           ],
-          exampleBoolean: true, // No defined Usage on FSH file sets this to true
+          exampleCanonical: 'http://hl7.org/fhir/sushi-test/StructureDefinition/sample-patient', // No defined Usage on FSH file means this is an example
           groupingId: 'PatientGroup'
         },
         {
@@ -846,7 +852,7 @@ describe('IGExporter', () => {
           },
           name: 'Another Patient Example',
           description: 'Another example of a Patient',
-          exampleBoolean: true, // Usage set to Example sets this to true
+          exampleCanonical: 'http://hl7.org/fhir/sushi-test/StructureDefinition/sample-patient', // Usage set to Example sets this to InstanceOf url
           groupingId: 'PatientGroup'
         },
         {


### PR DESCRIPTION
Fixes #1243 and completes task [CIMPL-1080](https://standardhealthrecord.atlassian.net/browse/CIMPL-1080).

The configuration option for controlling whether `meta.profile` on Instances automatically gets an entry based on what it is an `InstanceOf` means that you can get examples without anything in their `meta.profile`. But, if they're examples of Profiles from the current package, set `exampleCanonical` in the IG to the URL of that Profile.

The small regression set showed a change in [HL7/davinci-epdx](https://github.com/HL7/davinci-epdx). The [PdexPriorAuth](https://github.com/HL7/davinci-epdx/blob/master/input/fsh/ExamplePriorAuthEOB.fsh) Instance has its `meta.profile` manually set to a versioned URL, which doesn't match the actual version of the [PdexPriorAuthorization](https://github.com/HL7/davinci-epdx/blob/master/input/fsh/ProfilePdexPriorAuthorization.fsh) profile. But, since it's an Instance of PdexPriorAuthorization, we can safely set `exampleCanonical` to PdexPriorAuthorization's URL.