### PR TITLE
Change hl7.fhir.uv.extensions autoload to use 'latest' version

### DIFF
--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -53,6 +53,7 @@ import { EOL } from 'os';
 const NUM_R4_AUTO_DEPENDENCIES = 2;
 const NUM_R5_AUTO_DEPENDENCIES = 3;
 
+// Represents a typical response from packages.fhir.org
 const TERM_PKG_RESPONSE = {
   _id: 'hl7.terminology.r4',
   name: 'hl7.terminology.r4',
@@ -68,6 +69,26 @@ const TERM_PKG_RESPONSE = {
       },
       fhirVersion: 'R4',
       url: 'https://packages.simplifier.net/hl7.terminology.r4/1.2.3-test'
+    }
+  }
+};
+
+// Represents a typical response from packages2.fhir.org (note: not on packages.fhir.org)
+const EXT_PKG_RESPONSE = {
+  _id: 'hl7.fhir.uv.extensions',
+  name: 'hl7.fhir.uv.extensions',
+  'dist-tags': { latest: '4.5.6-test' },
+  versions: {
+    '4.5.6-test': {
+      name: 'hl7.fhir.uv.extensions',
+      date: '2023-03-26T08:46:31-00:00',
+      version: '1.0.0',
+      fhirVersion: '??',
+      kind: '??',
+      count: '18',
+      canonical: 'http://hl7.org/fhir/extensions',
+      description: 'None',
+      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/4.5.6-test'
     }
   }
 };
@@ -118,6 +139,14 @@ describe('Processing', () => {
   beforeEach(() => {
     termNockScope = nock('https://packages.fhir.org').persist().get('/hl7.terminology.r4');
     termNockScope.reply(200, TERM_PKG_RESPONSE);
+    nock('https://packages.fhir.org')
+      .persist()
+      .get('/hl7.fhir.uv.extensions')
+      .reply(404, 'Status Code: 404; Not Found');
+    nock('https://packages2.fhir.org')
+      .persist()
+      .get('/packages/hl7.fhir.uv.extensions')
+      .reply(200, EXT_PKG_RESPONSE);
   });
 
   afterEach(() => {
@@ -732,7 +761,7 @@ describe('Processing', () => {
         expect(loadedPackages).toContain('hl7.fhir.r5.core#5.0.0');
         expect(loadedPackages).toContain('hl7.fhir.uv.tools#current');
         expect(loadedPackages).toContain('hl7.terminology.r4#1.2.3-test');
-        expect(loadedPackages).toContain('hl7.fhir.uv.extensions#current');
+        expect(loadedPackages).toContain('hl7.fhir.uv.extensions#4.5.6-test');
         expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       });
     });
@@ -920,7 +949,7 @@ describe('Processing', () => {
         expect(loadedPackages).toHaveLength(3);
         expect(loadedPackages).toContain('hl7.fhir.uv.tools#current');
         expect(loadedPackages).toContain('hl7.terminology.r4#1.2.3-test');
-        expect(loadedPackages).toContain('hl7.fhir.uv.extensions#current');
+        expect(loadedPackages).toContain('hl7.fhir.uv.extensions#4.5.6-test');
         expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
       });
     });
@@ -933,7 +962,7 @@ describe('Processing', () => {
         expect(loadedPackages).toHaveLength(3);
         expect(loadedPackages).toContain('hl7.fhir.uv.tools#current');
         expect(loadedPackages).toContain('hl7.terminology.r4#1.2.3-test');
-        expect(loadedPackages).toContain('hl7.fhir.uv.extensions#current');
+        expect(loadedPackages).toContain('hl7.fhir.uv.extensions#4.5.6-test');
         expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
       });
     });


### PR DESCRIPTION
With the release of FHIR R5, the `hl7.fhir.uv.extensions` package got its first official release (1.0.0). As per [this conversation](https://chat.fhir.org/#narrow/stream/179239-tooling/topic/New.20Implicit.20Package/near/327872896), SUSHI and IG Publisher should automatically load the _latest published_ version of `hl7.fhir.uv.extensions`. Prior to this PR, we autoloaded the `current` version instead.

Note that I needed to enhance the logic for detecting `latest` so that it will fall back to `packages2.fhir.org` if there is no manifest for the package on `packages.fhir.org` (which is the case for `hl7.fhir.uv.extensions`).

To test this manually, create an R5 IG. When you run the `master` branch, you'll see it pull down the `current` version of `hl7.fhir.uv.extensions`.  When you run this PR branch, you should see it pull down version `1.0.0` instead.

