### PR TITLE
Allow versioned URL in extension contains rule

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -689,13 +689,21 @@ export class StructureDefinitionExporter implements Fishable {
     }
     rule.items.forEach(item => {
       if (item.type) {
-        const extension = this.fishForFHIR(item.type, Type.Extension);
+        // there might be a |version appended to the type, so don't include it while fishing
+        const [typeWithoutVersion, version] = item.type.split('|', 2);
+        const extension = this.fishForFHIR(typeWithoutVersion, Type.Extension);
         if (extension == null) {
           logger.error(
             `Cannot create ${item.name} extension; unable to locate extension definition for: ${item.type}.`,
             rule.sourceInfo
           );
           return;
+        }
+        if (version != null && extension.version != null && version != extension.version) {
+          logger.warn(
+            `${item.type} is based on ${typeWithoutVersion} version ${version}, but SUSHI found version ${extension.version}`,
+            rule.sourceInfo
+          );
         }
         try {
           const slice = element.addSlice(item.name);

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -5595,6 +5595,71 @@ describe('StructureDefinitionExporter R4', () => {
       expect(extensionSliceValueX.type).toEqual([new ElementDefinitionType('Quantity')]);
     });
 
+    it('should apply a ContainsRule of an extension with a versioned URL', () => {
+      const profile = new Profile('MyFamilyHistory');
+      profile.parent = 'FamilyMemberHistory';
+      const containsRule = new ContainsRule('extension');
+      containsRule.items = [
+        {
+          name: 'history',
+          type: 'http://hl7.org/fhir/StructureDefinition/familymemberhistory-type|4.0.1'
+        }
+      ];
+      profile.rules.push(containsRule);
+      doc.profiles.set(profile.name, profile);
+
+      exporter.exportStructDef(profile);
+      const sd = pkg.profiles[0];
+      const extension = sd.elements.find(e => e.id === 'FamilyMemberHistory.extension');
+      const extensionSlice = sd.elements.find(
+        e => e.id === 'FamilyMemberHistory.extension:history'
+      );
+      expect(extension.slicing).toBeDefined();
+      expect(extension.slicing.discriminator.length).toBe(1);
+      expect(extension.slicing.discriminator[0]).toEqual({ type: 'value', path: 'url' });
+      expect(extensionSlice).toBeDefined();
+      expect(extensionSlice.type).toEqual([
+        new ElementDefinitionType('Extension').withProfiles(
+          'http://hl7.org/fhir/StructureDefinition/familymemberhistory-type'
+        )
+      ]);
+      expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
+      expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
+    });
+
+    it('should apply a ContainsRule of an extension with a versioned URL and log a warning if the version does not match', () => {
+      const profile = new Profile('MyFamilyHistory');
+      profile.parent = 'FamilyMemberHistory';
+      const containsRule = new ContainsRule('extension');
+      containsRule.items = [
+        {
+          name: 'history',
+          type: 'http://hl7.org/fhir/StructureDefinition/familymemberhistory-type|1.2.3'
+        }
+      ];
+      profile.rules.push(containsRule);
+      doc.profiles.set(profile.name, profile);
+
+      exporter.exportStructDef(profile);
+      const sd = pkg.profiles[0];
+      const extension = sd.elements.find(e => e.id === 'FamilyMemberHistory.extension');
+      const extensionSlice = sd.elements.find(
+        e => e.id === 'FamilyMemberHistory.extension:history'
+      );
+      expect(extension.slicing).toBeDefined();
+      expect(extension.slicing.discriminator.length).toBe(1);
+      expect(extension.slicing.discriminator[0]).toEqual({ type: 'value', path: 'url' });
+      expect(extensionSlice).toBeDefined();
+      expect(extensionSlice.type).toEqual([
+        new ElementDefinitionType('Extension').withProfiles(
+          'http://hl7.org/fhir/StructureDefinition/familymemberhistory-type'
+        )
+      ]);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        'http://hl7.org/fhir/StructureDefinition/familymemberhistory-type|1.2.3 is based on http://hl7.org/fhir/StructureDefinition/familymemberhistory-type version 1.2.3, but SUSHI found version 4.0.1'
+      );
+    });
+
     it('should apply a ContainsRule of an extension with an overridden URL', () => {
       const profile = new Profile('Foo');
       profile.parent = 'Observation';
@@ -5607,9 +5672,9 @@ describe('StructureDefinitionExporter R4', () => {
       extBar.rules.push(caretValueRule);
       doc.extensions.set('Bar', extBar);
 
-      const constainsRule = new ContainsRule('extension');
-      constainsRule.items = [{ name: 'bar', type: 'Bar' }];
-      profile.rules.push(constainsRule);
+      const containsRule = new ContainsRule('extension');
+      containsRule.items = [{ name: 'bar', type: 'Bar' }];
+      profile.rules.push(containsRule);
 
       const onlyRule = new OnlyRule('extension[bar].value[x]');
       onlyRule.types = [{ type: 'Quantity' }];
@@ -5649,9 +5714,9 @@ describe('StructureDefinitionExporter R4', () => {
       extBar.rules.push(caretValueRule);
       doc.extensions.set('Bar', extBar);
 
-      const constainsRule = new ContainsRule('extension');
-      constainsRule.items = [{ name: 'bar', type: 'Bar' }];
-      profile.rules.push(constainsRule);
+      const containsRule = new ContainsRule('extension');
+      containsRule.items = [{ name: 'bar', type: 'Bar' }];
+      profile.rules.push(containsRule);
 
       const onlyRule = new OnlyRule(
         'extension[http://different-url.com/StructureDefinition/Bar].value[x]'


### PR DESCRIPTION
Completes task [CIMPL-1065](https://standardhealthrecord.atlassian.net/browse/CIMPL-1065).

A version can be specified after a pipe. The version is not used when fishing. If the type and extension both have a version, log a warning if they don't match.

I ran the small regression repo set against this branch, and no changes appeared.