### PR TITLE
Allow versioned URL in extension contains rule (#1251)

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -665,7 +665,9 @@ export class StructureDefinitionExporter implements Fishable {
     }
     rule.items.forEach(item => {
       if (item.type) {
-        const extension = this.fishForFHIR(item.type, Type.Extension);
+        // there might be a |version appended to the type, so don't include it while fishing
+        const [typeWithoutVersion, version] = item.type.split('|', 2);
+        const extension = this.fishForFHIR(typeWithoutVersion, Type.Extension);
         if (extension == null) {
           logger.error(
             `Cannot create ${item.name} extension; unable to locate extension definition for: ${item.type}.`,
@@ -673,12 +675,22 @@ export class StructureDefinitionExporter implements Fishable {
           );
           return;
         }
+        if (version != null && extension.version != null && version != extension.version) {
+          logger.warn(
+            `The ${typeWithoutVersion} extension was specified with version ${version}, but SUSHI found version ${extension.version}`,
+            rule.sourceInfo
+          );
+        }
         try {
+          let profileUrl = extension.url;
+          if (version) {
+            profileUrl += `|${version}`;
+          }
           const slice = element.addSlice(item.name);
           if (!slice.type[0].profile) {
             slice.type[0].profile = [];
           }
-          slice.type[0].profile.push(extension.url);
+          slice.type[0].profile.push(profileUrl);
         } catch (e) {
           // If this is a DuplicateSliceError, and it references the same extension definition,
           // then it is most likely a harmless no-op.  In this case, treat it as a warning.

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -5353,6 +5353,71 @@ describe('StructureDefinitionExporter R4', () => {
       expect(extensionSliceValueX.type).toEqual([new ElementDefinitionType('Quantity')]);
     });
 
+    it('should apply a ContainsRule of an extension with a versioned URL', () => {
+      const profile = new Profile('MyFamilyHistory');
+      profile.parent = 'FamilyMemberHistory';
+      const containsRule = new ContainsRule('extension');
+      containsRule.items = [
+        {
+          name: 'history',
+          type: 'http://hl7.org/fhir/StructureDefinition/familymemberhistory-type|4.0.1'
+        }
+      ];
+      profile.rules.push(containsRule);
+      doc.profiles.set(profile.name, profile);
+
+      exporter.exportStructDef(profile);
+      const sd = pkg.profiles[0];
+      const extension = sd.elements.find(e => e.id === 'FamilyMemberHistory.extension');
+      const extensionSlice = sd.elements.find(
+        e => e.id === 'FamilyMemberHistory.extension:history'
+      );
+      expect(extension.slicing).toBeDefined();
+      expect(extension.slicing.discriminator.length).toBe(1);
+      expect(extension.slicing.discriminator[0]).toEqual({ type: 'value', path: 'url' });
+      expect(extensionSlice).toBeDefined();
+      expect(extensionSlice.type).toEqual([
+        new ElementDefinitionType('Extension').withProfiles(
+          'http://hl7.org/fhir/StructureDefinition/familymemberhistory-type|4.0.1'
+        )
+      ]);
+      expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
+      expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
+    });
+
+    it('should apply a ContainsRule of an extension with a versioned URL and log a warning if the version does not match', () => {
+      const profile = new Profile('MyFamilyHistory');
+      profile.parent = 'FamilyMemberHistory';
+      const containsRule = new ContainsRule('extension');
+      containsRule.items = [
+        {
+          name: 'history',
+          type: 'http://hl7.org/fhir/StructureDefinition/familymemberhistory-type|1.2.3'
+        }
+      ];
+      profile.rules.push(containsRule);
+      doc.profiles.set(profile.name, profile);
+
+      exporter.exportStructDef(profile);
+      const sd = pkg.profiles[0];
+      const extension = sd.elements.find(e => e.id === 'FamilyMemberHistory.extension');
+      const extensionSlice = sd.elements.find(
+        e => e.id === 'FamilyMemberHistory.extension:history'
+      );
+      expect(extension.slicing).toBeDefined();
+      expect(extension.slicing.discriminator.length).toBe(1);
+      expect(extension.slicing.discriminator[0]).toEqual({ type: 'value', path: 'url' });
+      expect(extensionSlice).toBeDefined();
+      expect(extensionSlice.type).toEqual([
+        new ElementDefinitionType('Extension').withProfiles(
+          'http://hl7.org/fhir/StructureDefinition/familymemberhistory-type|1.2.3'
+        )
+      ]);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        'The http://hl7.org/fhir/StructureDefinition/familymemberhistory-type extension was specified with version 1.2.3, but SUSHI found version 4.0.1'
+      );
+    });
+
     it('should apply a ContainsRule of an extension with an overridden URL', () => {
       const profile = new Profile('Foo');
       profile.parent = 'Observation';
@@ -5365,9 +5430,9 @@ describe('StructureDefinitionExporter R4', () => {
       extBar.rules.push(caretValueRule);
       doc.extensions.set('Bar', extBar);
 
-      const constainsRule = new ContainsRule('extension');
-      constainsRule.items = [{ name: 'bar', type: 'Bar' }];
-      profile.rules.push(constainsRule);
+      const containsRule = new ContainsRule('extension');
+      containsRule.items = [{ name: 'bar', type: 'Bar' }];
+      profile.rules.push(containsRule);
 
       const onlyRule = new OnlyRule('extension[bar].value[x]');
       onlyRule.types = [{ type: 'Quantity' }];
@@ -5407,9 +5472,9 @@ describe('StructureDefinitionExporter R4', () => {
       extBar.rules.push(caretValueRule);
       doc.extensions.set('Bar', extBar);
 
-      const constainsRule = new ContainsRule('extension');
-      constainsRule.items = [{ name: 'bar', type: 'Bar' }];
-      profile.rules.push(constainsRule);
+      const containsRule = new ContainsRule('extension');
+      containsRule.items = [{ name: 'bar', type: 'Bar' }];
+      profile.rules.push(containsRule);
 
       const onlyRule = new OnlyRule(
         'extension[http://different-url.com/StructureDefinition/Bar].value[x]'


### PR DESCRIPTION
Completes task [CIMPL-1086](https://standardhealthrecord.atlassian.net/browse/CIMPL-1086).

* Allow versioned URL in extension contains rule

A version can be specified after a pipe. The version is not used when fishing. If the type and extension both have a version, log a warning if they don't match.

* Include version in extension type profile when specified

Modify warning message for version mismatch on extension type profile to be less verbose.

(cherry picked from commit 892ccf8a2a965710e8156bf9e7bbbd3464f07b37)