### PR TITLE
When assigning a value on an Instance, convert primitive to object only if assigned with a slice name

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -554,12 +554,6 @@ export function setPropertyOnInstance(
         if (current[key] == null) current[key] = [];
         sliceName = getSliceName(pathPart);
         if (sliceName) {
-          if (typeof assignedValue !== 'object') {
-            // When an assignedValue is a primitive but also a slice, we convert to an object so that
-            // the sliceName field can be tracked on the object. The _primitive field marks the object
-            // to later be converted back to a primitive by replaceField in cleanResource
-            assignedValue = { assignedValue, _primitive: true };
-          }
           const sliceIndices: number[] = [];
           // Find the indices where slices are placed
           const sliceExtensionUrl = fisher.fishForMetadata(sliceName)?.url;
@@ -614,6 +608,12 @@ export function setPropertyOnInstance(
             current._sliceName = sliceName;
           }
         } else {
+          if (sliceName && typeof assignedValue !== 'object') {
+            // When an assignedValue is a primitive but also a slice, we convert to an object so that
+            // the sliceName field can be tracked on the object. The _primitive field marks the object
+            // to later be converted back to a primitive by replaceField in cleanResource
+            assignedValue = { assignedValue, _primitive: true };
+          }
           if (typeof assignedValue === 'object') {
             Object.assign(current[key][index], assignedValue);
           } else {


### PR DESCRIPTION
Completes part of task [CIMPL-1091](https://standardhealthrecord.atlassian.net/browse/CIMPL-1091).

When assigning a primitive value on an Instance, if it is being assigned as an element in an array, and it has a slice name, convert it into an object immediately before assigning the value. In the previous implementation, the conversion happened as soon as a slice name was encountered anywhere in the assignment path, which meant that the assigned value would be an object even in cases where it was not assigned as an array element. This led to undesired behavior when a later assignment path did not include a slice name, leading to the primitive assignment value being assigned as if it were an object (that is, using `assignComplexValue`).

As an example, consider the following rule:
```
* identifier[myid].value = "123456"
```
Under the previous implementation, as the rule's path was traversed, the assigned value would turn into an object when using the first part of the path `identifier[myid]`, since it contains a slice name. So, the assigned value would be:
```
{
  assignedValue: "123456",
  _primitive: true
}
```
This led to complications later, when another rule would attempt to write to the same array position:
```
* identifier[0].value = "abc"
```
This rule contains no slice names, and the element at the end of the path is not an array element. But since the existing value at `identifier[0].value` is an object, `assignComplexValue` would be called with a string `assignedValue`! So, `assignComplexValue` dutifully performed its job of assigning each property of `assignedValue` to the existing value, leading to this:
```
{
  assignedValue: "123456"
  _primitive: true
  0: "a",
  1: "b",
  2: "c"
}
```

Under the new implementation, the assigned value at path `identifier[myid].value` is not converted into an object, because the last path part `value` does not include a slice name. So, when the later rule on `identifier[0].value` is processed, the existing value is _not_ an object, and the new `assignedValue` is overwritten with a simple `=` assignment.

As a question about desired behavior: as written in the test case, this should happen when the named slice is optional. But what if it's required? If the test case is changed so that the slice's cardinality is `1..1`, no errors are emitted regarding a missing child element. The functions that check for required child elements check cardinality, but not pattern/fixed properties. The usual warnings about not referring to named slices with a numeric index are emitted. Does this make the current implementation insufficient?