### PR TITLE
Log an error when applying type and binding constraints on CodeableReference subelements

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -738,7 +738,11 @@ export class StructureDefinitionExporter implements Fishable {
             if (csURI && !isUri(vsURI)) {
               throw new MismatchedBindingTypeError(rule.valueSet, rule.path, 'ValueSet');
             }
-            element.bindToVS(vsURI, rule.strength as ElementDefinitionBindingStrength);
+            element.bindToVS(
+              vsURI,
+              rule.strength as ElementDefinitionBindingStrength,
+              rule.sourceInfo
+            );
           } else if (rule instanceof ContainsRule) {
             const isExtension =
               element.type?.length === 1 &&

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1006,7 +1006,7 @@ export class ElementDefinition {
       this.parent()?.type?.[0]?.code === 'CodeableReference'
     ) {
       logger.error(
-        'Constraining references on CodeableReference elements should not be applied directly on the .reference element',
+        "Constraining references on a CodeableReference element's underlying .reference path is not allowed. Instead, constrain the references directly on the CodeableReference element.",
         rule.sourceInfo
       );
     }
@@ -1618,7 +1618,7 @@ export class ElementDefinition {
       this.parent()?.type?.[0]?.code === 'CodeableReference'
     ) {
       logger.error(
-        'Binding constraints on CodeableReference elements should not be applied directly on the .concept element.',
+        "Applying value set bindings to a CodeableReference element's underlying .concept path is not allowed. Instead, apply the binding directly to the CodeableReference element.",
         ruleSourceInfo
       );
     }

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1005,13 +1005,10 @@ export class ElementDefinition {
       this.path.endsWith('.reference') &&
       this.parent()?.type?.[0]?.code === 'CodeableReference'
     ) {
-      const errorMessage =
-        'Constraining references on CodeableReference elements should not be applied directly on the .reference element. ' +
-        `The constraint should be applied to the parent element: ${this.path
-          .split('.')
-          .slice(1, -1) // slice of the resource name and the final .concept portion in order to match the recommended FSH path
-          .join('.')}`;
-      logger.error(errorMessage);
+      logger.error(
+        'Constraining references on CodeableReference elements should not be applied directly on the .reference element',
+        rule.sourceInfo
+      );
     }
 
     // Setup a map to store how each existing element type maps to the input types
@@ -1590,11 +1587,16 @@ export class ElementDefinition {
    * @see {@link http://hl7.org/fhir/R4/terminologies.html#strength}
    * @param {string} vsURI - the value set URI to bind
    * @param {string} strength - the strength of the binding (e.g., 'required')
+   * @param {SourceInfo} - optionally include rule.sourceInfo if the binding is coming from a rule
    * @throws {BindingStrengthError} when the binding can't be applied because it is looser than the existing binding
    * @throws {CodedTypeNotFoundError} - when the binding can't be applied because the element is the wrong type
    * @throws {InvalidUriError} when the value set uri is not valid
    */
-  bindToVS(vsURI: string, strength: ElementDefinitionBindingStrength): void {
+  bindToVS(
+    vsURI: string,
+    strength: ElementDefinitionBindingStrength,
+    ruleSourceInfo?: SourceInfo
+  ): void {
     // Check if this is a valid type to be bound against
     const validTypes = this.findTypesByCode(
       'code',
@@ -1615,13 +1617,10 @@ export class ElementDefinition {
       this.path.endsWith('.concept') &&
       this.parent()?.type?.[0]?.code === 'CodeableReference'
     ) {
-      const errorMessage =
-        'Binding constraints on CodeableReference elements should not be applied directly on the .concept element. ' +
-        `The constraint should be applied to the parent element: ${this.path
-          .split('.')
-          .slice(1, -1) // slice of the resource name and the final .concept portion in order to match the recommended FSH path
-          .join('.')}`;
-      logger.error(errorMessage);
+      logger.error(
+        'Binding constraints on CodeableReference elements should not be applied directly on the .concept element.',
+        ruleSourceInfo
+      );
     }
     const strengths = ['example', 'preferred', 'extensible', 'required'];
     // Check if this is a valid strength (if the binding.strength already exists)

--- a/test/fhirtypes/ElementDefinition.bindToVS.test.ts
+++ b/test/fhirtypes/ElementDefinition.bindToVS.test.ts
@@ -222,7 +222,7 @@ describe('ElementDefinition R5', () => {
       expect(concept.binding.strength).toBe('required');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Binding constraints on CodeableReference elements should not be applied directly on the \.concept element/is
+        /Applying value set bindings to a CodeableReference element's underlying \.concept path is not allowed.* directly to the CodeableReference element/is
       );
       expect(loggerSpy.getLastMessage('error')).toMatch(/File: fishy\.fsh.*Line: 6\D*/s);
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);

--- a/test/fhirtypes/ElementDefinition.bindToVS.test.ts
+++ b/test/fhirtypes/ElementDefinition.bindToVS.test.ts
@@ -208,13 +208,23 @@ describe('ElementDefinition R5', () => {
       const addresses = r5CarePlan.elements.find(e => e.id === 'CarePlan.addresses');
       addresses.unfold(fisher);
       const concept = r5CarePlan.elements.find(e => e.id === 'CarePlan.addresses.concept');
-      concept.bindToVS('http://myvaluesets.org/myvs', 'required');
+      const ruleSourceInfo = {
+        file: 'fishy.fsh',
+        location: {
+          startLine: 6,
+          startColumn: 1,
+          endLine: 6,
+          endColumn: 10
+        }
+      };
+      concept.bindToVS('http://myvaluesets.org/myvs', 'required', ruleSourceInfo);
       expect(concept.binding.valueSet).toBe('http://myvaluesets.org/myvs');
       expect(concept.binding.strength).toBe('required');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Binding constraints on CodeableReference elements should not be applied directly on the \.concept element.* addresses/i
+        /Binding constraints on CodeableReference elements should not be applied directly on the \.concept element/is
       );
+      expect(loggerSpy.getLastMessage('error')).toMatch(/File: fishy\.fsh.*Line: 6\D*/s);
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
     });
   });

--- a/test/fhirtypes/ElementDefinition.constrainType.test.ts
+++ b/test/fhirtypes/ElementDefinition.constrainType.test.ts
@@ -1499,7 +1499,9 @@ describe('ElementDefinition R5', () => {
       const reference = r5CarePlan.elements.find(
         e => e.id === 'CarePlan.activity.performedActivity.reference'
       );
-      const onlyRule = new OnlyRule('activity.performedActivity.reference');
+      const onlyRule = new OnlyRule('activity.performedActivity.reference')
+        .withFile('fishy.fsh')
+        .withLocation([6, 1, 6, 20]);
       onlyRule.types = [{ type: 'Practitioner', isReference: true }];
       reference.constrainType(onlyRule, fisher);
       // applies the constraint author specified, even though the spec says this should not be done
@@ -1512,8 +1514,9 @@ describe('ElementDefinition R5', () => {
       // log an error because the author should not have constrained reference directly
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Constraining references on CodeableReference elements should not be applied directly on the \.reference element.* activity\.performedActivity/i
+        /Constraining references on CodeableReference elements should not be applied directly on the \.reference element/is
       );
+      expect(loggerSpy.getLastMessage('error')).toMatch(/File: fishy\.fsh.*Line: 6\D*/s);
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
     });
   });

--- a/test/fhirtypes/ElementDefinition.constrainType.test.ts
+++ b/test/fhirtypes/ElementDefinition.constrainType.test.ts
@@ -1490,5 +1490,31 @@ describe('ElementDefinition R5', () => {
         }).toThrow(/"CodeableReference\(Patient\).*CodeableReference\(.*Condition\)/);
       });
     });
+
+    it('should log an error when trying to constrain the reference portion of a CodeableReference element directly', () => {
+      const performedActivity = r5CarePlan.elements.find(
+        e => e.id === 'CarePlan.activity.performedActivity'
+      );
+      performedActivity.unfold(fisher);
+      const reference = r5CarePlan.elements.find(
+        e => e.id === 'CarePlan.activity.performedActivity.reference'
+      );
+      const onlyRule = new OnlyRule('activity.performedActivity.reference');
+      onlyRule.types = [{ type: 'Practitioner', isReference: true }];
+      reference.constrainType(onlyRule, fisher);
+      // applies the constraint author specified, even though the spec says this should not be done
+      expect(reference.type).toHaveLength(1);
+      expect(reference.type[0]).toEqual(
+        new ElementDefinitionType('Reference').withTargetProfiles(
+          'http://hl7.org/fhir/StructureDefinition/Practitioner'
+        )
+      );
+      // log an error because the author should not have constrained reference directly
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Constraining references on CodeableReference elements should not be applied directly on the \.reference element.* activity\.performedActivity/i
+      );
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+    });
   });
 });

--- a/test/fhirtypes/ElementDefinition.constrainType.test.ts
+++ b/test/fhirtypes/ElementDefinition.constrainType.test.ts
@@ -1514,7 +1514,7 @@ describe('ElementDefinition R5', () => {
       // log an error because the author should not have constrained reference directly
       expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Constraining references on CodeableReference elements should not be applied directly on the \.reference element/is
+        /Constraining references on a CodeableReference element's underlying \.reference path is not allowed.* directly on the CodeableReference element/is
       );
       expect(loggerSpy.getLastMessage('error')).toMatch(/File: fishy\.fsh.*Line: 6\D*/s);
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);


### PR DESCRIPTION
Fixes #1264 

When constraining the `reference` portion of the CodeableReference or applying a binding to the `concept` portion of the CodeableReference, the constraints should be applied to the top level CodeableReference element. If an author tries to add the to the `reference` or `concept` portion of the CodeableReference element directly, log an error.

As it is implemented now, SUSHI will still apply the constraint or binding to the element as the author specified, but this is not correct according the the spec. If we think SUSHI should not even apply the element at all, I can adjust the implementation to throw an error, which will not apply the constraint or binding.