### PR TITLE
Update fhir-package-loader dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15,7 +15,7 @@
         "chalk": "^3.0.0",
         "commander": "^8.2.0",
         "fhir": "^4.9.0",
-        "fhir-package-loader": "^0.3.0",
+        "fhir-package-loader": "^0.4.0",
         "fs-extra": "^8.1.0",
         "html-minifier-terser": "5.1.1",
         "https-proxy-agent": "^5.0.0",
@@ -3548,9 +3548,9 @@
       }
     },
     "node_modules/fhir-package-loader": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.3.0.tgz",
-      "integrity": "sha512-+S1jC8OxFWTeD6Ro+76/29Tk9ffIYIxpOvfEFu1qlnWLNzvTuTI7uM0RjOW79sD1TWv9XWaZRKTIPZooioMUbQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.4.0.tgz",
+      "integrity": "sha512-l7spvyZhSykRtcQkbmuZmsvqh+z31eyY1jVTW1dpE4gd6Ydk/0+rEt9imr2mvFPvRgneB0/GN2gOWfh0pxOoSQ==",
       "dependencies": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",
@@ -10634,9 +10634,9 @@
       }
     },
     "fhir-package-loader": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.3.0.tgz",
-      "integrity": "sha512-+S1jC8OxFWTeD6Ro+76/29Tk9ffIYIxpOvfEFu1qlnWLNzvTuTI7uM0RjOW79sD1TWv9XWaZRKTIPZooioMUbQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.4.0.tgz",
+      "integrity": "sha512-l7spvyZhSykRtcQkbmuZmsvqh+z31eyY1jVTW1dpE4gd6Ydk/0+rEt9imr2mvFPvRgneB0/GN2gOWfh0pxOoSQ==",
       "requires": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "chalk": "^3.0.0",
     "commander": "^8.2.0",
     "fhir": "^4.9.0",
-    "fhir-package-loader": "^0.3.0",
+    "fhir-package-loader": "^0.4.0",
     "fs-extra": "^8.1.0",
     "html-minifier-terser": "5.1.1",
     "https-proxy-agent": "^5.0.0",

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -105,6 +105,9 @@ jest.mock('fhir-package-loader', () => {
     ...original,
     mergeDependency: jest.fn(
       async (packageName: string, version: string, FHIRDefs: FHIRDefinitions) => {
+        if (version === 'latest') {
+          version = await original.lookUpLatestVersion(packageName);
+        }
         // the mock loader can find hl7.fhir.(r2|r3|r4|r5|us).core and auto dependencies
         if (forceLoadErrorOnPackages.indexOf(packageName) !== -1) {
           throw new PackageLoadError(`${packageName}#${version}`);


### PR DESCRIPTION
Completes task [CIMPL-1126](https://standardhealthrecord.atlassian.net/browse/CIMPL-1126).

fhir-package-loader now supports "latest" as a version string, so there is no more need for custom logic to handle it.