### PR TITLE
Log the name of the file that is not processed by SUSHI

### DIFF
--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -68,9 +68,7 @@ export function loadCustomResources(
             resourceJSON = converter.xmlToObj(xml);
           } else {
             invalidFileCount++;
-            logger.info(
-              `File not processed by SUSHI: ${file}`
-            );
+            logger.debug(`File not processed by SUSHI: ${file}`);
             continue;
           }
         } catch (e) {
@@ -101,8 +99,8 @@ export function loadCustomResources(
   if (invalidFileCount > 0) {
     logger.info(
       invalidFileCount > 1
-        ? `Found ${invalidFileCount} files in input/* resource folders that were neither XML nor JSON. These files were not processed as resources by SUSHI.`
-        : `Found ${invalidFileCount} file in an input/* resource folder that was neither XML nor JSON. This file was not processed as a resource by SUSHI.`
+        ? `Found ${invalidFileCount} files in input/* resource folders that were neither XML nor JSON. These files were not processed as resources by SUSHI. To see the unprocessed files in the logs, run SUSHI with the "--log-level debug" flag.`
+        : `Found ${invalidFileCount} file in an input/* resource folder that was neither XML nor JSON. This file was not processed as a resource by SUSHI. To see the unprocessed file in the logs, run SUSHI with the "--log-level debug" flag.`
     );
   }
 }

--- a/src/fhirdefs/load.ts
+++ b/src/fhirdefs/load.ts
@@ -68,6 +68,9 @@ export function loadCustomResources(
             resourceJSON = converter.xmlToObj(xml);
           } else {
             invalidFileCount++;
+            logger.info(
+              `File not processed by SUSHI: ${file}`
+            );
             continue;
           }
         } catch (e) {


### PR DESCRIPTION
Add a log message for each of the files not processed by SUSHI.

I get that the current implementation is faster, and also results in fewer log messages when there are a lot of files in the `input` directory that are not processed by SUSHI. But there should not be that many such files, right? So let's just print the name of each of the files, and then the total count too. It's much more helpful.

Fixes #1306.