### PR TITLE
v3.2.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "fsh-sushi",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fsh-sushi",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15,7 +15,7 @@
         "chalk": "^3.0.0",
         "commander": "^8.2.0",
         "fhir": "^4.9.0",
-        "fhir-package-loader": "^0.5.0",
+        "fhir-package-loader": "^0.6.0",
         "fs-extra": "^8.1.0",
         "html-minifier-terser": "5.1.1",
         "https-proxy-agent": "^5.0.0",
@@ -3535,9 +3535,9 @@
       }
     },
     "node_modules/fhir-package-loader": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.5.0.tgz",
-      "integrity": "sha512-Q+W+l0jNLkpC2lUCIbtJ76P7xUvU3Bady/dcHo6f45q/CpFtvE9DyfeSNIGJZwpI72IIVZe5lvZ+lA58CGoVuA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.6.0.tgz",
+      "integrity": "sha512-rqO2Iiz7rCopNbPbEF59j4jOMScb5fCnf/gdgLFpsWvkGsnalbV/Q+T3E4bRPjdvwhuyZAoUJezwnvEfrQfnZg==",
       "dependencies": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",
@@ -10579,9 +10579,9 @@
       }
     },
     "fhir-package-loader": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.5.0.tgz",
-      "integrity": "sha512-Q+W+l0jNLkpC2lUCIbtJ76P7xUvU3Bady/dcHo6f45q/CpFtvE9DyfeSNIGJZwpI72IIVZe5lvZ+lA58CGoVuA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.6.0.tgz",
+      "integrity": "sha512-rqO2Iiz7rCopNbPbEF59j4jOMScb5fCnf/gdgLFpsWvkGsnalbV/Q+T3E4bRPjdvwhuyZAoUJezwnvEfrQfnZg==",
       "requires": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Sushi Unshortens Short Hand Inputs (FSH Compiler)",
   "scripts": {
     "build": "del-cli dist && tsc && copyfiles -u 3 \"src/utils/init-project/*\" dist/utils/init-project",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "chalk": "^3.0.0",
     "commander": "^8.2.0",
     "fhir": "^4.9.0",
-    "fhir-package-loader": "^0.5.0",
+    "fhir-package-loader": "^0.6.0",
     "fs-extra": "^8.1.0",
     "html-minifier-terser": "5.1.1",
     "https-proxy-agent": "^5.0.0",


### PR DESCRIPTION
This PR upgrades FPL to v0.6.0 and bumps its own version number to 3.2.0. I chose to consider it a minor release since support for wildcard versions is a feature, not a fix.