### PR TITLE
Warn and ignore version when replacing reference

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -940,6 +940,16 @@ export function replaceReferences<T extends AssignmentRule | CaretValueRule>(
           rule.sourceInfo
         );
       }
+    } else {
+      // if we still haven't found anything, there's one more possibility:
+      // the reference includes a version, which it doesn't need.
+      const firstPipe = value.reference.indexOf('|');
+      if (firstPipe > -1) {
+        logger.warn('Reference assignments should not include a version.', rule.sourceInfo);
+        clone = cloneDeep(rule);
+        (clone.value as FshReference).reference = value.reference.slice(0, firstPipe);
+        clone = replaceReferences(clone, tank, fisher);
+      }
     }
   } else if (value instanceof FshCode) {
     const codeSystemMeta = fishForMetadataBestVersion(


### PR DESCRIPTION
Fixes #1298 and completes task [CIMPL-1142](https://standardhealthrecord.atlassian.net/browse/CIMPL-1142).

When assigning a reference, versions should not be included. Ignore the version, warn the user to not do that, and try to fish up the referenced item.

A side effect of this is that it is no longer possible to fish up a locally defined entity by name if its name has a `|` character in it. However, it can still be fished up by id, and also, putting `|` in a name is not recommended by the FHIR spec. Please don't do it.