### PR TITLE
Update FSH version to indicate full support for 3.0.0-ballot

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,7 +34,7 @@ import {
   checkSushiVersion
 } from './utils';
 
-const FSH_VERSION = '3.0.0-ballot (partial)';
+const FSH_VERSION = '3.0.0-ballot';
 
 function logUnexpectedError(e: Error) {
   logger.error(`SUSHI encountered the following unexpected error: ${e.message}`);


### PR DESCRIPTION
Running `ts-node src/app.ts -v` was reporting:
> SUSHI v3.3.0 (implements FHIR Shorthand specification v3.0.0-ballot (partial))

But now it should be:
> SUSHI v3.3.0 (implements FHIR Shorthand specification v3.0.0-ballot)

This PR corrects that. One reviewer should be sufficient.