### PR TITLE
Antlr4 performance workaround

### DIFF
--- a/dev/fixAntlr4.js
+++ b/dev/fixAntlr4.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 /**
  * The purpose of this script is to modify the configuration.
  * of the antlr4 dependency. This is necessary as a workaround

--- a/dev/fixAntlr4.js
+++ b/dev/fixAntlr4.js
@@ -1,0 +1,18 @@
+/**
+ * The purpose of this script is to modify the configuration.
+ * of the antlr4 dependency. This is necessary as a workaround
+ * in order to avoid performance problems from antlr4.
+ * The fix is taken from https://github.com/antlr/antlr4/pull/4323
+ * This script can be removed when the fix is available as part of
+ * a published NPM package.
+ */
+
+const fs = require('fs-extra');
+const path = require('path');
+
+const antlr4BabelPath = path.join(__dirname, '..', 'node_modules', 'antlr4', '.babelrc');
+const babelContents = {
+  presets: ['@babel/preset-env'],
+  targets: 'defaults'
+};
+fs.writeJSONSync(antlr4BabelPath, babelContents);

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "regression": "ts-node regression/run-regression.ts",
     "regression:all": "ts-node regression/run-regression.ts regression/repos-all.txt",
     "prepare": "npm run build",
+    "postinstall": "npm run fixAntlr4",
     "prepublishOnly": "npm run check && npm run fixGrammarTypes",
-    "fixGrammarTypes": "ts-node dev/fixGrammarTypes.ts"
+    "fixGrammarTypes": "ts-node dev/fixGrammarTypes.ts",
+    "fixAntlr4": "node dev/fixAntlr4.js && cd node_modules && cd antlr4 && npm install && npm run build"
   },
   "contributors": [
     "Julia Afeltra <jafeltra@mitre.org>",
@@ -42,7 +44,8 @@
     "dist/**/*.{js,json,d.ts}",
     "dist/ig/files/**/*",
     "dist/utils/init-project/**/*",
-    "antlr/**/*.g4"
+    "antlr/**/*.g4",
+    "dev/fixAntlr4.js"
   ],
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
Completes task [CIMPL-1153](https://standardhealthrecord.atlassian.net/browse/CIMPL-1153).

Modifying the babel configuration and rebuilding antlr4 restores performance to an acceptable speed. This workaround can be removed when the configuration change is available in the official antlr4 package.

To test, change to the PR's branch, then run `npm pack` to create a `.tgz` file for the package. Then, run `npm install -g <package-name>.tgz` to globally install the package. This will add the workaround to your globally installed version of SUSHI. Then, go to any SUSHI project and build it. You should notice that the FSH text import is restored to an acceptable speed and is much faster than in v3.3.0. A [test repo](https://github.com/amosref/GitTest) is available that clearly demonstrates the performance difference.