### PR TITLE
Better antlr4 workaround

### DIFF
--- a/dev/fixAntlr4.js
+++ b/dev/fixAntlr4.js
@@ -11,7 +11,8 @@
 const fs = require('fs-extra');
 const path = require('path');
 const execSync = require('child_process').execSync;
-const antlr4Path = path.dirname(require.resolve(path.join('antlr4', 'package.json')));
+// the directory containing .babelrc is one step up
+const antlr4Path = path.join(path.dirname(require.resolve('antlr4')), '..');
 
 const antlr4BabelPath = path.join(antlr4Path, '.babelrc');
 const babelContents = {

--- a/dev/fixAntlr4.js
+++ b/dev/fixAntlr4.js
@@ -10,10 +10,14 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const execSync = require('child_process').execSync;
+const antlr4Path = path.dirname(require.resolve(path.join('antlr4', 'package.json')));
 
-const antlr4BabelPath = path.join(__dirname, '..', 'node_modules', 'antlr4', '.babelrc');
+const antlr4BabelPath = path.join(antlr4Path, '.babelrc');
 const babelContents = {
   presets: ['@babel/preset-env'],
   targets: 'defaults'
 };
 fs.writeJSONSync(antlr4BabelPath, babelContents);
+
+execSync('npm install', { cwd: antlr4Path });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7,6 +7,7 @@
     "": {
       "name": "fsh-sushi",
       "version": "3.3.1",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -3520,12 +3521,7 @@
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/fhir/-/fhir-4.11.1.tgz",
       "integrity": "sha512-SAKwyqjTpDs2JY4TLSdtyEi9XoyX3KtknXcyJK+9OW8j0tNNHxtx5Nq0Z449g6yUfkdxTHdxsUMFzR1jOk67BQ==",
-      "bundleDependencies": [
-        "lodash",
-        "path",
-        "q",
-        "xml-js"
-      ],
+      "bundleDependencies": ["lodash", "path", "q", "xml-js"],
       "dependencies": {
         "lodash": "^4.17.19",
         "path": "^0.12.7",
@@ -3780,9 +3776,7 @@
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "postinstall": "npm run fixAntlr4",
     "prepublishOnly": "npm run check && npm run fixGrammarTypes",
     "fixGrammarTypes": "ts-node dev/fixGrammarTypes.ts",
-    "fixAntlr4": "node dev/fixAntlr4.js && cd node_modules && cd antlr4 && npm install && npm run build"
+    "fixAntlr4": "node dev/fixAntlr4.js"
   },
   "contributors": [
     "Julia Afeltra <jafeltra@mitre.org>",


### PR DESCRIPTION
The first workaround #1323 for fixing up `antlr4` did not behave correctly under a variety of circumstances, such as when `antlr4` was not contained within SUSHI's `node_modules` directory, or on linux/mac systems. This workaround is more consistent, and should work regardless of OS or other installed packages.