### PR TITLE
Add build command to antlr4 workaround script

### DIFF
--- a/dev/fixAntlr4.js
+++ b/dev/fixAntlr4.js
@@ -22,4 +22,4 @@ const babelContents = {
 fs.writeJSONSync(antlr4BabelPath, babelContents);
 
 execSync('npm install', { cwd: antlr4Path });
-execSync('npm run build', {cwd: antlr4Path });
+execSync('npm run build', { cwd: antlr4Path });

--- a/dev/fixAntlr4.js
+++ b/dev/fixAntlr4.js
@@ -22,3 +22,4 @@ const babelContents = {
 fs.writeJSONSync(antlr4BabelPath, babelContents);
 
 execSync('npm install', { cwd: antlr4Path });
+execSync('npm run build', {cwd: antlr4Path });


### PR DESCRIPTION
The updated script in #1325 should have included the `npm run build` step that was removed from `package.json`.