### PR TITLE
Improve performance with Code Systems and Value Sets

### DIFF
--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -1608,6 +1608,34 @@ describe('ValueSetExporter', () => {
     });
   });
 
+  it('should apply a CaretValueRule with extension slices in the correct order', () => {
+    const valueSet = new FshValueSet('SliceVS');
+    const caretRule1 = new CaretValueRule('');
+    caretRule1.caretPath =
+      'extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger';
+    caretRule1.value = 0;
+    const caretRule2 = new CaretValueRule('');
+    caretRule2.caretPath =
+      'extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status].valueCode';
+    caretRule2.value = new FshCode('draft');
+    valueSet.rules.push(caretRule1, caretRule2);
+    doc.valueSets.set(valueSet.name, valueSet);
+    const exported = exporter.export().valueSets;
+    expect(exported.length).toBe(1);
+    expect(exported[0].extension).toEqual([
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
+        valueInteger: 0
+      },
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status',
+        valueCode: 'draft'
+      }
+    ]);
+    expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+    expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+  });
+
   it('should apply a CaretValueRule that assigns an inline Instance', () => {
     // ValueSet: BreakfastVS
     // Title: "Breakfast Values"

--- a/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-structuredefinition-standards-status.json
+++ b/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-structuredefinition-standards-status.json
@@ -1,0 +1,309 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "structuredefinition-standards-status",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+      "valueCode": "fhir"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+      "valueInteger": 1
+    }
+  ],
+  "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+  "version": "4.3.0",
+  "name": "standards-status",
+  "title": "Standards Status",
+  "status": "draft",
+  "experimental": false,
+  "date": "2014-01-31",
+  "publisher": "Health Level Seven, Inc. - [WG Name] WG",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.org/special/committees/FHIR"
+        }
+      ]
+    }
+  ],
+  "description": "The Current HL7 ballot/Standards status of this artifact.",
+  "fhirVersion": "4.3.0",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "Element"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "snapshot": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "HL7 Ballot/Standards status of artifact",
+        "definition": "The Current HL7 ballot/Standards status of this artifact.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Extension",
+          "min": 0,
+          "max": "*"
+        },
+        "condition": [
+          "ele-1"
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children unless an empty Parameters resource",
+            "expression": "hasValue() or (children().count() > id.count()) or $this is Parameters",
+            "xpath": "@value|f:*|h:div|self::f:Parameters",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          },
+          {
+            "key": "ext-1",
+            "severity": "error",
+            "human": "Must have either extensions or value[x], not both",
+            "expression": "extension.exists() != value.exists()",
+            "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+            "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+          }
+        ],
+        "isModifier": false
+      },
+      {
+        "id": "Extension.id",
+        "path": "Extension.id",
+        "representation": [
+          "xmlAttr"
+        ],
+        "short": "Unique id for inter-element referencing",
+        "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Element.id",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                "valueUrl": "id"
+              }
+            ],
+            "code": "http://hl7.org/fhirpath/System.String"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "n/a"
+          }
+        ]
+      },
+      {
+        "id": "Extension.extension",
+        "path": "Extension.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "description": "Extensions are always sliced by (at least) url",
+          "rules": "open"
+        },
+        "short": "Extension",
+        "definition": "An Extension",
+        "min": 0,
+        "max": "0",
+        "base": {
+          "path": "Element.extension",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          },
+          {
+            "key": "ext-1",
+            "severity": "error",
+            "human": "Must have either extensions or value[x], not both",
+            "expression": "extension.exists() != value.exists()",
+            "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+            "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "representation": [
+          "xmlAttr"
+        ],
+        "short": "identifies the meaning of the extension",
+        "definition": "Source of the definition for the extension code - a logical name or a URL.",
+        "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Extension.url",
+          "min": 1,
+          "max": "1"
+        },
+        "type": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                "valueUrl": "uri"
+              }
+            ],
+            "code": "http://hl7.org/fhirpath/System.String"
+          }
+        ],
+        "fixedUri": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "N/A"
+          }
+        ]
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "short": "Value of extension",
+        "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Extension.value[x]",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "code"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "binding": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/build/StructureDefinition/definition",
+              "valueString": "HL7 Ballot/Standards status of artifact."
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "StandardsStatus"
+            }
+          ],
+          "strength": "required",
+          "description": "HL7 Ballot/Standards status of artifact.",
+          "valueSet": "http://hl7.org/fhir/ValueSet/standards-status"
+        },
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "N/A"
+          }
+        ]
+      }
+    ]
+  },
+  "differential": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "HL7 Ballot/Standards status of artifact",
+        "definition": "The Current HL7 ballot/Standards status of this artifact.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Extension.extension",
+        "path": "Extension.extension",
+        "max": "0"
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "fixedUri": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "code"
+          }
+        ],
+        "binding": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/build/StructureDefinition/definition",
+              "valueString": "HL7 Ballot/Standards status of artifact."
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "StandardsStatus"
+            }
+          ],
+          "strength": "required",
+          "description": "HL7 Ballot/Standards status of artifact.",
+          "valueSet": "http://hl7.org/fhir/ValueSet/standards-status"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR improves the performance when exporting CodeSystems and ValueSets by setting all implied properties from `CaretValueRules` one time during the export.

Instead of setting implied properties one rule at a time each time that `setPropertyOnDefinitionInstance` is called, collect all known slices for all rules once and set all implied properties once. This helps speed up performance because `setImpliedPropertiesOnInstance` is expensive and caused the processing of Code Systems and Value Sets with a lot of `CaretValueRules` to be very slow.

This approach is only implemented for those two exporters right now because to make the same change for StructureDefinition exports required more changes to the code that made things more complex, and there were no repos that I saw that stood out as one that would benefit significantly from that change.

The performance degradation was originally reported on Zulip [here](https://chat.fhir.org/#narrow/stream/215610-shorthand/topic/.E2.9C.94.20Sushi.203.2E0.2E0.2E.20.D0.A2imeout.20300.20seconds/near/363994155) in the [HL7EE/ig-ee-base#master](https://github.com/HL7EE/ig-ee-base/tree/master/) repo. In addition to that repo, when I ran a regression on the old `repos-all` file, there were three other repos that had significant time improvements when using this branch: [HL7/fhir-us-ph-library#master](https://github.com/HL7/fhir-us-ph-library/tree/master/), [HL7/fhir-directory-attestation#master](https://github.com/HL7/fhir-directory-attestation/tree/master/), and [ahdis/chmed#master](https://github.com/ahdis/chmed/tree/master/). There should not be any actual changes to output on this branch.