### PR TITLE
Update type signature for loadAutomaticDependencies

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -6,7 +6,7 @@ import YAML from 'yaml';
 import { execSync } from 'child_process';
 import { YAMLMap, Collection } from 'yaml/types';
 import { isPlainObject, padEnd, sortBy, upperFirst } from 'lodash';
-import { mergeDependency } from 'fhir-package-loader';
+import { mergeDependency, FHIRDefinitions as BaseFHIRDefinitions } from 'fhir-package-loader';
 import { EOL } from 'os';
 import { AxiosResponse } from 'axios';
 import { logger, logMessage } from './FSHLogger';
@@ -342,7 +342,7 @@ export async function loadExternalDependencies(
 export async function loadAutomaticDependencies(
   fhirVersion: string,
   configuredDependencies: ImplementationGuideDependsOn[],
-  defs: FHIRDefinitions
+  defs: BaseFHIRDefinitions
 ): Promise<void> {
   // Load dependencies serially so dependency loading order is predictable and repeatable
   for (const dep of AUTOMATIC_DEPENDENCIES) {


### PR DESCRIPTION
Completes task [CIMPL-1143](https://standardhealthrecord.atlassian.net/browse/CIMPL-1143).

The base FHIRDefinitions from fhir-package-loader can be used in this function. This makes it easier to reuse loadAutomaticDependencies when importing SUSHI as a dependency. This is relevant to GoFSH, but also to anyone else using importing SUSHI.