### PR TITLE
Add Resources to FshToFhir exports

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -232,7 +232,12 @@ export class FSHImporter extends FSHVisitor {
     let [definitions, instances] = [0, 0];
     this.docs.forEach(doc => {
       definitions +=
-        doc.codeSystems.size + doc.extensions.size + doc.profiles.size + doc.valueSets.size;
+        doc.codeSystems.size +
+        doc.extensions.size +
+        doc.profiles.size +
+        doc.valueSets.size +
+        doc.logicals.size +
+        doc.resources.size;
       instances += doc.instances.size;
     });
     logger.info(`Imported ${definitions} definitions and ${instances} instances.`);

--- a/src/run/FshToFhir.ts
+++ b/src/run/FshToFhir.ts
@@ -76,7 +76,15 @@ export async function fshToFhir(
   const outPackage = exportFHIR(tank, defs);
   const fhir: any[] = [];
   (
-    ['profiles', 'extensions', 'instances', 'valueSets', 'codeSystems', 'logicals'] as const
+    [
+      'profiles',
+      'extensions',
+      'instances',
+      'valueSets',
+      'codeSystems',
+      'logicals',
+      'resources'
+    ] as const
   ).forEach(artifactType => {
     outPackage[artifactType].forEach((artifact: { toJSON: (snapshot: boolean) => any }) => {
       fhir.push(artifact.toJSON(false));

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -608,14 +608,34 @@ Long statement:
   });
 
   it('should log info messages during import', () => {
-    const input = '';
+    const input = leftAlign(`
+    Profile: OneProfile
+    Parent: Observation
+
+    Extension: OneExtension
+
+    ValueSet: OneValueSet
+
+    CodeSystem: OneCodeSystem
+
+    Logical: OneLogicalModel
+    Parent: Base
+
+    Resource: OneResource
+    Parent: DomainResource
+
+    Instance: OneInstance
+    InstanceOf: Observation
+    * status = #final
+    * code = #123
+    `);
     importSingleText(input);
     const allLogs = loggerSpy.getAllLogs();
     expect(allLogs.length).toBe(2);
     expect(allLogs[0].level).toMatch(/info/);
     expect(allLogs[0].message).toMatch(/Preprocessed/);
     expect(allLogs[1].level).toMatch(/info/);
-    expect(allLogs[1].message).toMatch(/Imported 0 definitions/);
+    expect(allLogs[1].message).toMatch(/Imported 6 definitions and 1 instance/);
   });
 
   it('should avoid crashing and log error messages because of mismatched input', () => {


### PR DESCRIPTION
This PR does two simple things:

[96ed567](https://github.com/FHIR/sushi/pull/1349/commits/96ed56783605850fabcb3044a9e82cba0067977b) completes the list of FSH entities that are exported from the FshToFhir API. It adds `resources` to be exported.

[5cd87ad](https://github.com/FHIR/sushi/pull/1349/commits/5cd87ade4b74869cf125f93e90d1fd1fe31d5f0e) updates the log message in the FSHImporter to include logicals and resources when counting how many definitions have been imported.