### PR TITLE
Don't return instance rules when looking for id

### DIFF
--- a/src/fshtypes/common.ts
+++ b/src/fshtypes/common.ts
@@ -49,13 +49,18 @@ export function findIdCaretRule(rules: Rule[]): CaretValueRule | undefined {
       rule instanceof CaretValueRule &&
       rule.path === '' &&
       rule.caretPath === 'id' &&
-      typeof rule.value === 'string'
+      typeof rule.value === 'string' &&
+      !rule.isInstance
   ) as CaretValueRule;
 }
 
 export function findIdAssignmentRule(rules: Rule[]): AssignmentRule | undefined {
   return findLast(
     rules,
-    rule => rule instanceof AssignmentRule && rule.path === 'id' && typeof rule.value === 'string'
+    rule =>
+      rule instanceof AssignmentRule &&
+      rule.path === 'id' &&
+      typeof rule.value === 'string' &&
+      !rule.isInstance
   ) as AssignmentRule;
 }

--- a/test/fshtypes/Instance.test.ts
+++ b/test/fshtypes/Instance.test.ts
@@ -15,6 +15,26 @@ describe('Instance', () => {
     });
   });
 
+  describe('#id', () => {
+    it('should return an id set by a string assignment rule', () => {
+      const p = new Instance('MyInstance');
+      const idRule = new AssignmentRule('id');
+      idRule.value = 'different-id';
+      p.rules.push(idRule);
+      expect(p.id).toBe('different-id');
+    });
+
+    it('should not return an id set by an instance assignment rule', () => {
+      const p = new Instance('MyInstance');
+      const idRule = new AssignmentRule('id');
+      idRule.value = 'different-id';
+      idRule.isInstance = true;
+      p.rules.push(idRule);
+      // the id is still the default
+      expect(p.id).toBe('MyInstance');
+    });
+  });
+
   describe('#toFSH', () => {
     it('should produce FSH for the simplest Instance', () => {
       const i = new Instance('MyInstance');

--- a/test/fshtypes/Profile.test.ts
+++ b/test/fshtypes/Profile.test.ts
@@ -1,7 +1,13 @@
 import { EOL } from 'os';
 import 'jest-extended';
 import { Profile } from '../../src/fshtypes/Profile';
-import { CardRule, FlagRule, BindingRule, ObeysRule } from '../../src/fshtypes/rules';
+import {
+  CardRule,
+  FlagRule,
+  BindingRule,
+  ObeysRule,
+  CaretValueRule
+} from '../../src/fshtypes/rules';
 describe('Profile', () => {
   describe('#constructor', () => {
     it('should set the properties correctly', () => {
@@ -10,6 +16,27 @@ describe('Profile', () => {
       expect(p.id).toBe('MyProfile');
       expect(p.parent).toBeUndefined();
       expect(p.rules).toBeEmpty();
+    });
+  });
+
+  describe('#id', () => {
+    it('should return an id set by a string caret rule', () => {
+      const p = new Profile('MyObservation');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = 'different-id';
+      p.rules.push(idRule);
+      expect(p.id).toBe('different-id');
+    });
+
+    it('should not return an id set by an instance caret rule', () => {
+      const p = new Profile('MyObservation');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = 'different-id';
+      idRule.isInstance = true;
+      p.rules.push(idRule);
+      expect(p.id).toBe('MyObservation');
     });
   });
 


### PR DESCRIPTION
Completes task [CIMPL-1169](https://standardhealthrecord.atlassian.net/browse/CIMPL-1169).

When searching for a rule that sets an id, check the rule's isInstance flag. Only return the rule if the flag is not set.

To explain how this was going infinite: an Instance had a rule that looked like this:
```
* id = procedure-death-certification-ut-example1
```
Because the value is unquoted, the rule's `isInstance` flag is set. So, when applying this rule during export, the exporter attempts to fish up an Instance with a matching name or id. When checking the same instance, `findIdAssignmentRule` would find this rule, meaning that it now wants to assign this Instance. But, the Instance must be exported before it can be assigned. So we start exporting the Instance, attempt to apply this rule, and thus we are stuck until the call stack fills up and the computer drops it all on the ground.

This FSH still results in an error, but a much more helpful one: the fisher reports that it can't find an Instance called `procedure-death-certification-ut-example1` to assign for this rule.