### PR TITLE
Allow binding to types with the #can-bind characteristic

### DIFF
--- a/src/errors/CodedTypeNotFoundError.ts
+++ b/src/errors/CodedTypeNotFoundError.ts
@@ -8,7 +8,7 @@ export class CodedTypeNotFoundError extends Error implements Annotated {
     super(
       `Cannot bind value set to ${foundTypes.join(
         ','
-      )}; must be coded (code, Coding, CodeableConcept, Quantity, CodeableReference), the data types (string, uri), or a Logical Model with the #can-bind Characteristic.`
+      )}; must be coded (code, Coding, CodeableConcept, Quantity, CodeableReference), the data types (string, uri), or a logical model with the #can-bind characteristic.`
     );
   }
 }

--- a/src/errors/CodedTypeNotFoundError.ts
+++ b/src/errors/CodedTypeNotFoundError.ts
@@ -8,7 +8,7 @@ export class CodedTypeNotFoundError extends Error implements Annotated {
     super(
       `Cannot bind value set to ${foundTypes.join(
         ','
-      )}; must be coded (code, Coding, CodeableConcept, Quantity, CodeableReference), or the data types (string, uri).`
+      )}; must be coded (code, Coding, CodeableConcept, Quantity, CodeableReference), the data types (string, uri), or a Logical Model with the #can-bind Characteristic.`
     );
   }
 }

--- a/src/export/Package.ts
+++ b/src/export/Package.ts
@@ -192,6 +192,16 @@ export class Package implements Fishable {
           if (metadata.canBeTarget === false && result.inProgress) {
             return undefined;
           }
+
+          metadata.canBind =
+            result.extension?.some(
+              ext => ext?.url === TYPE_CHARACTERISTICS_EXTENSION && ext?.valueCode === 'can-bind'
+            ) ?? false;
+          // if the export is still in progress, there may be unprocessed rules that make this a valid bindable type
+          // return undefined to force the metadata to come from the tank
+          if (metadata.canBeTarget === false && result.inProgress) {
+            return undefined;
+          }
         }
       }
       return metadata;

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -857,7 +857,8 @@ export class StructureDefinitionExporter implements Fishable {
             element.bindToVS(
               vsURI,
               rule.strength as ElementDefinitionBindingStrength,
-              rule.sourceInfo
+              rule.sourceInfo,
+              this.fisher
             );
           } else if (rule instanceof ContainsRule) {
             const isExtension =

--- a/src/fhirdefs/FHIRDefinitions.ts
+++ b/src/fhirdefs/FHIRDefinitions.ts
@@ -114,6 +114,7 @@ export class FHIRDefinitions extends BaseFHIRDefinitions implements Fishable {
     const result = this.fishForFHIR(item, ...types);
     if (result) {
       let canBeTarget: boolean;
+      let canBind: boolean;
       if (result.resourceType === 'StructureDefinition' && result.kind === 'logical') {
         canBeTarget =
           result.extension?.some((ext: any) => {
@@ -122,6 +123,11 @@ export class FHIRDefinitions extends BaseFHIRDefinitions implements Fishable {
               (ext?.url === LOGICAL_TARGET_EXTENSION && ext?.valueBoolean === true)
             );
           }) ?? false;
+        canBind =
+          result.extension?.some(
+            (ext: any) =>
+              ext?.url === TYPE_CHARACTERISTICS_EXTENSION && ext?.valueCode === 'can-bind'
+          ) ?? false;
       }
       return {
         id: result.id as string,
@@ -132,7 +138,8 @@ export class FHIRDefinitions extends BaseFHIRDefinitions implements Fishable {
         abstract: result.abstract as boolean,
         version: result.version as string,
         resourceType: result.resourceType as string,
-        canBeTarget
+        canBeTarget,
+        canBind
       };
     }
   }

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1636,10 +1636,10 @@ export class ElementDefinition {
       'string',
       'uri'
     );
-    const isBindable = this.type?.some(
-      type => fisher?.fishForMetadata(type.code, Type.Logical)?.canBind
-    );
-    if (isEmpty(validTypes) && !isBindable) {
+    const isBindable =
+      validTypes.length ||
+      this.type?.some(type => fisher?.fishForMetadata(type.code, Type.Logical)?.canBind);
+    if (!isBindable) {
       if (this.type?.some(type => fisher?.fishForMetadata(type.code, Type.Logical) != null)) {
         // Only warn if it was from a logical model that doesn't have #can-bind characteristic
         logger.warn(

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1643,7 +1643,7 @@ export class ElementDefinition {
       if (this.type?.some(type => fisher?.fishForMetadata(type.code, Type.Logical) != null)) {
         // Only warn if it was from a logical model that doesn't have #can-bind characteristic
         logger.warn(
-          'Binding on a Logical Model type without the #can-bind Characteristic is discouraged',
+          `Bindings can only be applied to logical model types with the #can-bind characteristic. Update the target logical model to declare the #can-bind characteristic or remove the binding from ${this.id}.`,
           ruleSourceInfo
         );
       } else {

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -419,82 +419,8 @@ export class FSHTank implements Fishable {
           // Ref: https://chat.fhir.org/#narrow/stream/179177-conformance/topic/StructureDefinition.2Etype.20for.20Logical.20Models.2FCustom.20Resources/near/240488388
           const HL7_URL = 'http://hl7.org/fhir/StructureDefinition/';
           meta.sdType = meta.url.startsWith(HL7_URL) ? meta.url.slice(HL7_URL.length) : meta.url;
-          meta.canBeTarget = false;
-          if (result.characteristics.includes('can-be-target')) {
-            meta.canBeTarget = true;
-          } else {
-            // * ^extension[0].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-type-characteristics"
-            // * ^extension[0].valueCode = #can-be-target
-            // or
-            // * ^extension[0].url = "http://hl7.org/fhir/tools/StructureDefinition/logical-target"
-            // * ^extension[0].valueBoolean = true
-            // - give me every caret rule where path is empty and caretPath is extension.url or extension\[\d+\].url
-            // - for each index, tell me what the last url is. so now we have a mapping of "index" to "url"
-            // - filter that down to indices where the url is the one i want. so now i have the indices to check.
-            // - now, give me every caret rule with no path, caretPath is extension.valueWhatever, and the index is in my list
-            // - for each index, tell me what the last value is. that's the actual value.
-            // - if one of them has The Value I Seek, then the overall condition is true
-            // - otherwise, the overall condition is false
-            const extensionUrlRules = result.rules.filter(rule => {
-              return (
-                rule instanceof CaretValueRule &&
-                rule.path === '' &&
-                /^extension(\[\d+\])?\.url$/.test(rule.caretPath)
-              );
-            }) as CaretValueRule[];
-            const extensionUrls = new Map<number, string>();
-            extensionUrlRules.forEach(urlRule => {
-              const match = urlRule.caretPath.match(/^extension(\[(\d+)\])?\.url$/);
-              if (match?.[2]) {
-                extensionUrls.set(parseInt(match[2]), urlRule.value.toString());
-              } else {
-                extensionUrls.set(0, urlRule.value.toString());
-              }
-            });
-            for (const [idx, url] of extensionUrls.entries()) {
-              if (url === TYPE_CHARACTERISTICS_EXTENSION) {
-                const caretPaths = [`extension[${idx}].valueCode`];
-                if (idx === 0) {
-                  caretPaths.push('extension.valueCode');
-                }
-                const valueRule = result.rules
-                  .filter(rule => {
-                    return (
-                      rule instanceof CaretValueRule &&
-                      rule.path === '' &&
-                      caretPaths.includes(rule.caretPath)
-                    );
-                  })
-                  .pop() as CaretValueRule;
-                if (
-                  valueRule &&
-                  valueRule.value instanceof FshCode &&
-                  valueRule.value.code === 'can-be-target'
-                ) {
-                  meta.canBeTarget = true;
-                  break;
-                }
-              } else if (url === LOGICAL_TARGET_EXTENSION) {
-                const caretPaths = [`extension[${idx}].valueBoolean`];
-                if (idx === 0) {
-                  caretPaths.push('extension.valueBoolean');
-                }
-                const valueRule = result.rules
-                  .filter(rule => {
-                    return (
-                      rule instanceof CaretValueRule &&
-                      rule.path === '' &&
-                      caretPaths.includes(rule.caretPath)
-                    );
-                  })
-                  .pop() as CaretValueRule;
-                if (valueRule?.value === true) {
-                  meta.canBeTarget = true;
-                  break;
-                }
-              }
-            }
-          }
+          meta.canBeTarget = hasLogicalCharacteristic(result, 'can-be-target');
+          meta.canBind = hasLogicalCharacteristic(result, 'can-bind');
         }
       } else if (result instanceof FshValueSet || result instanceof FshCodeSystem) {
         meta.url = getUrlFromFshDefinition(result, this.config.canonical);
@@ -522,4 +448,77 @@ export class FSHTank implements Fishable {
     // the FSHTank cannot return FHIR definitions, but we define this function
     // in order to implement the Fishable interface
   }
+}
+
+function hasLogicalCharacteristic(logical: Logical, code: string) {
+  if (logical.characteristics.includes(code)) {
+    return true;
+  } else {
+    // * ^extension[0].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-type-characteristics"
+    // * ^extension[0].valueCode = #can-be-target
+    // or
+    // * ^extension[0].url = "http://hl7.org/fhir/tools/StructureDefinition/logical-target"
+    // * ^extension[0].valueBoolean = true
+    // - give me every caret rule where path is empty and caretPath is extension.url or extension\[\d+\].url
+    // - for each index, tell me what the last url is. so now we have a mapping of "index" to "url"
+    // - filter that down to indices where the url is the one i want. so now i have the indices to check.
+    // - now, give me every caret rule with no path, caretPath is extension.valueWhatever, and the index is in my list
+    // - for each index, tell me what the last value is. that's the actual value.
+    // - if one of them has The Value I Seek, then the overall condition is true
+    // - otherwise, the overall condition is false
+    const extensionUrlRules = logical.rules.filter(rule => {
+      return (
+        rule instanceof CaretValueRule &&
+        rule.path === '' &&
+        /^extension(\[\d+\])?\.url$/.test(rule.caretPath)
+      );
+    }) as CaretValueRule[];
+    const extensionUrls = new Map<number, string>();
+    extensionUrlRules.forEach(urlRule => {
+      const match = urlRule.caretPath.match(/^extension(\[(\d+)\])?\.url$/);
+      if (match?.[2]) {
+        extensionUrls.set(parseInt(match[2]), urlRule.value.toString());
+      } else {
+        extensionUrls.set(0, urlRule.value.toString());
+      }
+    });
+    for (const [idx, url] of extensionUrls.entries()) {
+      if (url === TYPE_CHARACTERISTICS_EXTENSION) {
+        const caretPaths = [`extension[${idx}].valueCode`];
+        if (idx === 0) {
+          caretPaths.push('extension.valueCode');
+        }
+        const valueRule = logical.rules
+          .filter(rule => {
+            return (
+              rule instanceof CaretValueRule &&
+              rule.path === '' &&
+              caretPaths.includes(rule.caretPath)
+            );
+          })
+          .pop() as CaretValueRule;
+        if (valueRule && valueRule.value instanceof FshCode && valueRule.value.code === code) {
+          return true;
+        }
+      } else if (url === LOGICAL_TARGET_EXTENSION && code === 'can-be-target') {
+        const caretPaths = [`extension[${idx}].valueBoolean`];
+        if (idx === 0) {
+          caretPaths.push('extension.valueBoolean');
+        }
+        const valueRule = logical.rules
+          .filter(rule => {
+            return (
+              rule instanceof CaretValueRule &&
+              rule.path === '' &&
+              caretPaths.includes(rule.caretPath)
+            );
+          })
+          .pop() as CaretValueRule;
+        if (valueRule?.value === true) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }

--- a/src/utils/Fishable.ts
+++ b/src/utils/Fishable.ts
@@ -25,6 +25,7 @@ export interface Metadata {
   version?: string;
   instanceUsage?: Instance['usage'];
   canBeTarget?: boolean;
+  canBind?: boolean;
 }
 
 export interface Fishable {

--- a/test/export/Package.test.ts
+++ b/test/export/Package.test.ts
@@ -93,6 +93,24 @@ describe('Package', () => {
       }
     ];
     pkg.logicals.push(logical2);
+    // Logical[3]: IcedCoffee / iced-coffee / iced-coffee
+    const logical3 = new StructureDefinition();
+    logical3.name = 'IcedCoffee';
+    logical3.id = 'iced-coffee';
+    logical3.type = 'iced-coffee';
+    logical3.url = 'http://hl7.org/fhir/us/minimal/StructureDefinition/iced-coffee';
+    logical3.baseDefinition = 'http://hl7.org/fhir/StructureDefinition/Basic';
+    logical3.kind = 'logical';
+    logical3.derivation = 'specialization';
+    logical3.fhirVersion = '4.0.1';
+    logical3.version = '1.0.2';
+    logical3.extension = [
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-type-characteristics',
+        valueCode: 'can-bind'
+      }
+    ];
+    pkg.logicals.push(logical3);
     // Resource[0]: Destination / Destination / Destination
     const resource0 = new StructureDefinition();
     resource0.name = 'Destination';
@@ -723,7 +741,7 @@ describe('Package', () => {
       ).toEqual(poorTasteExtensionByID);
     });
 
-    it('should find logicals that can not be a reference target', () => {
+    it('should find logicals that can not be a reference target or have bindings', () => {
       const wheatBeerLogicalByID = pkg.fishForMetadata('wheat-beer', Type.Logical);
       expect(wheatBeerLogicalByID).toEqual({
         id: 'wheat-beer',
@@ -733,7 +751,8 @@ describe('Package', () => {
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
         resourceType: 'StructureDefinition',
         version: '1.0.0',
-        canBeTarget: false
+        canBeTarget: false,
+        canBind: false
       });
       expect(pkg.fishForMetadata('WheatBeer', Type.Logical)).toEqual(wheatBeerLogicalByID);
       expect(
@@ -754,7 +773,8 @@ describe('Package', () => {
         parent: 'http://hl7.org/fhir/StructureDefinition/Basic',
         resourceType: 'StructureDefinition',
         version: '1.0.0',
-        canBeTarget: true
+        canBeTarget: true,
+        canBind: false
       });
       expect(pkg.fishForMetadata('RedWine', Type.Logical)).toEqual(redWineLogicalByID);
       expect(
@@ -775,7 +795,8 @@ describe('Package', () => {
         parent: 'http://hl7.org/fhir/StructureDefinition/Basic',
         resourceType: 'StructureDefinition',
         version: '1.0.2',
-        canBeTarget: true
+        canBeTarget: true,
+        canBind: false
       });
       expect(pkg.fishForMetadata('SparklingWater', Type.Logical)).toEqual(
         sparklingWaterLogicalByID
@@ -786,6 +807,21 @@ describe('Package', () => {
           Type.Logical
         )
       ).toEqual(sparklingWaterLogicalByID);
+    });
+
+    it('should find logicals that can have a binding using the can-bind extension', () => {
+      const icedCoffeeLogicalById = pkg.fishForMetadata('iced-coffee', Type.Logical);
+      expect(icedCoffeeLogicalById).toEqual({
+        id: 'iced-coffee',
+        name: 'IcedCoffee',
+        sdType: 'iced-coffee',
+        url: 'http://hl7.org/fhir/us/minimal/StructureDefinition/iced-coffee',
+        parent: 'http://hl7.org/fhir/StructureDefinition/Basic',
+        resourceType: 'StructureDefinition',
+        version: '1.0.2',
+        canBeTarget: false,
+        canBind: true
+      });
     });
 
     it('should find resources', () => {
@@ -974,7 +1010,8 @@ describe('Package', () => {
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
         resourceType: 'StructureDefinition',
         version: '1.0.0',
-        canBeTarget: false
+        canBeTarget: false,
+        canBind: false
       });
       expect(pkg.fishForMetadata('WheatBeer')).toEqual(wheatBeerLogicalByID);
       expect(

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -3564,7 +3564,7 @@ describe('StructureDefinitionExporter R4', () => {
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Binding on a Logical Model type without the #can-bind Characteristic is discouraged/
+        /Bindings can only be applied to logical model types with the #can-bind characteristic\. .*remove the binding from FutureResource\.era\./
       );
       expect(loggerSpy.getLastMessage('warn')).toMatch(/File: NoBinding\.fsh.*Line: 5\D*/s);
     });

--- a/test/fhirdefs/FHIRDefinitions.test.ts
+++ b/test/fhirdefs/FHIRDefinitions.test.ts
@@ -511,7 +511,8 @@ describe('FHIRDefinitions', () => {
         version: '0.1.0',
         parent: 'http://hl7.org/fhir/StructureDefinition/Element',
         resourceType: 'StructureDefinition',
-        canBeTarget: false
+        canBeTarget: false,
+        canBind: false
       });
       expect(
         defs.fishForMetadata(
@@ -1007,12 +1008,31 @@ describe('FHIRDefinitions', () => {
         url: 'http://hl7.org/fhir/us/eltss/StructureDefinition/eLTSSServiceModel',
         version: '0.1.0',
         resourceType: 'StructureDefinition',
-        canBeTarget: false
+        canBeTarget: false,
+        canBind: false
       });
       expect(defs.fishForMetadata('ELTSSServiceModel')).toEqual(eLTSSServiceModelByID);
       expect(
         defs.fishForMetadata('http://hl7.org/fhir/us/eltss/StructureDefinition/eLTSSServiceModel')
       ).toEqual(eLTSSServiceModelByID);
+    });
+
+    it('should find logical models with the can-bind type characteristic extension', () => {
+      const bindableLMById = defs.fishForMetadata('BindableLM', Type.Logical);
+      expect(bindableLMById).toEqual({
+        abstract: false,
+        id: 'BindableLM',
+        name: 'BindableLM',
+        sdType: 'http://example.org/StructureDefinition/BindableLM',
+        url: 'http://example.org/StructureDefinition/BindableLM',
+        parent: 'http://hl7.org/fhir/StructureDefinition/Base',
+        resourceType: 'StructureDefinition',
+        canBeTarget: false,
+        canBind: true // BindableLM has can-bind type-characteristics extension
+      });
+      expect(
+        defs.fishForMetadata('http://example.org/StructureDefinition/BindableLM', Type.Logical)
+      ).toEqual(bindableLMById);
     });
   });
 

--- a/test/import/FSHTank.test.ts
+++ b/test/import/FSHTank.test.ts
@@ -834,7 +834,8 @@ describe('FSHTank', () => {
       sdType: 'http://hl7.org/fhir/us/minimal/StructureDefinition/log1',
       parent: 'Element',
       resourceType: 'StructureDefinition',
-      canBeTarget: false
+      canBeTarget: false,
+      canBind: false
     };
     const res1MD: Metadata = {
       id: 'res1',
@@ -1188,7 +1189,8 @@ describe('FSHTank for HL7', () => {
       sdType: 'hl7-log',
       parent: 'Element',
       resourceType: 'StructureDefinition',
-      canBeTarget: false
+      canBeTarget: false,
+      canBind: false
     };
 
     it('should find valid HL7 fish metadata when fishing by id for logical models', () => {

--- a/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-BindableLM.json
+++ b/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-BindableLM.json
@@ -1,0 +1,47 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "BindableLM",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-type-characteristics",
+      "valueCode": "can-bind"
+    }
+  ],
+  "url": "http://example.org/StructureDefinition/BindableLM",
+  "name": "BindableLM",
+  "status": "draft",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "logical",
+  "abstract": false,
+  "type": "http://example.org/StructureDefinition/BindableLM",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Base",
+  "derivation": "specialization",
+  "differential": {
+    "element": [
+      {
+        "id": "BindableLM",
+        "path": "BindableLM"
+      },
+      {
+        "id": "BindableLM.drinks",
+        "path": "BindableLM.drinks",
+        "short": "there are many types of drinks",
+        "definition": "there are many types of drinks",
+        "min": 1,
+        "max": "1",
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #1347.

This PR makes it so that if a Logical Model includes `#can-bind` included in the `Characteristics` or if it has the `type-characteristics` extension with the `can-bind` value, then that type can have bindings applied to it.

If an element tries to add a binding and is not one of the bindable types and one of the allowed types is a Logical Model, SUSHI will now log a warning. If an element tries to add a binding and it is not a bindable type and none of the types are a Logical Model, SUSHI's original behavior is the same and an error is thrown.

I did update the message in that error to reflect that the type can have a binding if it is a logical model with #can-bind because it seemed to make the error message the most correct, but there technically is not a case when that error message will be logged and the fix will be to add `#can-bind` because that case would case the warning to be logged instead. If you disagree with this approach, let me know.

The approach I took to implement this was to add another metadata field `canBind`, similar to `canBeTarget`. After talking to @cmoesel, we might want to consider refactoring this to have one `characteristics` metadata field, which can be an object that has each characteristic's value. We decided that this refactor could be a separate task, but I wanted to note it here for context.