### PR TITLE
Update FPL dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15,7 +15,7 @@
         "chalk": "^3.0.0",
         "commander": "^8.2.0",
         "fhir": "^4.9.0",
-        "fhir-package-loader": "^0.6.0",
+        "fhir-package-loader": "^0.7.0",
         "fs-extra": "^8.1.0",
         "html-minifier-terser": "5.1.1",
         "https-proxy-agent": "^5.0.0",
@@ -3535,9 +3535,9 @@
       }
     },
     "node_modules/fhir-package-loader": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.6.0.tgz",
-      "integrity": "sha512-rqO2Iiz7rCopNbPbEF59j4jOMScb5fCnf/gdgLFpsWvkGsnalbV/Q+T3E4bRPjdvwhuyZAoUJezwnvEfrQfnZg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.7.0.tgz",
+      "integrity": "sha512-Zd9A1yohoCNTMEp/vO4YiBmqvkdQgR7fxx0/7jqa6/Rd8JkYPjyXby137SHNdluRs+Wv1tUdztKfzYNWZv9bYg==",
       "dependencies": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",
@@ -10579,9 +10579,9 @@
       }
     },
     "fhir-package-loader": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.6.0.tgz",
-      "integrity": "sha512-rqO2Iiz7rCopNbPbEF59j4jOMScb5fCnf/gdgLFpsWvkGsnalbV/Q+T3E4bRPjdvwhuyZAoUJezwnvEfrQfnZg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.7.0.tgz",
+      "integrity": "sha512-Zd9A1yohoCNTMEp/vO4YiBmqvkdQgR7fxx0/7jqa6/Rd8JkYPjyXby137SHNdluRs+Wv1tUdztKfzYNWZv9bYg==",
       "requires": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "chalk": "^3.0.0",
     "commander": "^8.2.0",
     "fhir": "^4.9.0",
-    "fhir-package-loader": "^0.6.0",
+    "fhir-package-loader": "^0.7.0",
     "fs-extra": "^8.1.0",
     "html-minifier-terser": "5.1.1",
     "https-proxy-agent": "^5.0.0",

--- a/test/fhirdefs/FHIRDefinitions.test.ts
+++ b/test/fhirdefs/FHIRDefinitions.test.ts
@@ -296,7 +296,7 @@ describe('FHIRDefinitions', () => {
       });
     });
 
-    it('should find definitions by the type order supplied', () => {
+    it('should find definitions by the enforced type order', () => {
       // NOTE: There are two things with id allergyintolerance-clinical (the ValueSet and CodeSystem)
       const allergyStatusValueSetByID = defs.fishForFHIR(
         'allergyintolerance-clinical',
@@ -310,7 +310,7 @@ describe('FHIRDefinitions', () => {
         Type.CodeSystem,
         Type.ValueSet
       );
-      expect(allergyStatusCodeSystemByID.resourceType).toBe('CodeSystem');
+      expect(allergyStatusCodeSystemByID.resourceType).toBe('ValueSet');
     });
 
     it('should not find the definition when the type is not requested', () => {
@@ -801,7 +801,7 @@ describe('FHIRDefinitions', () => {
       });
     });
 
-    it('should find definitions by the type order supplied', () => {
+    it('should find definitions by the enforced type order', () => {
       // NOTE: There are two things with id allergyintolerance-clinical (the ValueSet and CodeSystem)
       const allergyStatusValueSetByID = defs.fishForMetadata(
         'allergyintolerance-clinical',
@@ -818,7 +818,7 @@ describe('FHIRDefinitions', () => {
         Type.ValueSet
       );
       expect(allergyStatusCodeSystemByID.url).toBe(
-        'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical'
+        'http://hl7.org/fhir/ValueSet/allergyintolerance-clinical'
       );
     });
 


### PR DESCRIPTION
Completes task [CIMPL-1184](https://standardhealthrecord.atlassian.net/browse/CIMPL-1184). This FPL update enforces the type order when fishing. A default-settings regression showed no changes.