### PR TITLE
Cimpl 1177 implied codeableconcept

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -22,7 +22,8 @@ import {
   isModifierExtension,
   createUsefulSlices,
   determineKnownSlices,
-  setImpliedPropertiesOnInstance
+  setImpliedPropertiesOnInstance,
+  replaceField
 } from '../fhirtypes/common';
 import { InstanceOfNotDefinedError } from '../errors/InstanceOfNotDefinedError';
 import { AbstractInstanceOfError } from '../errors/AbstractInstanceOfError';
@@ -36,7 +37,6 @@ import {
   isEmpty,
   isEqual,
   isMatch,
-  merge,
   mergeWith,
   padEnd,
   uniq,
@@ -344,8 +344,7 @@ export class InstanceExporter implements Fishable {
         }
       });
     });
-    instanceDef = merge(instanceDef, ruleInstance);
-    return instanceDef;
+    return ruleInstance; // do we even need to clone anymore
   }
 
   /**
@@ -623,6 +622,12 @@ export class InstanceExporter implements Fishable {
           .map(v => {
             const cleanValue = cloneDeep(v);
             delete cleanValue._sliceName;
+            replaceField(
+              cleanValue,
+              (o, p) => p === '_wasImplied',
+              (o, p) => delete o[p],
+              () => false
+            );
             return { name: v._sliceName, value: cleanValue };
           });
         if (namedValues.length) {


### PR DESCRIPTION
Fixes #1341 and completes task [CIMPL-1177](https://standardhealthrecord.atlassian.net/browse/CIMPL-1177).

When a profile element has a `patternCodeableConcept`, make sure that the `coding` it contains doesn't get overwritten in instances of that profile by assignment rules on that element's `coding` sub-element. At the same time, make sure that if there is an assignment on the `coding` that matches the implied value, don't create an extra element for it.

A full regression for this branch has changes on some repos. All of the changes are one of these:
- reordering elements of a `coding` array, which is equally correct
- preserving the coding from a `patternCodeableConcept`, which is more correct
- assigning a `coding` from an instance rule at the same index as the implied value when it matches the pattern, which is more correct

None of these repos require changes in order to handle this PR.

All of that said, while this implementation is correct, it feels a little sloppy. Specifically, adding in a new function for a different way of assigning a complex value is a little awkward, but I needed to do something very slightly different than what I'd get from `Object.assign`. Additionally, the current implementation only really handles `CodeableConcept`, but maybe it should handle any type that contains an array? And that could be basically anything, given that a profile could have a pattern value on `contained`, or the pattern could include extensions. So, maybe this needs to cook a little longer. Please let me know what you think.