### PR TITLE
Add Characteristics to Logical FSH representation

### DIFF
--- a/src/fshtypes/Logical.ts
+++ b/src/fshtypes/Logical.ts
@@ -18,6 +18,18 @@ export class Logical extends FshStructure {
     return 'Logical';
   }
 
+  metadataToFSH(): string {
+    const sdMetadata = super.metadataToFSH();
+    if (this.characteristics.length) {
+      const characteristicsFsh = this.characteristics
+        .map(characteristic => `#${characteristic}`)
+        .join(', ');
+      return `${sdMetadata}${EOL}Characteristics: ${characteristicsFsh}`;
+    } else {
+      return sdMetadata;
+    }
+  }
+
   toFSH(): string {
     const metadataFSH = this.metadataToFSH();
     const rulesFSH = this.rules.map(r => r.toFSH()).join(EOL);

--- a/test/fshtypes/Logical.test.ts
+++ b/test/fshtypes/Logical.test.ts
@@ -33,12 +33,14 @@ describe('Logical', () => {
       input.id = 'my-model';
       input.title = 'My Model';
       input.description = 'A new model for logical modeling.';
+      input.characteristics = ['can-be-target', 'has-size', 'has-length'];
       const expectedResult = [
         'Logical: MyModel',
         'Parent: Base',
         'Id: my-model',
         'Title: "My Model"',
-        'Description: "A new model for logical modeling."'
+        'Description: "A new model for logical modeling."',
+        'Characteristics: #can-be-target, #has-size, #has-length'
       ].join(EOL);
       expect(input.toFSH()).toEqual(expectedResult);
     });


### PR DESCRIPTION
Completes task [CIMPL-1206](https://standardhealthrecord.atlassian.net/browse/CIMPL-1206).

Adds an implementation of `metadataToFSH` to `Logical` so that characteristics will be included in the FSH representation. If no characteristics are present, the keyword is not added.