### PR TITLE
Use rules for most Invariant keywords

### DIFF
--- a/src/fshtypes/Invariant.ts
+++ b/src/fshtypes/Invariant.ts
@@ -47,13 +47,13 @@ export class Invariant extends FshEntity {
       }
     }
     if (this.severity) {
-      resultLines.push(`Severity: ${this.severity}`);
+      resultLines.push(`* severity = ${this.severity}`);
     }
     if (this.expression) {
-      resultLines.push(`Expression: "${fshifyString(this.expression)}"`);
+      resultLines.push(`* expression = "${fshifyString(this.expression)}"`);
     }
     if (this.xpath) {
-      resultLines.push(`XPath: "${fshifyString(this.xpath)}"`);
+      resultLines.push(`* xpath = "${fshifyString(this.xpath)}"`);
     }
     return resultLines.join(EOL);
   }

--- a/test/fshtypes/Invariant.test.ts
+++ b/test/fshtypes/Invariant.test.ts
@@ -1,5 +1,6 @@
 import 'jest-extended';
 import { Invariant, FshCode } from '../../src/fshtypes';
+import { AssignmentRule } from '../../src/fshtypes/rules';
 import { EOL } from 'os';
 
 describe('Invariant', () => {
@@ -33,9 +34,9 @@ describe('Invariant', () => {
       const expectedResult = [
         'Invariant: inv-2',
         'Description: "This is an important condition."',
-        'Severity: #error',
-        'Expression: "requirement.exists()"',
-        'XPath: "f:requirement"'
+        '* severity = #error',
+        '* expression = "requirement.exists()"',
+        '* xpath = "f:requirement"'
       ].join(EOL);
       const result = input.toFSH();
       expect(result).toBe(expectedResult);
@@ -51,9 +52,38 @@ describe('Invariant', () => {
       const expectedResult = [
         'Invariant: inv-3',
         'Description: """Please do this.\nPlease always do this with a \\ character."""',
-        'Severity: #warning',
-        'Expression: "requirement.contains(\\"\\\\\\")"',
-        'XPath: "f:requirement"'
+        '* severity = #warning',
+        '* expression = "requirement.contains(\\"\\\\\\")"',
+        '* xpath = "f:requirement"'
+      ].join(EOL);
+      const result = input.toFSH();
+      expect(result).toBe(expectedResult);
+    });
+
+    it('should produce FSH for an invariant with additional rules', () => {
+      const input = new Invariant('inv-4');
+      input.description = 'This is an important condition.';
+      input.severity = new FshCode('error');
+      input.expression = 'requirement.exists()';
+      input.xpath = 'f:requirement';
+
+      const requirements = new AssignmentRule('requirements');
+      requirements.value = 'This is necessary because it is important.';
+      const extensionUrl = new AssignmentRule('human.extension[0].url');
+      extensionUrl.value = 'http://example.org/SomeExtension';
+      const extensionValue = new AssignmentRule('human.extension[0].valueString');
+      extensionValue.value = 'ExtensionValue';
+      input.rules.push(requirements, extensionUrl, extensionValue);
+
+      const expectedResult = [
+        'Invariant: inv-4',
+        'Description: "This is an important condition."',
+        '* severity = #error',
+        '* expression = "requirement.exists()"',
+        '* xpath = "f:requirement"',
+        '* requirements = "This is necessary because it is important."',
+        '* human.extension[0].url = "http://example.org/SomeExtension"',
+        '* human.extension[0].valueString = "ExtensionValue"'
       ].join(EOL);
       const result = input.toFSH();
       expect(result).toBe(expectedResult);


### PR DESCRIPTION
Helps with [CIMPL-1164](https://standardhealthrecord.atlassian.net/browse/CIMPL-1164).

Description still gets to be a keyword, but all the others use assignment rules. This is the style we want to encourage.