### PR TITLE
Use https to download scripts during sushi init

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -747,7 +747,7 @@ export async function init(): Promise<void> {
     '_updatePublisher.bat',
     '_updatePublisher.sh'
   ]) {
-    const url = `http://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/${script}`;
+    const url = `https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/${script}`;
     try {
       const res = await axiosGet(url);
       fs.writeFileSync(path.join(outputDir, script), res.data);

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -2251,7 +2251,7 @@ describe('Processing', () => {
       expect(copyFileSpy.mock.calls[2][1]).toMatch(/.*ExampleIG.*input.*ignoreWarnings\.txt/);
 
       expect(getSpy.mock.calls).toHaveLength(4);
-      const base = 'http://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
+      const base = 'https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
       expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
       expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
       expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
@@ -2325,7 +2325,7 @@ describe('Processing', () => {
       );
 
       expect(getSpy.mock.calls).toHaveLength(4);
-      const base = 'http://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
+      const base = 'https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
       expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
       expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
       expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');


### PR DESCRIPTION
SUSHI init should use https instead of http to download scripts. The message it logs to the console _says_ https, but the actual network request was over http. The PR fixes that so it uses https to download the IG Publisher scripts.

To test, run `sushi init` using this PR and ensure it successfully downloads the scripts.

Fixes #1393 