### PR TITLE
Use actual version in IG JSON when dependency version is "latest"

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -259,6 +259,13 @@ export class IGExporter {
       return;
     }
 
+    if (dependsOn.version === 'latest') {
+      const dependencyIG = igs.find(ig => ig.packageId === dependsOn.packageId);
+      if (dependencyIG != null) {
+        dependsOn.version = dependencyIG.version;
+      }
+    }
+
     if (dependsOn.uri == null) {
       // Need to find the URI from the IG in the FHIR cache
       const dependencyIG = igs.find(

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -443,6 +443,30 @@ describe('IGExporter', () => {
       ]);
     });
 
+    it('should use the resolved version of a package when a dependency version is "latest"', () => {
+      config.dependencies = [{ packageId: 'hl7.fhir.us.core', version: 'latest' }];
+      exporter.export(tempOut);
+      const igPath = path.join(
+        tempOut,
+        'fsh-generated',
+        'resources',
+        'ImplementationGuide-sushi-test.json'
+      );
+      expect(fs.existsSync(igPath)).toBeTruthy();
+      const content = fs.readJSONSync(igPath);
+      const dependencies: ImplementationGuideDependsOn[] = content.dependsOn;
+      expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
+      // Ensure US Core is exported with the resolved version
+      expect(dependencies).toEqual([
+        {
+          id: 'hl7_fhir_us_core',
+          uri: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core',
+          packageId: 'hl7.fhir.us.core',
+          version: '3.1.0'
+        }
+      ]);
+    });
+
     it('should issue an error when a dependency version is not provided', () => {
       config.dependencies = [
         // NOTE: version is intentionally missing


### PR DESCRIPTION
Fixes #1398 and completes task [CIMPL-1213](https://standardhealthrecord.atlassian.net/browse/CIMPL-1213).

The IG publisher does not support `latest` as a version for packages in the IG's `dependsOn` array. When adding package information to this array, if the version is `latest`, look for the dependency's IG in the available FHIR definitions. If the dependency's IG is found, use the version it specifies.