### PR TITLE
Fix fishing type order to match default order

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1377,11 +1377,11 @@ export class ElementDefinition {
         const version = versionParts.join('|') || null;
         result = fisher.fishForMetadata(
           name,
-          Type.Extension,
-          Type.Profile,
           Type.Resource,
           Type.Logical,
-          Type.Type
+          Type.Type,
+          Type.Profile,
+          Type.Extension
         );
         if (result && version != null && result.version != null && result.version != version) {
           logger.warn(
@@ -1410,11 +1410,11 @@ export class ElementDefinition {
             p instanceof FshCanonical
               ? fisher.fishForMetadata(
                   p.entityName,
-                  Type.Extension,
-                  Type.Profile,
                   Type.Resource,
                   Type.Logical,
-                  Type.Type
+                  Type.Type,
+                  Type.Profile,
+                  Type.Extension
                 )?.url
               : p;
           if (url && !imposeProfiles.includes(url) && !seenUrls.includes(url)) {


### PR DESCRIPTION
Follow-on to #1395 that fixes the type order in two places where types were added, but the order was not fixed before the PR was merged. Oops. Oops!!!!

I ran a full regression, and no changes occurred.