### PR TITLE
Fall back to package.json when resolving "latest" version in IG

### DIFF
--- a/src/fhirdefs/FHIRDefinitions.ts
+++ b/src/fhirdefs/FHIRDefinitions.ts
@@ -25,6 +25,11 @@ export class FHIRDefinitions extends BaseFHIRDefinitions implements Fishable {
     }
   }
 
+  // Expose the package.json files to support extracting the version when "latest" is used
+  allPackageJsons(): any[] {
+    return Array.from(this.packageJsons?.values() ?? []);
+  }
+
   // This getter is only used in tests to verify what supplemental packages are loaded
   get supplementalFHIRPackages(): string[] {
     return flatten(Array.from(this.supplementalFHIRDefinitions.keys()));

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -261,8 +261,15 @@ export class IGExporter {
 
     if (dependsOn.version === 'latest') {
       const dependencyIG = igs.find(ig => ig.packageId === dependsOn.packageId);
-      if (dependencyIG != null) {
+      if (dependencyIG?.version != null) {
         dependsOn.version = dependencyIG.version;
+      } else {
+        const packageJSON = this.fhirDefs
+          .allPackageJsons()
+          .find(p => p.name === dependsOn.packageId);
+        if (packageJSON?.version != null) {
+          dependsOn.version = packageJSON.version;
+        }
       }
     }
 

--- a/test/fhirdefs/FHIRDefinitions.test.ts
+++ b/test/fhirdefs/FHIRDefinitions.test.ts
@@ -1231,4 +1231,16 @@ describe('FHIRDefinitions', () => {
       ]);
     });
   });
+
+  describe('#allPackageJSONs', () => {
+    it('should return all package jsons', () => {
+      const testDefs = new FHIRDefinitions();
+      testDefs.addPackageJson('sushi.test.1', { name: 'sushi.test.1', version: '0.0.1' });
+      testDefs.addPackageJson('sushi.test.2', { name: 'sushi.test.2', version: '0.0.2' });
+      expect(testDefs.allPackageJsons()).toEqual([
+        { name: 'sushi.test.1', version: '0.0.1' },
+        { name: 'sushi.test.2', version: '0.0.2' }
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
When a dependency uses the "latest" version in sushi-config.yaml, SUSHI must populate the generated IG JSON with the real version number (not "latest"). PR #1409 fixes this for dependency packages that contain an ImplementationGuide resource, but it does not address the case were a dependency package does not have an ImplementationGuide resource. In this case, we should fall back to the package's package.json file.

This was raised on Zulip here: https://chat.fhir.org/#narrow/stream/215610-shorthand/topic/automatically.20get.20latest.20dependencies/near/419233182