### PR TITLE
Export new mappings only (or at top of list in snapshot mode)

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -662,6 +662,7 @@ export class StructureDefinitionExporter implements Fishable {
       // for consistency, delete rather than leaving null-valued
       delete structDef.elements[0].modifierExtension;
     }
+    structDef.captureOriginalMapping();
     structDef.elements[0].captureOriginal();
 
     // The remaining logic only pertains to logicals and resources, so return here if otherwise

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -1,6 +1,9 @@
 import upperFirst from 'lodash/upperFirst';
 import cloneDeep from 'lodash/cloneDeep';
 import escapeRegExp from 'lodash/escapeRegExp';
+import differenceWith from 'lodash/differenceWith';
+import isEqual from 'lodash/isEqual';
+import isEmpty from 'lodash/isEmpty';
 import sanitize from 'sanitize-filename';
 import { ElementDefinition, ElementDefinitionType, LooseElementDefJSON } from './ElementDefinition';
 import { Meta } from './specialTypes';
@@ -88,6 +91,7 @@ export class StructureDefinition {
    * A StructureDefinition instance of StructureDefinition itself.  Needed for supporting escape syntax.
    */
   private _sdStructureDefinition: StructureDefinition;
+  private originalMapping: StructureDefinitionMapping[] = [];
 
   validate(): ValidationError[] {
     const validationErrors: ValidationError[] = [];
@@ -404,6 +408,14 @@ export class StructureDefinition {
   }
 
   /**
+   * Capture the current state of the mapping array. This is used to determine
+   * which mappings have been added and which are inherited.
+   */
+  captureOriginalMapping(): void {
+    this.originalMapping = cloneDeep(this.mapping) ?? [];
+  }
+
+  /**
    * Exports the StructureDefinition to a properly formatted FHIR JSON representation.
    * @returns {any} the FHIR JSON representation of the StructureDefinition
    */
@@ -413,8 +425,30 @@ export class StructureDefinition {
     for (const prop of PROPS_AND_UNDERPROPS) {
       // @ts-ignore
       if (this[prop] !== undefined) {
-        // @ts-ignore
-        j[prop] = this[prop];
+        if (prop === 'mapping') {
+          const newMappings: StructureDefinitionMapping[] = differenceWith(
+            this.mapping,
+            this.originalMapping,
+            isEqual
+          );
+          if (snapshot) {
+            const filteredOriginalMappings = this.originalMapping.filter(
+              m =>
+                !newMappings.some(
+                  nm => nm.identity === m.identity && nm.name === m.name && nm.uri === m.uri
+                )
+            );
+            j.mapping = [...newMappings, ...filteredOriginalMappings];
+          } else {
+            j.mapping = newMappings;
+          }
+          if (isEmpty(j.mapping)) {
+            delete j.mapping;
+          }
+        } else {
+          // @ts-ignore
+          j[prop] = this[prop];
+        }
       }
     }
 
@@ -936,6 +970,7 @@ export type PathPart = {
 interface LooseStructDefJSON {
   resourceType: string;
   derivation?: string;
+  mapping?: StructureDefinitionMapping[];
   snapshot?: { element: LooseElementDefJSON[] };
   differential?: { element: LooseElementDefJSON[] };
   inProgress?: boolean;


### PR DESCRIPTION
Fixes #1422.

This PR makes it so that only new mappings are included in the `StructureDefinition.mapping` list when running SUSHI normally (i.e. not with the `--snapshot` flag). When running SUSHI with the `--snapshot -s` flag, the new mappings will appear at the top of the `StructureDefinition.mapping` list.

SUSHI also supports using FSH `Mapping`s to add a new `comment` to existing mappings on the base definition. When that happens, those mappings are included in the list (or moved to the top with `--snapshot`).

I ran a regression for this in both regular (no `-s`) mode and `-s` mode. Without the `-s` (so a regular regression against `master`), there are a lot of changes because every `mapping` list changes. It is either removed entirely or the inherited mapping elements are removed. Running a regression comparing repos with `-s` on results in 35 repos with changes, which are all repos that added mappings, so the mapping array order has changed. There were a couple repos that directly added mappings with assignment rules. This previously overwrote inherited mapping entries, but those mappings are now re-added at the end of the list, so I think this is an improvement.