### PR TITLE
Update alias regex

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -132,7 +132,7 @@ enum Flag {
 const FLAGS = ['MS', 'SU', '?!', 'TU', 'N', 'D'];
 const INDENT_WIDTH = 2;
 const DEFAULT_START_COLUMN = 1;
-const aliasRegex = /^\$?[a-zA-z0-9_\-\.]*$/;
+const aliasRegex = /^\$?[a-zA-z0-9_\-\.]+$/;
 
 function unescapeUnicode(match: string, p1: string): string {
   return JSON.parse(`"\\${p1}"`);


### PR DESCRIPTION
Small PR to update the Alias regular expression to require at least one other character besides `$`.

I ran a regression and there were three repos that actually did have Aliases that were just `$`, so they get a new warning now. The three repos are [joofio/ufis-ig#main](https://github.com/joofio/ufis-ig/tree/main/), [joofio/ufis-swe-ig#main](https://github.com/joofio/ufis-swe-ig/tree/main/), and [hl7-eu/gravitate-health#master](https://github.com/hl7-eu/gravitate-health/tree/master/), if you wanted to run a regression on them specifically. The first two also had aliases with unsupported characters, so it would already have been receiving at least one new warning before this PR.