### PR TITLE
Override sushi-config options from command line

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -73,8 +73,12 @@ async function app() {
     )
     .option('-s, --snapshot', 'generate snapshot in Structure Definition output', false)
     .option(
-      '-c, --config <config...>',
-      "override elements in sushi-config.yaml (supported: 'version', 'status', 'releaselabel') (eg: --config 'status:draft')"
+      '-c, --config <config>',
+      "override elements in sushi-config.yaml (supported: 'version', 'status', 'releaselabel') (eg: --config 'status:draft')",
+      (value: string, previous = {}) => {
+        const [k,...v] = value.split(':');
+        return Object.assign(previous, {[k]: v.join(':')});
+      }
     )
     .action(async function (projectPath, options) {
       setLogLevel(options);
@@ -179,7 +183,7 @@ async function runBuild(input: string, program: OptionValues, helpText: string) 
     logger.info(`  --out ${path.resolve(program.out)}`);
   }
   if (program.config) {
-    logger.info(`  --config ${program.config}`);
+    Object.entries(program.config).forEach(([k, v]) => logger.info(`  --config ${k}:${v}`));
   }
   logger.info(`  ${path.resolve(input || '.')}`);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -72,7 +72,10 @@ async function app() {
       false
     )
     .option('-s, --snapshot', 'generate snapshot in Structure Definition output', false)
-    .option('-c, --config <config...>', 'override elements in sushi-config.yaml (supported: \'version\', \'status\', \'releaselabel\') (eg: --config \'status:draft\')')
+    .option(
+      '-c, --config <config...>',
+      "override elements in sushi-config.yaml (supported: 'version', 'status', 'releaselabel') (eg: --config 'status:draft')"
+    )
     .action(async function (projectPath, options) {
       setLogLevel(options);
       await runBuild(projectPath, options, program.helpInformation()).catch(logUnexpectedError);

--- a/src/app.ts
+++ b/src/app.ts
@@ -74,10 +74,10 @@ async function app() {
     .option('-s, --snapshot', 'generate snapshot in Structure Definition output', false)
     .option(
       '-c, --config <config>',
-      "override elements in sushi-config.yaml (supported: 'version', 'status', 'releaselabel') (eg: --config 'status:draft')",
+      "override elements in sushi-config.yaml (supported: 'version', 'status', 'releaselabel') (eg: --config status:draft)",
       (value: string, previous = {}) => {
-        const [k,...v] = value.split(':');
-        return Object.assign(previous, {[k]: v.join(':')});
+        const [k, ...v] = value.split(':');
+        return Object.assign(previous, { [k]: v.join(':') });
       }
     )
     .action(async function (projectPath, options) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -72,9 +72,7 @@ async function app() {
       false
     )
     .option('-s, --snapshot', 'generate snapshot in Structure Definition output', false)
-    .option('-igv, --ig-version <version>', 'override the version in sushi-config.yaml')
-    .option('-igs, --ig-status <status>', 'override the status in sushi-config.yaml')
-    .option('-igrl, --ig-releaselabel <releaselabel>', 'override the releaselabel in sushi-config.yaml')
+    .option('-c, --config <config...>', 'override elements in sushi-config.yaml (supported: \'version\', \'status\', \'releaselabel\') (eg: --config \'status:draft\')')
     .action(async function (projectPath, options) {
       setLogLevel(options);
       await runBuild(projectPath, options, program.helpInformation()).catch(logUnexpectedError);
@@ -177,14 +175,8 @@ async function runBuild(input: string, program: OptionValues, helpText: string) 
   if (program.out) {
     logger.info(`  --out ${path.resolve(program.out)}`);
   }
-  if (program.igVersion) {
-    logger.info(`  --ig-version ${program.igVersion}`);
-  }
-  if (program.igStatus) {
-    logger.info(`  --ig-status ${program.igStatus}`);
-  }
-  if (program.igReleaselabel) {
-    logger.info(`  --ig-releaselabel ${program.igReleaselabel}`);
+  if (program.config) {
+    logger.info(`  --config ${program.config}`);
   }
   logger.info(`  ${path.resolve(input || '.')}`);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,7 +32,8 @@ import {
   setIgnoredWarnings,
   getLocalSushiVersion,
   checkSushiVersion,
-  writeFSHIndex
+  writeFSHIndex,
+  updateConfig
 } from './utils';
 
 const FSH_VERSION = '3.0.0-ballot';
@@ -71,6 +72,9 @@ async function app() {
       false
     )
     .option('-s, --snapshot', 'generate snapshot in Structure Definition output', false)
+    .option('-igv, --ig-version <version>', 'override the version in sushi-config.yaml')
+    .option('-igs, --ig-status <status>', 'override the status in sushi-config.yaml')
+    .option('-igrl, --ig-releaselabel <releaselabel>', 'override the releaselabel in sushi-config.yaml')
     .action(async function (projectPath, options) {
       setLogLevel(options);
       await runBuild(projectPath, options, program.helpInformation()).catch(logUnexpectedError);
@@ -173,6 +177,15 @@ async function runBuild(input: string, program: OptionValues, helpText: string) 
   if (program.out) {
     logger.info(`  --out ${path.resolve(program.out)}`);
   }
+  if (program.igVersion) {
+    logger.info(`  --ig-version ${program.igVersion}`);
+  }
+  if (program.igStatus) {
+    logger.info(`  --ig-status ${program.igStatus}`);
+  }
+  if (program.igReleaselabel) {
+    logger.info(`  --ig-releaselabel ${program.igReleaselabel}`);
+  }
   logger.info(`  ${path.resolve(input || '.')}`);
 
   const sushiVersions = await checkSushiVersion();
@@ -251,6 +264,7 @@ async function runBuild(input: string, program: OptionValues, helpText: string) 
       process.exit(0);
     }
     config = readConfig(originalInput);
+    updateConfig(config, program);
     tank = fillTank(rawFSH, config);
   } catch (e) {
     // If no errors have been logged yet, log this exception so the user knows why we're exiting

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -224,38 +224,24 @@ export function readConfig(input: string): Configuration {
 
 export function updateConfig(config: Configuration, program: OptionValues): void {
   if (program.config) {
-    const configOverrides = parseConfigOverrides(program.config);
-
-    if (configOverrides.version) {
-      config.version = configOverrides.version;
+    if (program.config.version) {
+      config.version = program.config.version;
     }
-    if (configOverrides.status) {
-      config.status = configOverrides.status;
+    if (program.config.status) {
+      config.status = program.config.status;
     }
-    if (configOverrides.releaselabel) {
+    if (program.config.releaselabel) {
       const labelIndex = config.parameters.findIndex(p => p.code === 'releaselabel');
       if (labelIndex !== -1) {
-        config.parameters[labelIndex].value = configOverrides.releaselabel;
+        config.parameters[labelIndex].value = program.config.releaselabel;
       } else {
         config.parameters.push({
           code: 'releaselabel',
-          value: configOverrides.releaselabel
+          value: program.config.releaselabel
         });
       }
     }
   }
-}
-
-function parseConfigOverrides(config: string[]) {
-  return config
-    .map(c => {
-      const pos = c.indexOf(':');
-      return [c.substring(0, pos), c.substring(pos + 1)];
-    })
-    .reduce((acc, cur) => {
-      acc[cur[0]] = cur[1];
-      return acc;
-    }, {} as any);
 }
 
 export async function updateExternalDependencies(config: Configuration): Promise<boolean> {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -223,23 +223,42 @@ export function readConfig(input: string): Configuration {
 }
 
 export function updateConfig(config: Configuration, program: OptionValues): void {
-  if (program.igVersion) {
-    config.version = program.igVersion;
-  }
-  if (program.igStatus) {
-    config.status = program.igStatus;
-  }
-  if (program.igReleaselabel) {
-    const labelIndex = config.parameters.findIndex(p => p.code === 'releaselabel');
-    if(labelIndex !== -1){
-      config.parameters[labelIndex].value = program.igReleaselabel;
-    } else {
-      config.parameters.push({
-        code: 'releaselabel',
-        value: program.igReleaselabel
-      });
+  if(program.config){
+    const configOverrides = parseConfigOverrides(program.config);
+    
+    if (configOverrides.version) {
+      config.version = configOverrides.version;
     }
-  }
+    if (configOverrides.status) {
+      config.status = configOverrides.status;
+    }
+    if (configOverrides.releaselabel) {
+      const labelIndex = config.parameters.findIndex(p => p.code === 'releaselabel');
+      if(labelIndex !== -1){
+        config.parameters[labelIndex].value = configOverrides.releaselabel;
+      } else {
+        config.parameters.push({
+          code: 'releaselabel',
+          value: configOverrides.releaselabel
+        });
+      }
+    }
+  }  
+}
+
+function parseConfigOverrides(config: string[]) {
+  
+  
+
+  return config
+    .map(c => {
+      const pos = c.indexOf(':');
+      return [c.substring(0, pos), c.substring(pos+1)];
+    })
+    .reduce((acc, cur) => {
+      acc[cur[0]] = cur[1];
+      return acc;
+    }, {} as any);
 }
 
 export async function updateExternalDependencies(config: Configuration): Promise<boolean> {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -223,9 +223,9 @@ export function readConfig(input: string): Configuration {
 }
 
 export function updateConfig(config: Configuration, program: OptionValues): void {
-  if(program.config){
+  if (program.config) {
     const configOverrides = parseConfigOverrides(program.config);
-    
+
     if (configOverrides.version) {
       config.version = configOverrides.version;
     }
@@ -234,7 +234,7 @@ export function updateConfig(config: Configuration, program: OptionValues): void
     }
     if (configOverrides.releaselabel) {
       const labelIndex = config.parameters.findIndex(p => p.code === 'releaselabel');
-      if(labelIndex !== -1){
+      if (labelIndex !== -1) {
         config.parameters[labelIndex].value = configOverrides.releaselabel;
       } else {
         config.parameters.push({
@@ -243,17 +243,14 @@ export function updateConfig(config: Configuration, program: OptionValues): void
         });
       }
     }
-  }  
+  }
 }
 
 function parseConfigOverrides(config: string[]) {
-  
-  
-
   return config
     .map(c => {
       const pos = c.indexOf(':');
-      return [c.substring(0, pos), c.substring(pos+1)];
+      return [c.substring(0, pos), c.substring(pos + 1)];
     })
     .reduce((acc, cur) => {
       acc[cur[0]] = cur[1];

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -25,6 +25,7 @@ import { axiosGet } from './axiosUtils';
 import { ImplementationGuideDependsOn } from '../fhirtypes';
 import { FHIRVersionName, getFHIRVersionInfo } from '../utils/FHIRVersionUtils';
 import table from 'text-table';
+import { OptionValues } from 'commander';
 
 const EXT_PKG_TO_FHIR_PKG_MAP: { [key: string]: string } = {
   'hl7.fhir.extensions.r2': 'hl7.fhir.r2.core#1.0.2',
@@ -219,6 +220,26 @@ export function readConfig(input: string): Configuration {
     throw Error;
   }
   return config;
+}
+
+export function updateConfig(config: Configuration, program: OptionValues): void {
+  if (program.igVersion) {
+    config.version = program.igVersion;
+  }
+  if (program.igStatus) {
+    config.status = program.igStatus;
+  }
+  if (program.igReleaselabel) {
+    const labelIndex = config.parameters.findIndex(p => p.code === 'releaselabel');
+    if(labelIndex !== -1){
+      config.parameters[labelIndex].value = program.igReleaselabel;
+    } else {
+      config.parameters.push({
+        code: 'releaselabel',
+        value: program.igReleaselabel
+      });
+    }
+  }
 }
 
 export async function updateExternalDependencies(config: Configuration): Promise<boolean> {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -490,10 +490,8 @@ describe('Processing', () => {
     it('should update the config with the command line options', () => {
       const input = path.join(__dirname, 'fixtures', 'valid-yaml');
       const config = readConfig(input);
-      updateConfig(config, { 
-        igVersion: '1.2.3',
-        igStatus: 'draft',
-        igReleaselabel: 'qa-preview'
+      updateConfig(config, {
+        config: ['version:1.2.3', 'status:draft','releaselabel:qa-preview'],
        });
 
       expect(config).toEqual({
@@ -533,6 +531,105 @@ describe('Processing', () => {
           {
             code: 'releaselabel',
             value: 'qa-preview'
+          }
+        ]
+      });
+    });
+
+    it('should ignore unsupported elements', () => {
+      const input = path.join(__dirname, 'fixtures', 'valid-yaml');
+      const config = readConfig(input);
+      updateConfig(config, {
+        config: ['version:1.2.3', 'title:unsupported'],
+       });
+
+      expect(config).toEqual({
+        filePath: path.join(__dirname, 'fixtures', 'valid-yaml', 'sushi-config.yaml'),
+        id: 'sushi-test',
+        packageId: 'sushi-test',
+        canonical: 'http://hl7.org/fhir/sushi-test',
+        url: 'http://hl7.org/fhir/sushi-test/ImplementationGuide/sushi-test',
+        version: '1.2.3',
+        name: 'FSHTestIG',
+        title: 'FSH Test IG',
+        status: 'active',
+        contact: [
+          {
+            name: 'Bill Cod',
+            telecom: [
+              { system: 'url', value: 'https://capecodfishermen.org/' },
+              { system: 'email', value: 'cod@reef.gov' }
+            ]
+          }
+        ],
+        description: 'Provides a simple example of how FSH can be used to create an IG',
+        license: 'CC0-1.0',
+        fhirVersion: ['4.0.1'],
+        dependencies: [
+          { packageId: 'hl7.fhir.us.core', version: '3.1.0' },
+          { packageId: 'hl7.fhir.uv.vhdir', version: 'current' }
+        ],
+        FSHOnly: false,
+        applyExtensionMetadataToRoot: true,
+        instanceOptions: { setMetaProfile: 'always', setId: 'always', manualSliceOrdering: false },
+        parameters: [
+          {
+            code: 'copyrightyear',
+            value: '2020'
+          },
+          {
+            code: 'releaselabel',
+            value: 'CI Build'
+          }
+        ]
+      });      
+    });
+
+    it('should support values with colons', () => {
+      const input = path.join(__dirname, 'fixtures', 'valid-yaml');
+      const config = readConfig(input);
+      updateConfig(config, {
+        //not a valid semver, just to make a point
+        config: ['version:1.2.3-beta:1'],
+       });
+
+      expect(config).toEqual({
+        filePath: path.join(__dirname, 'fixtures', 'valid-yaml', 'sushi-config.yaml'),
+        id: 'sushi-test',
+        packageId: 'sushi-test',
+        canonical: 'http://hl7.org/fhir/sushi-test',
+        url: 'http://hl7.org/fhir/sushi-test/ImplementationGuide/sushi-test',
+        version: '1.2.3-beta:1',
+        name: 'FSHTestIG',
+        title: 'FSH Test IG',
+        status: 'active',
+        contact: [
+          {
+            name: 'Bill Cod',
+            telecom: [
+              { system: 'url', value: 'https://capecodfishermen.org/' },
+              { system: 'email', value: 'cod@reef.gov' }
+            ]
+          }
+        ],
+        description: 'Provides a simple example of how FSH can be used to create an IG',
+        license: 'CC0-1.0',
+        fhirVersion: ['4.0.1'],
+        dependencies: [
+          { packageId: 'hl7.fhir.us.core', version: '3.1.0' },
+          { packageId: 'hl7.fhir.uv.vhdir', version: 'current' }
+        ],
+        FSHOnly: false,
+        applyExtensionMetadataToRoot: true,
+        instanceOptions: { setMetaProfile: 'always', setId: 'always', manualSliceOrdering: false },
+        parameters: [
+          {
+            code: 'copyrightyear',
+            value: '2020'
+          },
+          {
+            code: 'releaselabel',
+            value: 'CI Build'
           }
         ]
       });

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -31,7 +31,8 @@ import {
   getLocalSushiVersion,
   getLatestSushiVersion,
   checkSushiVersion,
-  writeFSHIndex
+  writeFSHIndex,
+  updateConfig
 } from '../../src/utils/Processing';
 import { FHIRDefinitions } from '../../src/fhirdefs';
 import { Package } from '../../src/export';
@@ -482,6 +483,59 @@ describe('Processing', () => {
       expect(loggerSpy.getLastMessage('error')).toMatch(
         /must specify a supported version of FHIR/s
       );
+    });
+  });
+
+  describe('#updateConfig', () => {
+    it('should update the config with the command line options', () => {
+      const input = path.join(__dirname, 'fixtures', 'valid-yaml');
+      const config = readConfig(input);
+      updateConfig(config, { 
+        igVersion: '1.2.3',
+        igStatus: 'draft',
+        igReleaselabel: 'qa-preview'
+       });
+
+      expect(config).toEqual({
+        filePath: path.join(__dirname, 'fixtures', 'valid-yaml', 'sushi-config.yaml'),
+        id: 'sushi-test',
+        packageId: 'sushi-test',
+        canonical: 'http://hl7.org/fhir/sushi-test',
+        url: 'http://hl7.org/fhir/sushi-test/ImplementationGuide/sushi-test',
+        version: '1.2.3',
+        name: 'FSHTestIG',
+        title: 'FSH Test IG',
+        status: 'draft',
+        contact: [
+          {
+            name: 'Bill Cod',
+            telecom: [
+              { system: 'url', value: 'https://capecodfishermen.org/' },
+              { system: 'email', value: 'cod@reef.gov' }
+            ]
+          }
+        ],
+        description: 'Provides a simple example of how FSH can be used to create an IG',
+        license: 'CC0-1.0',
+        fhirVersion: ['4.0.1'],
+        dependencies: [
+          { packageId: 'hl7.fhir.us.core', version: '3.1.0' },
+          { packageId: 'hl7.fhir.uv.vhdir', version: 'current' }
+        ],
+        FSHOnly: false,
+        applyExtensionMetadataToRoot: true,
+        instanceOptions: { setMetaProfile: 'always', setId: 'always', manualSliceOrdering: false },
+        parameters: [
+          {
+            code: 'copyrightyear',
+            value: '2020'
+          },
+          {
+            code: 'releaselabel',
+            value: 'qa-preview'
+          }
+        ]
+      });
     });
   });
 

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -491,8 +491,8 @@ describe('Processing', () => {
       const input = path.join(__dirname, 'fixtures', 'valid-yaml');
       const config = readConfig(input);
       updateConfig(config, {
-        config: ['version:1.2.3', 'status:draft','releaselabel:qa-preview'],
-       });
+        config: ['version:1.2.3', 'status:draft', 'releaselabel:qa-preview']
+      });
 
       expect(config).toEqual({
         filePath: path.join(__dirname, 'fixtures', 'valid-yaml', 'sushi-config.yaml'),
@@ -540,8 +540,8 @@ describe('Processing', () => {
       const input = path.join(__dirname, 'fixtures', 'valid-yaml');
       const config = readConfig(input);
       updateConfig(config, {
-        config: ['version:1.2.3', 'title:unsupported'],
-       });
+        config: ['version:1.2.3', 'title:unsupported']
+      });
 
       expect(config).toEqual({
         filePath: path.join(__dirname, 'fixtures', 'valid-yaml', 'sushi-config.yaml'),
@@ -582,7 +582,7 @@ describe('Processing', () => {
             value: 'CI Build'
           }
         ]
-      });      
+      });
     });
 
     it('should support values with colons', () => {
@@ -590,8 +590,8 @@ describe('Processing', () => {
       const config = readConfig(input);
       updateConfig(config, {
         //not a valid semver, just to make a point
-        config: ['version:1.2.3-beta:1'],
-       });
+        config: ['version:1.2.3-beta:1']
+      });
 
       expect(config).toEqual({
         filePath: path.join(__dirname, 'fixtures', 'valid-yaml', 'sushi-config.yaml'),

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -491,7 +491,7 @@ describe('Processing', () => {
       const input = path.join(__dirname, 'fixtures', 'valid-yaml');
       const config = readConfig(input);
       updateConfig(config, {
-        config: ['version:1.2.3', 'status:draft', 'releaselabel:qa-preview']
+        config: {version: '1.2.3', status: 'draft', releaselabel: 'qa-preview'}
       });
 
       expect(config).toEqual({
@@ -540,7 +540,7 @@ describe('Processing', () => {
       const input = path.join(__dirname, 'fixtures', 'valid-yaml');
       const config = readConfig(input);
       updateConfig(config, {
-        config: ['version:1.2.3', 'title:unsupported']
+        config: {version: '1.2.3', something: 'unsupported'}
       });
 
       expect(config).toEqual({
@@ -590,7 +590,7 @@ describe('Processing', () => {
       const config = readConfig(input);
       updateConfig(config, {
         //not a valid semver, just to make a point
-        config: ['version:1.2.3-beta:1']
+        config: {version:'1.2.3-beta:1'}
       });
 
       expect(config).toEqual({

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -491,7 +491,7 @@ describe('Processing', () => {
       const input = path.join(__dirname, 'fixtures', 'valid-yaml');
       const config = readConfig(input);
       updateConfig(config, {
-        config: {version: '1.2.3', status: 'draft', releaselabel: 'qa-preview'}
+        config: { version: '1.2.3', status: 'draft', releaselabel: 'qa-preview' }
       });
 
       expect(config).toEqual({
@@ -540,7 +540,7 @@ describe('Processing', () => {
       const input = path.join(__dirname, 'fixtures', 'valid-yaml');
       const config = readConfig(input);
       updateConfig(config, {
-        config: {version: '1.2.3', something: 'unsupported'}
+        config: { version: '1.2.3', something: 'unsupported' }
       });
 
       expect(config).toEqual({
@@ -590,7 +590,7 @@ describe('Processing', () => {
       const config = readConfig(input);
       updateConfig(config, {
         //not a valid semver, just to make a point
-        config: {version:'1.2.3-beta:1'}
+        config: { version: '1.2.3-beta:1' }
       });
 
       expect(config).toEqual({


### PR DESCRIPTION
#1439 

Added command line option to override some elements in sushi-config.yaml:
```
 -c, --config <config>    override elements in sushi-config.yaml (supported: 'version', 'status', 'releaselabel') (eg: --config status:draft)
```