### PR TITLE
Improve performance when exporting Instances

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -302,15 +302,33 @@ export class InstanceExporter implements Fishable {
       // Don't create slices, just determine what will be created later
       knownSlices = determineKnownSlices(instanceOfStructureDefinition, ruleMap, this.fisher);
     }
-    setImpliedPropertiesOnInstance(
-      instanceDef,
-      instanceOfStructureDefinition,
-      paths,
-      inlineResourcePaths.map(p => p.path),
-      this.fisher,
-      knownSlices,
-      manualSliceOrdering
-    );
+
+    // for core defs, only extension slices can appear
+    if (
+      instanceOfStructureDefinition.url ===
+      `http://hl7.org/fhir/StructureDefinition/${instanceOfStructureDefinition.type}`
+    ) {
+      const secretPaths = paths.filter(path => /(^|\.)(extension|modifierExtension)\[/.test(path));
+      setImpliedPropertiesOnInstance(
+        instanceDef,
+        instanceOfStructureDefinition,
+        secretPaths,
+        inlineResourcePaths.map(p => p.path),
+        this.fisher,
+        knownSlices,
+        manualSliceOrdering
+      );
+    } else {
+      setImpliedPropertiesOnInstance(
+        instanceDef,
+        instanceOfStructureDefinition,
+        paths,
+        inlineResourcePaths.map(p => p.path),
+        this.fisher,
+        knownSlices,
+        manualSliceOrdering
+      );
+    }
     const ruleInstance = cloneDeep(instanceDef);
     ruleMap.forEach(rule => {
       setPropertyOnInstance(ruleInstance, rule.pathParts, rule.assignedValue, this.fisher);

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -50,6 +50,7 @@ import { AssignmentRule, AssignmentValueType, PathRule } from '../fshtypes/rules
 import chalk from 'chalk';
 
 export class InstanceExporter implements Fishable {
+  sdCache: Map<string, StructureDefinition> = new Map();
   constructor(
     private readonly tank: FSHTank,
     private readonly pkg: Package,
@@ -769,7 +770,14 @@ export class InstanceExporter implements Fishable {
       );
     }
 
-    const instanceOfStructureDefinition = StructureDefinition.fromJSON(json);
+    let instanceOfStructureDefinition: StructureDefinition;
+    if (this.sdCache.has(json.url)) {
+      instanceOfStructureDefinition = this.sdCache.get(json.url);
+    } else {
+      instanceOfStructureDefinition = StructureDefinition.fromJSON(json);
+      this.sdCache.set(instanceOfStructureDefinition.url, instanceOfStructureDefinition);
+    }
+
     let instanceDef = new InstanceDefinition();
     instanceDef._instanceMeta.name = fshDefinition.name; // This is name of the instance in the FSH
     if (fshDefinition.title == '') {

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -694,6 +694,7 @@ export class StructureDefinitionExporter implements Fishable {
     }
 
     structDef.elements = elements;
+    elements.forEach(e => structDef.addElementToTree(e));
     structDef.captureOriginalElements();
 
     // The following changes to the root element will be included in the

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -1395,7 +1395,7 @@ export class StructureDefinitionExporter implements Fishable {
     // The recursive structDef fields on elements should be ignored to avoid infinite looping
     // And, the _sliceName and _primitive properties added by SUSHI should be skipped.
     cleanResource(structDef, (prop: string) =>
-      ['structDef', '_sliceName', '_primitive'].includes(prop)
+      ['structDef', 'treeParent', 'treeChildren', '_sliceName', '_primitive'].includes(prop)
     );
     structDef.inProgress = false;
 

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -1393,7 +1393,7 @@ export class StructureDefinitionExporter implements Fishable {
       this.setContext(structDef, fshDefinition);
     }
 
-    // The recursive structDef fields on elements should be ignored to avoid infinite looping
+    // The recursive structDef, treeParent, and treeChildren fields on elements should be ignored to avoid infinite looping
     // And, the _sliceName and _primitive properties added by SUSHI should be skipped.
     cleanResource(structDef, (prop: string) =>
       ['structDef', 'treeParent', 'treeChildren', '_sliceName', '_primitive'].includes(prop)

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -273,7 +273,7 @@ export class StructureDefinition {
     let newMatchingElements: ElementDefinition[] = [];
     // Iterate over the path, filtering out elements that do not match
     for (const pathPart of parsedPath) {
-      // if we have all our elements can we do this with a tree instead
+      // TODO: if we have all our elements, can we do this with a tree instead?
       // Add the next part to the path, and see if we have matches on it
       fhirPathString += `.${pathPart.base}`;
       newMatchingElements = matchingElements.filter(

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -1,6 +1,5 @@
 import upperFirst from 'lodash/upperFirst';
 import cloneDeep from 'lodash/cloneDeep';
-import escapeRegExp from 'lodash/escapeRegExp';
 import differenceWith from 'lodash/differenceWith';
 import isEqual from 'lodash/isEqual';
 import isEmpty from 'lodash/isEmpty';
@@ -158,26 +157,75 @@ export class StructureDefinition {
 
   /**
    * Adds an ElementDefinition to the StructureDefinition's elements, inserting it into the proper location based
-   * on its ID.  This should be used rather than pushing directly to the elements array.
+   * on its ID and sliceName.  This should be used rather than pushing directly to the elements array.
    * @param {ElementDefinition} element - the ElementDefinition to add
    */
   addElement(element: ElementDefinition) {
-    let i = 0;
-    let lastMatchId = '';
-    for (; i < this.elements.length; i++) {
-      const currentId = this.elements[i].id;
-      if (new RegExp(`^${escapeRegExp(currentId)}[.:/]`).test(element.id)) {
-        lastMatchId = currentId;
-      } else if (
-        !new RegExp(`^${escapeRegExp(lastMatchId)}[./:]`).test(currentId) ||
-        // If element is not a slice at this level, and the currentId is a slice, break to add children before slices
-        (new RegExp(`^${escapeRegExp(lastMatchId)}[.]`).test(element.id) &&
-          new RegExp(`^${escapeRegExp(lastMatchId)}[:/]`).test(currentId))
-      ) {
-        break;
+    element.structDef = this;
+    this.addElementToTree(element);
+    if (element.treeParent?.treeChildren != null) {
+      if (element.sliceName != null) {
+        // a newly added element with a slicename should have at least one sibling: its sliced element
+        // all slices come after all child elements.
+        // so, insert a slice before the sliced element's next non-slice sibling that comes after it
+        // this is unfortunately most easily done with string tests since we need to keep slices and reslices organized
+        const slicedElement = element.slicedElement();
+        let i = slicedElement ? this.elements.indexOf(slicedElement) : 0;
+        let lastMatchId = this.elements[i].id;
+        for (; i < this.elements.length; i++) {
+          const currentId = this.elements[i].id;
+          if (new RegExp(`^${this.escapePath(currentId)}[.:/]`).test(element.id)) {
+            lastMatchId = currentId;
+          } else {
+            const lastMatchRegex = this.escapePath(lastMatchId);
+            if (
+              !new RegExp(`^${lastMatchRegex}[./:]`).test(currentId) ||
+              // If element is not a slice at this level, and the currentId is a slice, break to add children before slices
+              (new RegExp(`^${lastMatchRegex}[.]`).test(element.id) &&
+                new RegExp(`^${lastMatchRegex}[:/]`).test(currentId))
+            ) {
+              break;
+            }
+          }
+        }
+        this.elements.splice(i, 0, element);
+      } else {
+        // if this is the only child, splice in after parent
+        // if this is not the only child, splice in after your next-older sibling's last child
+        if (element.treeParent.treeChildren.length === 1) {
+          const parentIndex = this.elements.indexOf(element.treeParent);
+          this.elements.splice(parentIndex + 1, 0, element);
+        } else {
+          const olderSibling = element.treeParent.treeChildren.slice(
+            -2,
+            element.treeParent.treeChildren.length - 1
+          )[0];
+          const olderSiblingChildren = olderSibling.children();
+          if (olderSiblingChildren.length === 0) {
+            const olderSiblingIndex = this.elements.indexOf(olderSibling);
+            this.elements.splice(olderSiblingIndex + 1, 0, element);
+          } else {
+            const lastChild = olderSiblingChildren.slice(-1)[0];
+            const lastChildIndex = this.elements.indexOf(lastChild);
+            this.elements.splice(lastChildIndex + 1, 0, element);
+          }
+        }
       }
     }
-    this.elements.splice(i, 0, element);
+  }
+
+  addElementToTree(element: ElementDefinition) {
+    element.treeParent = element.parent();
+    if (element.treeParent != null) {
+      if (element.treeParent.treeChildren == null) {
+        element.treeParent.treeChildren = [];
+      }
+      element.treeParent.treeChildren.push(element);
+    }
+  }
+
+  private escapePath(id: string): string {
+    return id.replace(/[.\[\]\/]/g, '\\$&');
   }
 
   /**
@@ -225,6 +273,7 @@ export class StructureDefinition {
     let newMatchingElements: ElementDefinition[] = [];
     // Iterate over the path, filtering out elements that do not match
     for (const pathPart of parsedPath) {
+      // if we have all our elements can we do this with a tree instead
       // Add the next part to the path, and see if we have matches on it
       fhirPathString += `.${pathPart.base}`;
       newMatchingElements = matchingElements.filter(
@@ -517,6 +566,7 @@ export class StructureDefinition {
         const ed = ElementDefinition.fromJSON(el, captureOriginalElements);
         ed.structDef = sd;
         sd.elements.push(ed);
+        sd.addElementToTree(ed);
       }
     } else {
       throw new MissingSnapshotError(sd.url);

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -196,10 +196,7 @@ export class StructureDefinition {
           const parentIndex = this.elements.indexOf(element.treeParent);
           this.elements.splice(parentIndex + 1, 0, element);
         } else {
-          const olderSibling = element.treeParent.treeChildren.slice(
-            -2,
-            element.treeParent.treeChildren.length - 1
-          )[0];
+          const olderSibling = element.treeParent.treeChildren.slice(-2, -1)[0];
           const olderSiblingChildren = olderSibling.children();
           if (olderSiblingChildren.length === 0) {
             const olderSiblingIndex = this.elements.indexOf(olderSibling);

--- a/test/export/StructureDefinition.LogicalExporter.test.ts
+++ b/test/export/StructureDefinition.LogicalExporter.test.ts
@@ -681,6 +681,46 @@ describe('LogicalExporter', () => {
     expect(exported.elements).toHaveLength(20); // 17 ELTSSServiceModel elements + 3 added elements
   });
 
+  it('should add new elements after inherited elements', () => {
+    const logical = new Logical('MyTestModel');
+    logical.parent = 'ELTSSServiceModel';
+    logical.id = 'MyModel';
+
+    const addElementRule1 = new AddElementRule('backboneProp');
+    addElementRule1.min = 0;
+    addElementRule1.max = '*';
+    addElementRule1.types = [{ type: 'BackboneElement' }];
+    addElementRule1.short = 'short of backboneProp';
+    logical.rules.push(addElementRule1);
+
+    const addElementRule2 = new AddElementRule('backboneProp.name');
+    addElementRule2.min = 1;
+    addElementRule2.max = '1';
+    addElementRule2.types = [{ type: 'HumanName' }];
+    addElementRule2.short = 'short of backboneProp.name';
+    logical.rules.push(addElementRule2);
+
+    const addElementRule3 = new AddElementRule('backboneProp.address');
+    addElementRule3.min = 0;
+    addElementRule3.max = '*';
+    addElementRule3.types = [{ type: 'Address' }];
+    addElementRule3.short = 'short of backboneProp.address';
+    logical.rules.push(addElementRule3);
+
+    doc.logicals.set(logical.name, logical);
+
+    const exported = exporter.export().logicals[0];
+    // ELTSSServiceModel has 17 elements, so the new elements are 18 19 and 20
+    const backboneProp = exported.findElement('MyModel.backboneProp');
+    expect(exported.elements.indexOf(backboneProp)).toBe(17);
+    const backbonePropName = exported.findElement('MyModel.backboneProp.name');
+    expect(exported.elements.indexOf(backbonePropName)).toBe(18);
+    const backbonePropAddress = exported.findElement('MyModel.backboneProp.address');
+    expect(exported.elements.indexOf(backbonePropAddress)).toBe(19);
+
+    expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+  });
+
   it('should log an error when slicing an inherited element', () => {
     const logical = new Logical('MyModel');
     logical.parent = 'ELTSSServiceModel';

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -8728,10 +8728,10 @@ describe('StructureDefinitionExporter R4', () => {
       expect(valueElement.type).toEqual([new ElementDefinitionType('string')]);
       expect(extensionElement).toBeDefined();
       expect(extensionElement.sliceName).toEqual('MySlice');
-      expect(loggerSpy.getLastMessage()).toMatch(
+      expect(loggerSpy.getLastMessage('error')).toMatch(
         /Extension on MyInvalidExtension cannot have both a value and sub-extensions/s
       );
-      expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidExtension\.fsh.*Line: 4\D*/s);
+      expect(loggerSpy.getLastMessage('error')).toMatch(/File: InvalidExtension\.fsh.*Line: 4\D*/s);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(1);
     });
 
@@ -8796,10 +8796,12 @@ describe('StructureDefinitionExporter R4', () => {
       expect(extensionElement).toBeDefined();
       expect(extensionElement.sliceName).toEqual('MySlice');
       expect(valueElement.type).toEqual([new ElementDefinitionType('string')]);
-      expect(loggerSpy.getLastMessage()).toMatch(
+      expect(loggerSpy.getLastMessage('error')).toMatch(
         /Extension on MyOtherInvalidExtension cannot have both a value and sub-extensions/s
       );
-      expect(loggerSpy.getLastMessage()).toMatch(/File: OtherInvalidExtension\.fsh.*Line: 4\D*/s);
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /File: OtherInvalidExtension\.fsh.*Line: 4\D*/s
+      );
       expect(loggerSpy.getAllLogs('error')).toHaveLength(1);
     });
 
@@ -8940,10 +8942,12 @@ describe('StructureDefinitionExporter R4', () => {
       expect(mySliceExtensionElement.max).toEqual('*');
       expect(mySliceValueElement.min).toEqual(1);
       expect(mySliceValueElement.max).toEqual('1');
-      expect(loggerSpy.getLastMessage()).toMatch(
+      expect(loggerSpy.getLastMessage('error')).toMatch(
         /Extension on MyInvalidExtension cannot have both a value and sub-extensions/s
       );
-      expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidInlineExtension\.fsh.*Line: 4\D*/s);
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /File: InvalidInlineExtension\.fsh.*Line: 4\D*/s
+      );
       expect(loggerSpy.getAllLogs('error')).toHaveLength(1);
     });
 
@@ -8979,10 +8983,12 @@ describe('StructureDefinitionExporter R4', () => {
       expect(mySliceExtensionElement.max).toEqual('*');
       expect(mySliceValueElement.min).toEqual(1);
       expect(mySliceValueElement.max).toEqual('1');
-      expect(loggerSpy.getLastMessage()).toMatch(
+      expect(loggerSpy.getLastMessage('error')).toMatch(
         /Extension on MyInvalidExtension cannot have both a value and sub-extensions/s
       );
-      expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidInlineExtension\.fsh.*Line: 5\D*/s);
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /File: InvalidInlineExtension\.fsh.*Line: 5\D*/s
+      );
       expect(loggerSpy.getAllLogs('error')).toHaveLength(1);
     });
 

--- a/test/fhirtypes/ElementDefinition.assignBoolean.test.ts
+++ b/test/fhirtypes/ElementDefinition.assignBoolean.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { cloneDeep } from 'lodash';
+import { omit } from 'lodash';
 import { loadFromPath } from 'fhir-package-loader';
 import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
 import { StructureDefinition } from '../../src/fhirtypes/StructureDefinition';
@@ -100,7 +100,7 @@ describe('ElementDefinition', () => {
       const userSelected = observation.elements.find(
         e => e.id === 'Observation.code.coding.userSelected'
       );
-      const clone = cloneDeep(userSelected);
+      const clone = userSelected.clone(false);
       expect(() => {
         userSelected.assignValue(true);
       }).toThrow(
@@ -111,7 +111,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         'Cannot assign true to this element; a different boolean is already assigned: false.'
       );
-      expect(clone).toEqual(userSelected);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(userSelected, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw ValueAlreadyAssignedError when assigning a boolean to a different value set in a parent by fixed[x]', () => {
@@ -123,13 +125,15 @@ describe('ElementDefinition', () => {
       const userSelected = observation.elements.find(
         e => e.id === 'Observation.code.coding.userSelected'
       );
-      const clone = cloneDeep(userSelected);
+      const clone = userSelected.clone(false);
       expect(() => {
         userSelected.assignValue(true, true);
       }).toThrow(
         'Cannot assign true to this element; a different boolean is already assigned: false.'
       );
-      expect(clone).toEqual(userSelected);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(userSelected, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw AssignedToPatternError when trying to change fixed[x] to pattern[x]', () => {

--- a/test/fhirtypes/ElementDefinition.assignFshQuantity.test.ts
+++ b/test/fhirtypes/ElementDefinition.assignFshQuantity.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { cloneDeep } from 'lodash';
+import { omit } from 'lodash';
 import { loadFromPath } from 'fhir-package-loader';
 import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
 import { StructureDefinition } from '../../src/fhirtypes/StructureDefinition';
@@ -146,7 +146,7 @@ describe('ElementDefinition', () => {
       const valueRangeLow = observation.elements.find(
         e => e.id === 'Observation.value[x]:valueRange.low'
       );
-      const clone = cloneDeep(valueRangeLow);
+      const clone = valueRangeLow.clone(false);
       expect(() => {
         valueRangeLow.assignValue(new FshQuantity(2.5));
       }).toThrow(
@@ -157,7 +157,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         'Cannot assign 2.5 to this element; a different Quantity is already assigned: {"value":1.5}.'
       );
-      expect(clone).toEqual(valueRangeLow);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(valueRangeLow, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw ValueAlreadyAssignedError when assigning a Quantity to a different value set in a parent by fixed[x]', () => {
@@ -168,7 +170,7 @@ describe('ElementDefinition', () => {
       const valueRangeLow = observation.elements.find(
         e => e.id === 'Observation.value[x]:valueRange.low'
       );
-      const clone = cloneDeep(valueRangeLow);
+      const clone = valueRangeLow.clone(false);
       expect(() => {
         valueRangeLow.assignValue(new FshQuantity(2.5));
       }).toThrow(
@@ -179,7 +181,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         'Cannot assign 2.5 to this element; a different Quantity is already assigned: {"value":1.5}.'
       );
-      expect(clone).toEqual(valueRangeLow);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(valueRangeLow, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw ValueAlreadyAssignedError when the value is assigned to a different value, no units by pattern[x]', () => {

--- a/test/fhirtypes/ElementDefinition.assignNumber.test.ts
+++ b/test/fhirtypes/ElementDefinition.assignNumber.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { cloneDeep } from 'lodash';
+import { omit } from 'lodash';
 import { loadFromPath } from 'fhir-package-loader';
 import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
 import { StructureDefinition } from '../../src/fhirtypes/StructureDefinition';
@@ -101,7 +101,7 @@ describe('ElementDefinition', () => {
       const valueQuantityValue = observation.elements.find(
         e => e.id === 'Observation.value[x]:valueQuantity.value'
       );
-      const clone = cloneDeep(valueQuantityValue);
+      const clone = valueQuantityValue.clone(false);
       expect(() => {
         valueQuantityValue.assignValue(2.5);
       }).toThrow(
@@ -112,7 +112,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         'Cannot assign 2.5 to this element; a different decimal is already assigned: 1.5.'
       );
-      expect(clone).toEqual(valueQuantityValue);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(valueQuantityValue, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw ValueAlreadyAssignedError when assigning a decimal to a different value set in a parent by fixed[x]', () => {
@@ -122,7 +124,7 @@ describe('ElementDefinition', () => {
       const valueQuantityValue = observation.elements.find(
         e => e.id === 'Observation.value[x]:valueQuantity.value'
       );
-      const clone = cloneDeep(valueQuantityValue);
+      const clone = valueQuantityValue.clone(false);
       expect(() => {
         valueQuantityValue.assignValue(2.5);
       }).toThrow(
@@ -133,7 +135,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         'Cannot assign 2.5 to this element; a different decimal is already assigned: 1.5.'
       );
-      expect(clone).toEqual(valueQuantityValue);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(valueQuantityValue, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw FixedToPatternError when trying to change fixed[x] to pattern[x]', () => {
@@ -475,7 +479,7 @@ describe('ElementDefinition', () => {
     });
 
     beforeEach(() => {
-      valueInteger64 = cloneDeep(valueX);
+      valueInteger64 = valueX.clone(false);
       valueInteger64.type = valueInteger64.type.filter(t => t.code === 'integer64');
     });
 

--- a/test/fhirtypes/ElementDefinition.assignString.test.ts
+++ b/test/fhirtypes/ElementDefinition.assignString.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { cloneDeep } from 'lodash';
+import { omit } from 'lodash';
 import { loadFromPath } from 'fhir-package-loader';
 import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
 import { StructureDefinition, ElementDefinition } from '../../src/fhirtypes';
@@ -89,7 +89,7 @@ describe('ElementDefinition', () => {
       const identifierValue = observation.elements.find(
         e => e.id === 'Observation.identifier.value'
       );
-      const clone = cloneDeep(identifierValue);
+      const clone = identifierValue.clone(false);
       expect(() => {
         identifierValue.assignValue('Bar');
       }).toThrow(
@@ -100,7 +100,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         'Cannot assign "Bar" to this element; a different string is already assigned: "Foo".'
       );
-      expect(clone).toEqual(identifierValue);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(identifierValue, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw ValueAlreadyAssignedError when assigning a decimal to a different value set in a parent by fixed[x]', () => {
@@ -111,7 +113,7 @@ describe('ElementDefinition', () => {
       const identifierValue = observation.elements.find(
         e => e.id === 'Observation.identifier.value'
       );
-      const clone = cloneDeep(identifierValue);
+      const clone = identifierValue.clone(false);
       expect(() => {
         identifierValue.assignValue('Bar');
       }).toThrow(
@@ -122,7 +124,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         'Cannot assign "Bar" to this element; a different string is already assigned: "Foo".'
       );
-      expect(clone).toEqual(identifierValue);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(identifierValue, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw FixedToPatternError when trying to change fixed[x] to pattern[x]', () => {
@@ -1138,7 +1142,7 @@ describe('ElementDefinition', () => {
       });
 
       beforeEach(() => {
-        valueInteger64 = cloneDeep(valueX);
+        valueInteger64 = valueX.clone(false);
         valueInteger64.type = valueInteger64.type.filter(t => t.code === 'integer64');
       });
 

--- a/test/fhirtypes/ElementDefinition.bindToVS.test.ts
+++ b/test/fhirtypes/ElementDefinition.bindToVS.test.ts
@@ -2,7 +2,7 @@ import { loadFromPath } from 'fhir-package-loader';
 import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
 import { StructureDefinition } from '../../src/fhirtypes/StructureDefinition';
 import { TestFisher, loggerSpy } from '../testhelpers';
-import cloneDeep from 'lodash/cloneDeep';
+import omit from 'lodash/omit';
 import path from 'path';
 
 describe('ElementDefinition', () => {
@@ -88,16 +88,18 @@ describe('ElementDefinition', () => {
 
     it('should throw CodedTypeNotFoundError when binding to an unsupported type', () => {
       const instant = observation.elements.find(e => e.id === 'Observation.issued');
-      const clone = cloneDeep(instant);
+      const clone = instant.clone(false);
       expect(() => {
         clone.bindToVS('http://myvaluesets.org/myvs', 'required');
       }).toThrow(/instant/);
-      expect(clone).toEqual(instant);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(instant, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw InvalidUriError when binding with a non-URI non-fragment value', () => {
       const category = observation.elements.find(e => e.id === 'Observation.category');
-      const clone = cloneDeep(category);
+      const clone = category.clone(false);
       expect(() => {
         clone.bindToVS('notAUri', 'required');
       }).toThrow(/notAUri/);
@@ -106,88 +108,100 @@ describe('ElementDefinition', () => {
     it('should only allow required to be rebound with required', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
       expect(status.binding.strength).toBe('required');
-      let clone = cloneDeep(status);
+      let clone = status.clone(false);
       clone.bindToVS('http://myvaluesets.org/myvs', 'required');
       expect(clone.binding.valueSet).toBe('http://myvaluesets.org/myvs');
       expect(clone.binding.strength).toBe('required');
-      clone = cloneDeep(status);
+      clone = status.clone(false);
       expect(() => {
         clone.bindToVS('http://myvaluesets.org/myvs', 'extensible');
       }).toThrow(/required.*extensible/);
-      expect(clone).toEqual(status);
-      clone = cloneDeep(status);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(status, ['structDef', 'treeParent', 'treeChildren'])
+      );
+      clone = status.clone(false);
       expect(() => {
         clone.bindToVS('http://myvaluesets.org/myvs', 'preferred');
       }).toThrow(/required.*preferred/);
-      expect(clone).toEqual(status);
-      clone = cloneDeep(status);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(status, ['structDef', 'treeParent', 'treeChildren'])
+      );
+      clone = status.clone(false);
       expect(() => {
         clone.bindToVS('http://myvaluesets.org/myvs', 'example');
       }).toThrow(/required.*example/);
-      expect(clone).toEqual(status);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(status, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should only allow extensible to be rebound with extensible or required', () => {
       const interpretation = observation.elements.find(e => e.id === 'Observation.interpretation');
       expect(interpretation.binding.strength).toBe('extensible');
-      let clone = cloneDeep(interpretation);
+      let clone = interpretation.clone(false);
       clone.bindToVS('http://myvaluesets.org/myvs', 'extensible');
       expect(clone.binding.valueSet).toBe('http://myvaluesets.org/myvs');
       expect(clone.binding.strength).toBe('extensible');
-      clone = cloneDeep(interpretation);
+      clone = interpretation.clone(false);
       clone.bindToVS('http://myvaluesets.org/myvs2', 'required');
       expect(clone.binding.valueSet).toBe('http://myvaluesets.org/myvs2');
       expect(clone.binding.strength).toBe('required');
-      clone = cloneDeep(interpretation);
+      clone = interpretation.clone(false);
       expect(() => {
         interpretation.bindToVS('http://myvaluesets.org/myvs', 'preferred');
       }).toThrow(/extensible.*preferred/);
-      expect(clone).toEqual(interpretation);
-      clone = cloneDeep(interpretation);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(interpretation, ['structDef', 'treeParent', 'treeChildren'])
+      );
+      clone = interpretation.clone(false);
       expect(() => {
         interpretation.bindToVS('http://myvaluesets.org/myvs', 'example');
       }).toThrow(/extensible.*example/);
-      expect(clone).toEqual(interpretation);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(interpretation, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should only allow preferred to be rebound with preferred, extensible, or required', () => {
       const category = observation.elements.find(e => e.id === 'Observation.category');
       expect(category.binding.strength).toBe('preferred');
-      let clone = cloneDeep(category);
+      let clone = category.clone(false);
       clone.bindToVS('http://myvaluesets.org/myvs', 'preferred');
       expect(clone.binding.valueSet).toBe('http://myvaluesets.org/myvs');
       expect(clone.binding.strength).toBe('preferred');
-      clone = cloneDeep(category);
+      clone = category.clone(false);
       clone.bindToVS('http://myvaluesets.org/myvs2', 'extensible');
       expect(clone.binding.valueSet).toBe('http://myvaluesets.org/myvs2');
       expect(clone.binding.strength).toBe('extensible');
-      clone = cloneDeep(category);
+      clone = category.clone(false);
       clone.bindToVS('http://myvaluesets.org/myvs3', 'required');
       expect(clone.binding.valueSet).toBe('http://myvaluesets.org/myvs3');
       expect(clone.binding.strength).toBe('required');
-      clone = cloneDeep(category);
+      clone = category.clone(false);
       expect(() => {
         category.bindToVS('http://myvaluesets.org/myvs', 'example');
       }).toThrow(/preferred.*example/);
-      expect(clone).toEqual(category);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(category, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should only allow example to be rebound with any strength', () => {
       const code = observation.elements.find(e => e.id === 'Observation.code');
       expect(code.binding.strength).toBe('example');
-      let clone = cloneDeep(code);
+      let clone = code.clone(false);
       clone.bindToVS('http://myvaluesets.org/myvs', 'example');
       expect(clone.binding.valueSet).toBe('http://myvaluesets.org/myvs');
       expect(clone.binding.strength).toBe('example');
-      clone = cloneDeep(code);
+      clone = code.clone(false);
       clone.bindToVS('http://myvaluesets.org/myvs2', 'preferred');
       expect(clone.binding.valueSet).toBe('http://myvaluesets.org/myvs2');
       expect(clone.binding.strength).toBe('preferred');
-      clone = cloneDeep(code);
+      clone = code.clone(false);
       clone.bindToVS('http://myvaluesets.org/myvs3', 'extensible');
       expect(clone.binding.valueSet).toBe('http://myvaluesets.org/myvs3');
       expect(clone.binding.strength).toBe('extensible');
-      clone = cloneDeep(code);
+      clone = code.clone(false);
       clone.bindToVS('http://myvaluesets.org/myvs4', 'required');
       expect(clone.binding.valueSet).toBe('http://myvaluesets.org/myvs4');
       expect(clone.binding.strength).toBe('required');
@@ -198,24 +212,28 @@ describe('ElementDefinition', () => {
     // See: https://github.com/FHIR/sushi/issues/1312
     const interpretation = observation.elements.find(e => e.id === 'Observation.interpretation');
     expect(interpretation.binding.strength).toBe('extensible');
-    let clone = cloneDeep(interpretation);
+    let clone = interpretation.clone(false);
     clone.bindToVS(null, 'extensible');
     expect(clone.binding.valueSet).toBeUndefined();
     expect(clone.binding.strength).toBe('extensible');
-    clone = cloneDeep(interpretation);
+    clone = interpretation.clone(false);
     clone.bindToVS(null, 'required');
     expect(clone.binding.valueSet).toBeUndefined();
     expect(clone.binding.strength).toBe('required');
-    clone = cloneDeep(interpretation);
+    clone = interpretation.clone(false);
     expect(() => {
       interpretation.bindToVS(null, 'preferred');
     }).toThrow(/extensible.*preferred/);
-    expect(clone).toEqual(interpretation);
-    clone = cloneDeep(interpretation);
+    expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+      omit(interpretation, ['structDef', 'treeParent', 'treeChildren'])
+    );
+    clone = interpretation.clone(false);
     expect(() => {
       interpretation.bindToVS(null, 'example');
     }).toThrow(/extensible.*example/);
-    expect(clone).toEqual(interpretation);
+    expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+      omit(interpretation, ['structDef', 'treeParent', 'treeChildren'])
+    );
   });
 });
 

--- a/test/fhirtypes/ElementDefinition.constrainCardinality.test.ts
+++ b/test/fhirtypes/ElementDefinition.constrainCardinality.test.ts
@@ -2,7 +2,7 @@ import { loadFromPath } from 'fhir-package-loader';
 import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
 import { StructureDefinition } from '../../src/fhirtypes/StructureDefinition';
 import { TestFisher, loggerSpy } from '../testhelpers';
-import cloneDeep from 'lodash/cloneDeep';
+import omit from 'lodash/omit';
 import path from 'path';
 
 describe('ElementDefinition', () => {
@@ -108,51 +108,61 @@ describe('ElementDefinition', () => {
 
     it('should throw InvalidCardinalityError when min > max', () => {
       const identifier = observation.elements.find(e => e.id === 'Observation.identifier');
-      const clone = cloneDeep(identifier);
+      const clone = identifier.clone(false);
       expect(() => {
         clone.constrainCardinality(2, '1');
       }).toThrow(/min 2 is > max 1\./);
-      expect(clone).toEqual(identifier);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(identifier, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw ConstrainingCardinalityError when min < original min', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
-      const clone = cloneDeep(status);
+      const clone = status.clone(false);
       expect(() => {
         // constrain 1..1 to 0..1
         clone.constrainCardinality(0, '1');
       }).toThrow(/0..1, as it does not fit within the original 1..1/);
-      expect(clone).toEqual(status);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(status, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw ConstrainingCardinalityError when max > original max', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
-      const clone = cloneDeep(status);
+      const clone = status.clone(false);
       expect(() => {
         // constrain 1..1 to 1..2
         clone.constrainCardinality(1, '2');
       }).toThrow(/1..2, as it does not fit within the original 1..1/);
-      expect(clone).toEqual(status);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(status, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw ConstrainingCardinalityError when min < original min and max > original max at the same time', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
-      const clone = cloneDeep(status);
+      const clone = status.clone(false);
       expect(() => {
         // constrain 1..1 to 0..2
         clone.constrainCardinality(0, '2');
       }).toThrow(/0..2, as it does not fit within the original 1..1/);
-      expect(clone).toEqual(status);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(status, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should throw ConstrainingCardinalityError when max is * and original max is not *', () => {
       const status = observation.elements.find(e => e.id === 'Observation.status');
-      const clone = cloneDeep(status);
+      const clone = status.clone(false);
       expect(() => {
         // constrain 1..1 to 1..*
         clone.constrainCardinality(1, '*');
       }).toThrow(/1..\*, as it does not fit within the original 1..1/);
-      expect(clone).toEqual(status);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(status, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     // Slice Handling
@@ -220,11 +230,13 @@ describe('ElementDefinition', () => {
       const category = respRate.elements.find(e => e.id === 'Observation.category');
       const fooSlice = category.addSlice('FooSlice');
       fooSlice.min = 1;
-      const clone = cloneDeep(category);
+      const clone = category.clone(false);
       expect(() => {
         category.constrainCardinality(1, '1');
       }).toThrow(/\(2\) > max \(1\) of Observation.category\./);
-      expect(clone).toEqual(category);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(category, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
 
     it('should log a warning and reduce slice cardinality when sliced element max is constrained less than any individual slice max', () => {
@@ -244,11 +256,13 @@ describe('ElementDefinition', () => {
       const category = respRate.elements.find(e => e.id === 'Observation.category');
       const fooSlice = category.addSlice('FooSlice');
       category.max = '2';
-      const clone = cloneDeep(fooSlice);
+      const clone = fooSlice.clone(false);
       expect(() => {
         fooSlice.constrainCardinality(2, '2');
       }).toThrow(/\(3\) > max \(2\) of Observation.category\./);
-      expect(clone).toEqual(fooSlice);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(fooSlice, ['structDef', 'treeParent', 'treeChildren'])
+      );
     });
   });
 });

--- a/test/fhirtypes/ElementDefinition.constrainType.test.ts
+++ b/test/fhirtypes/ElementDefinition.constrainType.test.ts
@@ -11,6 +11,7 @@ import { minimalConfig } from '../utils/minimalConfig';
 import { FshCanonical, Profile } from '../../src/fshtypes';
 import { FSHTank } from '../../src/import';
 import cloneDeep from 'lodash/cloneDeep';
+import omit from 'lodash/omit';
 import path from 'path';
 
 describe('ElementDefinition', () => {
@@ -1052,7 +1053,7 @@ describe('ElementDefinition', () => {
       );
       const vitalSigns = StructureDefinition.fromJSON(jsonVitalSigns);
       const hasMember = vitalSigns.elements.find(e => e.id === 'Observation.hasMember');
-      const hasMemberClone = cloneDeep(hasMember);
+      const hasMemberClone = hasMember.clone(false);
       expect(() => {
         const hasMemberConstraint = new OnlyRule('hasMember');
         hasMemberConstraint.types = [{ type: 'SomeOtherObsProfile', isReference: true }];
@@ -1060,7 +1061,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         /"Reference\(SomeOtherObsProfile\)" does not match .* Reference\(\S+\/QuestionnaireResponse \| \S+\/MolecularSequence \| \S+\/vitalsigns\)/
       );
-      expect(hasMember).toEqual(hasMemberClone);
+      expect(omit(hasMember, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(hasMemberClone, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
@@ -1114,7 +1117,7 @@ describe('ElementDefinition', () => {
       );
       const vitalSigns = StructureDefinition.fromJSON(jsonVitalSigns);
       const hasMember = vitalSigns.elements.find(e => e.id === 'Observation.hasMember');
-      const hasMemberClone = cloneDeep(hasMember);
+      const hasMemberClone = hasMember.clone(false);
       expect(() => {
         const hasMemberConstraint = new OnlyRule('hasMember');
         hasMemberConstraint.types = [
@@ -1125,7 +1128,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         /"Reference\(AnObsProfile\)" does not match .* Reference\(\S+\/QuestionnaireResponse \| \S+\/MolecularSequence \| \S+\/vitalsigns\)/
       );
-      expect(hasMember).toEqual(hasMemberClone);
+      expect(omit(hasMember, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(hasMemberClone, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
@@ -1172,7 +1177,7 @@ describe('ElementDefinition', () => {
       );
       const vitalSigns = StructureDefinition.fromJSON(jsonVitalSigns);
       const hasMember = vitalSigns.elements.find(e => e.id === 'Observation.hasMember');
-      const hasMemberClone = cloneDeep(hasMember);
+      const hasMemberClone = hasMember.clone(false);
       expect(() => {
         const hasMemberConstraint = new OnlyRule('hasMember');
         hasMemberConstraint.types = [
@@ -1184,7 +1189,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         /"Reference\(SomeOtherObsProfile\)" does not match .* Reference\(\S+\/QuestionnaireResponse \| \S+\/MolecularSequence \| \S+\/vitalsigns\)/
       );
-      expect(hasMember).toEqual(hasMemberClone);
+      expect(omit(hasMember, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(hasMemberClone, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
@@ -1673,20 +1680,22 @@ describe('ElementDefinition', () => {
 
     it('should throw InvalidTypeError when a passed in type cannot constrain any existing types', () => {
       const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
-      const clone = cloneDeep(valueX);
+      const clone = valueX.clone(false);
       expect(() => {
         const valueConstraint = new OnlyRule('value[x]');
         valueConstraint.types = [{ type: 'decimal' }];
         clone.constrainType(valueConstraint, fisher);
       }).toThrow(/"decimal" does not match .* Quantity or CodeableConcept or string/);
-      expect(clone).toEqual(valueX);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(valueX, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
 
     it('should throw InvalidTypeError when a passed in reference to a type that cannot constrain any existing references to types', () => {
       const valueX = observation.elements.find(e => e.id === 'Observation.performer');
-      const clone = cloneDeep(valueX);
+      const clone = valueX.clone(false);
       expect(() => {
         const performerConstraint = new OnlyRule('performer');
         performerConstraint.types = [{ type: 'Medication', isReference: true }];
@@ -1694,7 +1703,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         /"Reference\(Medication\)" does not match .* Reference\(http:\/\/hl7.org\/fhir\/StructureDefinition\/Practitioner | http:\/\/hl7.org\/fhir\/StructureDefinition\/PractitionerRole .*\)/
       );
-      expect(clone).toEqual(valueX);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(valueX, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
@@ -1702,20 +1713,22 @@ describe('ElementDefinition', () => {
     it('should throw InvalidTypeError when attempting to constrain Resource to a reference', () => {
       const bundle = fisher.fishForStructureDefinition('Bundle');
       const entryResource = bundle.elements.find(e => e.id === 'Bundle.entry.resource');
-      const clone = cloneDeep(entryResource);
+      const clone = entryResource.clone(false);
       expect(() => {
         const resourceConstraint = new OnlyRule('entry.resource');
         resourceConstraint.types = [{ type: 'Procedure', isReference: true }];
         clone.constrainType(resourceConstraint, fisher);
       }).toThrow(/"Reference\(Procedure\)" does not match .* Resource/);
-      expect(clone).toEqual(entryResource);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(entryResource, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
 
     it('should throw InvalidTypeError when the targetType does not match any existing types', () => {
       const hasMember = observation.elements.find(e => e.id === 'Observation.hasMember');
-      const clone = cloneDeep(hasMember);
+      const clone = hasMember.clone(false);
       expect(() => {
         const hasMemberConstraint = new OnlyRule('hasMember');
         hasMemberConstraint.types = [
@@ -1728,27 +1741,31 @@ describe('ElementDefinition', () => {
       }).toThrow(
         /"FamilyMemberHistory" does not match .* Reference\(http:\/\/hl7.org\/fhir\/StructureDefinition\/Observation .*\)/
       );
-      expect(clone).toEqual(hasMember);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(hasMember, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
 
     it('should throw InvalidTypeError when the passed in type does not match the targetType', () => {
       const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
-      const clone = cloneDeep(valueX);
+      const clone = valueX.clone(false);
       expect(() => {
         const valueConstraint = new OnlyRule('value[x]');
         valueConstraint.types = [{ type: 'SimpleQuantity' }];
         clone.constrainType(valueConstraint, fisher, 'CodeableConcept');
       }).toThrow(/"SimpleQuantity" does not match .* CodeableConcept/);
-      expect(clone).toEqual(valueX);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(valueX, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
 
     it('should throw InvalidTypeError when the passed in reference type does not match the targetType', () => {
       const hasMember = observation.elements.find(e => e.id === 'Observation.hasMember');
-      const clone = cloneDeep(hasMember);
+      const clone = hasMember.clone(false);
       expect(() => {
         const hasMemberConstraint = new OnlyRule('hasMember');
         hasMemberConstraint.types = [
@@ -1758,7 +1775,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         /"Reference\(http:\/\/hl7.org\/fhir\/StructureDefinition\/bodyheight\)" does not match .* Reference\(http:\/\/hl7.org\/fhir\/StructureDefinition\/QuestionnaireResponse\)/
       );
-      expect(clone).toEqual(hasMember);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(hasMember, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
@@ -1766,33 +1785,37 @@ describe('ElementDefinition', () => {
     it('should throw InvalidTypeError when attempting to constrain a reference when the target type is Resource', () => {
       const bundle = fisher.fishForStructureDefinition('Bundle');
       const entryResource = bundle.elements.find(e => e.id === 'Bundle.entry.resource');
-      const clone = cloneDeep(entryResource);
+      const clone = entryResource.clone(false);
       expect(() => {
         const resourceConstraint = new OnlyRule('entry.resource');
         resourceConstraint.types = [{ type: 'Procedure', isReference: true }];
         clone.constrainType(resourceConstraint, fisher, 'Resource');
       }).toThrow(/"Reference\(Procedure\)" does not match .* Resource/);
-      expect(clone).toEqual(entryResource);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(entryResource, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
 
     it('should throw TypeNotFoundError when a passed in type definition cannot be found', () => {
       const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
-      const clone = cloneDeep(valueX);
+      const clone = valueX.clone(false);
       expect(() => {
         const valueConstraint = new OnlyRule('value[x]');
         valueConstraint.types = [{ type: 'Quantity' }, { type: 'Monocle' }];
         clone.constrainType(valueConstraint, fisher);
       }).toThrow(/No definition for the type "Monocle" could be found./);
-      expect(clone).toEqual(valueX);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(valueX, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
 
     it('should throw TypeNotFoundError when a passed in reference types definition cannot be found', () => {
       const performer = observation.elements.find(e => e.id === 'Observation.performer');
-      const clone = cloneDeep(performer);
+      const clone = performer.clone(false);
       expect(() => {
         const performerConstraint = new OnlyRule('performer');
         performerConstraint.types = [
@@ -1801,14 +1824,16 @@ describe('ElementDefinition', () => {
         ];
         clone.constrainType(performerConstraint, fisher);
       }).toThrow(/No definition for the type "Juggler" could be found./);
-      expect(clone).toEqual(performer);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(performer, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
 
     it('should throw TypeNotFoundError when the targetType definition cannot be found', () => {
       const hasMember = observation.elements.find(e => e.id === 'Observation.hasMember');
-      const clone = cloneDeep(hasMember);
+      const clone = hasMember.clone(false);
       expect(() => {
         const hasMemberConstraint = new OnlyRule('hasMember');
         hasMemberConstraint.types = [
@@ -1816,14 +1841,16 @@ describe('ElementDefinition', () => {
         ];
         clone.constrainType(hasMemberConstraint, fisher, 'VitalBillboards');
       }).toThrow(/No definition for the type "VitalBillboards" could be found./);
-      expect(clone).toEqual(hasMember);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(hasMember, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });
 
     it('should throw NonAbstractParentError when constraining a non-abstract parent to a specialization of it', () => {
       const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
-      const clone = cloneDeep(valueX);
+      const clone = valueX.clone(false);
       expect(() => {
         const valueConstraint = new OnlyRule('value[x]');
         valueConstraint.types = [{ type: 'Duration' }];
@@ -1831,7 +1858,9 @@ describe('ElementDefinition', () => {
       }).toThrow(
         /The type Quantity is not abstract, so it cannot be constrained to the specialization Duration/
       );
-      expect(clone).toEqual(valueX);
+      expect(omit(clone, ['structDef', 'treeParent', 'treeChildren'])).toEqual(
+        omit(valueX, ['structDef', 'treeParent', 'treeChildren'])
+      );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
       expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
     });

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -122,7 +122,9 @@ describe('StructureDefinition', () => {
       expect(observation.elements).toHaveLength(50);
       const valueX = observation.elements[21];
       expect(valueX.hasDiff()).toBeTruthy();
-      expect(valueX.calculateDiff()).toEqual(valueX);
+      const valueXDiff = valueX.calculateDiff();
+      // the diff will not have any element tree relationships that the original may have
+      expect(valueX).toMatchObject(valueXDiff);
       expect(valueX.id).toBe('Observation.value[x]');
       expect(valueX.path).toBe('Observation.value[x]');
       expect(valueX.min).toBe(0);
@@ -931,9 +933,15 @@ describe('StructureDefinition', () => {
 
     it('should add an element in the right place even with substrings involved', () => {
       // Tests bug reported here: https://github.com/FHIR/sushi/issues/122
-      observation.addElement(new ElementDefinition('Observation.component:FooBefore'));
-      observation.addElement(new ElementDefinition('Observation.component:Foo'));
-      observation.addElement(new ElementDefinition('Observation.component:FooAfter'));
+      const fooBefore = new ElementDefinition('Observation.component:FooBefore');
+      fooBefore.sliceName = 'FooBefore';
+      const foo = new ElementDefinition('Observation.component:Foo');
+      foo.sliceName = 'Foo';
+      const fooAfter = new ElementDefinition('Observation.component:FooAfter');
+      fooAfter.sliceName = 'FooAfter';
+      observation.addElement(fooBefore);
+      observation.addElement(foo);
+      observation.addElement(fooAfter);
       observation.addElement(new ElementDefinition('Observation.component:Foo.id'));
       observation.addElement(new ElementDefinition('Observation.component:FooAfter.id'));
       observation.addElement(new ElementDefinition('Observation.component:FooBefore.id'));
@@ -951,7 +959,9 @@ describe('StructureDefinition', () => {
     });
 
     it('should add explicit choice element in the right place', () => {
-      observation.addElement(new ElementDefinition('Observation.value[x]:valueQuantity'));
+      const valueQuantity = new ElementDefinition('Observation.value[x]:valueQuantity');
+      valueQuantity.sliceName = 'valueQuantity';
+      observation.addElement(valueQuantity);
       expect(observation.elements).toHaveLength(51);
       expect(observation.elements[22].id).toBe('Observation.value[x]:valueQuantity');
     });
@@ -965,15 +975,21 @@ describe('StructureDefinition', () => {
 
     it('should add resliced elements in the right place', () => {
       const originalLength = resprate.elements.length;
-      resprate.addElement(new ElementDefinition('Observation.category:VSCat/foo'));
+      const vsCatFoo = new ElementDefinition('Observation.category:VSCat/foo');
+      vsCatFoo.sliceName = 'VSCat/foo';
+      resprate.addElement(vsCatFoo);
       expect(resprate.elements).toHaveLength(originalLength + 1);
       expect(resprate.elements[26].id).toBe('Observation.category:VSCat/foo');
     });
 
     it('should add children of resliced elements in the right place', () => {
       const originalLength = resprate.elements.length;
-      resprate.addElement(new ElementDefinition('Observation.category:VSCat/foo'));
-      resprate.addElement(new ElementDefinition('Observation.category:VSCat/foo/bar'));
+      const vsCatFoo = new ElementDefinition('Observation.category:VSCat/foo');
+      vsCatFoo.sliceName = 'VSCat/foo';
+      const vsCatFooBar = new ElementDefinition('Observation.category:VSCat/foo/bar');
+      vsCatFooBar.sliceName = 'VSCat/foo/bar';
+      resprate.addElement(vsCatFoo);
+      resprate.addElement(vsCatFooBar);
       resprate.addElement(new ElementDefinition('Observation.category:VSCat/foo.extension'));
       expect(resprate.elements).toHaveLength(originalLength + 3);
       expect(resprate.elements[26].id).toBe('Observation.category:VSCat/foo');


### PR DESCRIPTION
Fixes #1426 and completes task [CIMPL-1242](https://standardhealthrecord.atlassian.net/browse/CIMPL-1242).

Instance export remains one of SUSHI's most time-consuming operations. This PR includes several changes that aim to reduce the amount of time needed to export Instances.

- When exporting an Instance, one of the first steps is to find the StructureDefinition that SUSHI is exporting an instance of. This StructureDefinition will usually have its elements unfolded during Instance export in order to validate the paths of assignment rules. These unfolding operations can be time-consuming. In order to avoid repeatedly unfolding the same elements, StructureDefinitions are reused by the InstanceExporter. This offers significant performance gains in cases where a project defines many Instances of the same StructureDefinition, and those Instance definitions include many assignment rules to the same paths.
- Before any of an Instance's rules are applied, its implied properties from its StructureDefinition are set. But, Instances of core FHIR resources will never have their own implied properties. The only case where there may be properties to set is when the Instance contains assignment rules on extension paths where the extension's URL is given as the slice name. Therefore, when the StructureDefinition is a core FHIR resource, other paths do not need to be checked for implied properties.
- When validating an assignment rule on an Instance, a frequent operation is finding an element's parent or children. This can be accomplished by searching the StructureDefinition's list of elements based on the starting element id. However, this can become expensive when the list of elements is long. Elements now maintain references to their parents and children in order to minimize the amount of times the full element list is searched or filtered.

As examples of the benefits of these changes, here are a few selected repos from the regression set, with run times for SUSHI 3.8.0 and for this change set. These times are wall-clock times from my personal system, which are not perfectly accurate measurements of performance. However, I feel that the magnitude of the time reductions are significant.

| Repo | Number of Instances | SUSHI 3.8.0 time (seconds) | PR time (seconds) |
|--------|--------|--------|--------|
| [HL7/fhir-saner#master](https://github.com/HL7/fhir-saner/tree/master/) | 204 | 164 | 114 |
| [HL7/v2-to-fhir#master](https://github.com/HL7/v2-to-fhir/tree/master/) | 247 | 114 | 68 |
| [joofio/test-epi-composition#main](https://github.com/joofio/test-epi-composition/tree/main/) | 2714 | 2362 | 290 |

In the regression set for this PR, some changes appear. However, these are due to existing bugs that were revealed by the changes in this PR. Two issues have been added to the SUSHI backlog for these bugs: https://standardhealthrecord.atlassian.net/browse/CIMPL-1248 and https://standardhealthrecord.atlassian.net/browse/CIMPL-1249