### PR TITLE
Find value for choice slice when choice element has one type

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -434,6 +434,27 @@ export class InstanceExporter implements Fishable {
             break;
           }
         }
+        // if the choice only has one type, we may not have created the choice slice.
+        // if this happens, everything is fine.
+        if (instanceChild == null) {
+          const singleTypeChoiceElements = possibleChoiceSlices.filter(
+            c => c.path === child.path && c.type.length === 1
+          );
+          for (const choiceElement of singleTypeChoiceElements) {
+            const sliceName = childPathEnd.replace('[x]', upperFirst(choiceElement.type[0].code));
+            instanceChild = instance[`_${sliceName}`] ?? instance[sliceName];
+            const splitPath = splitOnPathPeriods(choiceElement.id);
+            if (
+              instanceChild != null &&
+              (instance._sliceName
+                ? splitPath[splitPath.length - 2].split(':')[1] === instance._sliceName
+                : true)
+            ) {
+              child = choiceElement;
+              break;
+            }
+          }
+        }
         // If we don't have instanceChild yet, it may be due to a rule that refers to a named slice using a numeric index somewhere in the path.
         // AssignmentRules on an Instance cause elements to be unfolded on the InstanceOf StructureDefinition, because that
         // allows the AssignmentRule's value to be validated.


### PR DESCRIPTION
Completes task [CIMPL-1248](https://standardhealthrecord.atlassian.net/browse/CIMPL-1248).

When a slice has a descendent that is a choice element, and that choice element has only one type, a choice slice is not created on the StructureDefinition to represent that choice slice. This is because the choice element itself has all the necessary information when it has only one type. When validating required elements on an instance, check for the presence of such an element. If it is found, use its type to determine the name of the property to look for on the instance being validated.