### PR TITLE
Ignore all regresion/output* folders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,6 +11,6 @@ build*/*
 # custom definition files
 /src/types/
 # regression output
-/regression/output
+/regression/output*
 # generated source code
 **/generated

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ tmp
 # Build
 public/css/main.css
 /build*
-/regression/output
+/regression/output*
 
 # Coverage reports
 coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,5 @@ coverage
 dist
 build*
 node_modules
-regression/output
+regression/output*
 **/generated


### PR DESCRIPTION
A small PR so I can continue to hold on to different regressions I still need without Git being sad. And may as well make ESLint and Prettier not sad.