### PR TITLE
Improve Logical Model type controls to not re-add elements

### DIFF
--- a/src/errors/InvalidTypeAccessError.ts
+++ b/src/errors/InvalidTypeAccessError.ts
@@ -1,7 +1,9 @@
 export class InvalidTypeAccessError extends Error {
-  constructor() {
+  constructor(public isLogical = false) {
     super(
-      'Cannot directly change type. StructureDefinitions will naturally inherit their Parent type.'
+      isLogical
+        ? 'Can only directly change logical model type to a uri.'
+        : 'Cannot directly change type. StructureDefinitions will naturally inherit their Parent type.'
     );
   }
 }

--- a/src/errors/InvalidTypeAccessError.ts
+++ b/src/errors/InvalidTypeAccessError.ts
@@ -1,9 +1,7 @@
 export class InvalidTypeAccessError extends Error {
-  constructor(public isLogical = false) {
+  constructor() {
     super(
-      isLogical
-        ? 'Can only directly change logical model type to a uri.'
-        : 'Cannot directly change type. StructureDefinitions will naturally inherit their Parent type.'
+      'Cannot directly change type. StructureDefinitions will naturally inherit their Parent type.'
     );
   }
 }

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -416,7 +416,7 @@ export class StructureDefinition {
       throw new InvalidElementAccessError(path);
     }
     if (path === 'type' && value !== this.type) {
-      throw new InvalidTypeAccessError(this.kind === 'logical');
+      throw new InvalidTypeAccessError();
     }
     setPropertyOnDefinitionInstance(this, path, value, fisher);
   }

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -415,8 +415,8 @@ export class StructureDefinition {
     if (path.startsWith('snapshot') || path.startsWith('differential')) {
       throw new InvalidElementAccessError(path);
     }
-    if (path === 'type' && value !== this.pathType) {
-      throw new InvalidTypeAccessError();
+    if (path === 'type' && value !== this.type) {
+      throw new InvalidTypeAccessError(this.kind === 'logical');
     }
     setPropertyOnDefinitionInstance(this, path, value, fisher);
   }
@@ -428,7 +428,7 @@ export class StructureDefinition {
    */
   newElement(name = '$UNKNOWN'): ElementDefinition {
     // Check if there already exists an element that is defined by an ancestor
-    if (this.elements.find(e => e.id == `${this.id}.${name}`)) {
+    if (this.elements.find(e => e.id == `${this.pathType}.${name}`)) {
       throw new ElementAlreadyDefinedError(name, this.id);
     }
     const el = this.elements[0].newChildElement(name);

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -1417,10 +1417,15 @@ export function getTypeFromFshDefinitionOrParent(
     // Select last CaretValueRule with caretPath === 'type' because rules processing
     // ends up applying the last rule in the processing order
     const lastCaretValueRule = caretValueRules[caretValueRules.length - 1];
+    const type = lastCaretValueRule.value.toString();
     // this value should only be a string, but that might change at some point
-    if (isUri(lastCaretValueRule.value.toString())) {
-      return lastCaretValueRule.value.toString();
+    if (fshDefinition instanceof Logical && !isUri(type)) {
+      logger.warn(
+        `${type} is an invalid type. Logical models require that the type be an absolute URL.`,
+        lastCaretValueRule.sourceInfo
+      );
     }
+    return type;
   }
 
   // Default type for logical model to the StructureDefinition url;

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -39,6 +39,7 @@ import { buildSliceTree, calculateSliceTreeCounts } from './sliceTree';
 import { InstanceExporter } from '../export';
 import { MismatchedTypeError } from '../errors';
 import { getValueFromRules } from '../fshtypes/common';
+import { isUri } from 'valid-url';
 
 // List of Conformance and Terminology resources from http://hl7.org/fhir/R4/resourcelist.html
 // and https://hl7.org/fhir/R5/resourcelist.html
@@ -1417,7 +1418,9 @@ export function getTypeFromFshDefinitionOrParent(
     // ends up applying the last rule in the processing order
     const lastCaretValueRule = caretValueRules[caretValueRules.length - 1];
     // this value should only be a string, but that might change at some point
-    return lastCaretValueRule.value.toString();
+    if (isUri(lastCaretValueRule.value.toString())) {
+      return lastCaretValueRule.value.toString();
+    }
   }
 
   // Default type for logical model to the StructureDefinition url;

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1615,10 +1615,25 @@ describe('StructureDefinitionExporter R4', () => {
       expect(exported.status).toBe('draft');
     });
 
-    it('should allow type to be overwritten with caret rule', () => {
+    it('should allow type to be overwritten with caret rule with a uri value', () => {
       const logical = new Logical('Foo');
       logical.parent = 'AlternateIdentification';
       const rule = new CaretValueRule('');
+      rule.caretPath = 'type';
+      rule.value = 'http://example.org/other/MyType';
+      logical.rules.push(rule);
+      doc.logicals.set(logical.name, logical);
+      exporter.exportStructDef(logical);
+      const exported = pkg.logicals[0];
+      expect(exported.name).toBe('Foo');
+      expect(exported.type).toBe('http://example.org/other/MyType');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+    });
+
+    it('should log an error when overwriting type with caret rule with a non-uri value', () => {
+      const logical = new Logical('Foo');
+      logical.parent = 'AlternateIdentification';
+      const rule = new CaretValueRule('').withFile('LogicalModels.fsh').withLocation([3, 3, 3, 25]);
       rule.caretPath = 'type';
       rule.value = 'MyType';
       logical.rules.push(rule);
@@ -1626,7 +1641,12 @@ describe('StructureDefinitionExporter R4', () => {
       exporter.exportStructDef(logical);
       const exported = pkg.logicals[0];
       expect(exported.name).toBe('Foo');
-      expect(exported.type).toBe('MyType');
+      expect(exported.type).toBe('http://hl7.org/fhir/us/minimal/StructureDefinition/Foo');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Can only directly change logical model type to a uri/s
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(/File: LogicalModels\.fsh.*Line: 3/s);
     });
 
     it('should log an error when multiple logical models have the same id', () => {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1628,9 +1628,10 @@ describe('StructureDefinitionExporter R4', () => {
       expect(exported.name).toBe('Foo');
       expect(exported.type).toBe('http://example.org/other/MyType');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
     });
 
-    it('should log an error when overwriting type with caret rule with a non-uri value', () => {
+    it('should log a warning and allow overwriting type with caret rule with a non-uri value', () => {
       const logical = new Logical('Foo');
       logical.parent = 'AlternateIdentification';
       const rule = new CaretValueRule('').withFile('LogicalModels.fsh').withLocation([3, 3, 3, 25]);
@@ -1641,12 +1642,13 @@ describe('StructureDefinitionExporter R4', () => {
       exporter.exportStructDef(logical);
       const exported = pkg.logicals[0];
       expect(exported.name).toBe('Foo');
-      expect(exported.type).toBe('http://hl7.org/fhir/us/minimal/StructureDefinition/Foo');
-      expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
-      expect(loggerSpy.getLastMessage('error')).toMatch(
-        /Can only directly change logical model type to a uri/s
+      expect(exported.type).toBe('MyType');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /MyType is an invalid type\. Logical models require that the type be an absolute URL\./s
       );
-      expect(loggerSpy.getLastMessage('error')).toMatch(/File: LogicalModels\.fsh.*Line: 3/s);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(/File: LogicalModels\.fsh.*Line: 3/s);
     });
 
     it('should log an error when multiple logical models have the same id', () => {


### PR DESCRIPTION
Fixes [CIMPL-1249](https://standardhealthrecord.atlassian.net/browse/CIMPL-1249).

This PR improves the logic for overwriting the `type` of a Logical Model with a caret value rule to only allow URIs to be set. This seems to line up with the FHIR spec for [type](http://hl7.org/fhir/structuredefinition-definitions.html#StructureDefinition.type). Because you can only overwrite `type` with a URI, I also updated the message of the InvalideTypeAccessError to be a little more specific for Logical Models. This also uses `this.pathType` when adding elements so the element id path is properly calculated so that elements that were in the parent aren't re-added when when the logical model overwrites the `type`.

This issue came up due to changes in the [IntelliSOFT-Consulting/ChanjoKe-FHIR-IG#main](https://github.com/IntelliSOFT-Consulting/ChanjoKe-FHIR-IG/tree/main/) repo after PR #1443. With this branch, there are still changes, but I think the changes are correct. Running a full 1-year regression resulted in 5 repos with changes. Looking at the differences, they all resulted from types that were not full URIs, which is not allowed in FHIR and no longer allowed on this branch. These are the 5 repos:

```
HL7/sdc#master
IHE-Germany/ITI.XDS.VS#main
IHE/pharm-vaccination#main
IntelliSOFT-Consulting/ChanjoKe-FHIR-IG#main
WorldHealthOrganization/ddcc#main
```