### PR TITLE
Set version based on sushi-config.yaml in FSHOnly projects

### DIFF
--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -38,7 +38,11 @@ export class CodeSystemExporter {
     }
     if (fshDefinition.title) codeSystem.title = fshDefinition.title;
     if (fshDefinition.description) codeSystem.description = fshDefinition.description;
-    delete codeSystem.version; // deleting to allow the IG Publisher default to take hold
+    if (this.tank.config.FSHOnly) {
+      codeSystem.version = this.tank.config.version;
+    } else {
+      delete codeSystem.version; // deleting to allow the IG Publisher default to take hold
+    }
     codeSystem.status = this.tank.config.status;
     codeSystem.url = `${this.tank.config.canonical}/CodeSystem/${codeSystem.id}`;
   }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -382,7 +382,11 @@ export class StructureDefinitionExporter implements Fishable {
       delete structDef.title;
     }
     structDef.status = this.tank.config.status;
-    delete structDef.version; // deleting to allow the IG Publisher default to take hold
+    if (this.tank.config.FSHOnly) {
+      structDef.version = this.tank.config.version;
+    } else {
+      delete structDef.version; // deleting to allow the IG Publisher default to take hold
+    }
     delete structDef.experimental;
     delete structDef.date;
     delete structDef.publisher;

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -52,7 +52,11 @@ export class ValueSetExporter {
     if (fshDefinition.description) {
       valueSet.description = fshDefinition.description;
     }
-    delete valueSet.version; // deleting to allow the IG Publisher default to take hold
+    if (this.tank.config.FSHOnly) {
+      valueSet.version = this.tank.config.version;
+    } else {
+      delete valueSet.version; // deleting to allow the IG Publisher default to take hold
+    }
     valueSet.status = this.tank.config.status;
     valueSet.url = `${this.tank.config.canonical}/ValueSet/${valueSet.id}`;
   }

--- a/src/import/importConfiguration.ts
+++ b/src/import/importConfiguration.ts
@@ -61,6 +61,7 @@ const MINIMAL_IG_ONLY_PROPERTIES = ['id', 'name', 'status', 'copyrightYear', 're
 const ALLOWED_FSH_ONLY_PROPERTIES = [
   ...MINIMAL_CONFIG_PROPERTIES,
   'version',
+  'status',
   'dependencies',
   'instanceOptions',
   'applyExtensionMetadataToRoot',

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -13,6 +13,7 @@ import { loggerSpy } from '../testhelpers/loggerSpy';
 import { TestFisher } from '../testhelpers';
 import { FHIRDefinitions } from '../../src/fhirdefs';
 import path from 'path';
+import { cloneDeep } from 'lodash';
 import {
   CaretValueRule,
   InsertRule,
@@ -105,6 +106,31 @@ describe('ValueSetExporter', () => {
       status: 'draft',
       title: 'Breakfast Values',
       description: 'A value set for breakfast items',
+      url: 'http://hl7.org/fhir/us/minimal/ValueSet/BreakfastVS'
+    });
+  });
+
+  it('should export a value set with status and version in FSHOnly mode', () => {
+    // Create a FSHOnly config with a status and version
+    const fshOnlyConfig = cloneDeep(minimalConfig);
+    fshOnlyConfig.FSHOnly = true;
+    fshOnlyConfig.version = '0.1.0';
+    fshOnlyConfig.status = 'active';
+    const input = new FSHTank([doc], fshOnlyConfig);
+    pkg = new Package(input.config);
+    const fisher = new TestFisher(input, defs, pkg);
+    exporter = new ValueSetExporter(input, pkg, fisher);
+
+    const valueSet = new FshValueSet('BreakfastVS');
+    doc.valueSets.set(valueSet.name, valueSet);
+    const exported = exporter.export().valueSets;
+    expect(exported.length).toBe(1);
+    expect(exported[0]).toEqual({
+      resourceType: 'ValueSet',
+      name: 'BreakfastVS',
+      id: 'BreakfastVS',
+      status: 'active',
+      version: '0.1.0',
       url: 'http://hl7.org/fhir/us/minimal/ValueSet/BreakfastVS'
     });
   });

--- a/test/import/importConfiguration.test.ts
+++ b/test/import/importConfiguration.test.ts
@@ -2915,7 +2915,7 @@ describe('importConfiguration', () => {
       minYAML.FSHOnly = true;
       const config = importConfiguration(minYAML, 'test-config.yaml');
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /The following properties are unused and only relevant for IG creation: id, name, status, copyrightYear, releaseLabel, template, menu, contained\..*File: test-config.yaml/s
+        /The following properties are unused and only relevant for IG creation: id, name, copyrightYear, releaseLabel, template, menu, contained\..*File: test-config.yaml/s
       );
       expect(config.FSHOnly).toBe(true);
     });


### PR DESCRIPTION
Fixes #1380

This PR adds back support for using the version specified in `sushi-config.yaml` in Structure Definitions, Value Sets, and Code Systems as a default value in FSH Only projects. If the `version` is set with a rule, that will overwrite the version from the config file. This is only done in the case where `FSHOnly` is set to `true` in the config file because the IG Publisher will set the version when it is used.

Because `status` is already set using the value in `sushi-config.yaml` as a default in all projects, this should restore the functionality that was removed in SUSHI 3.x. As a reference, I was looking at PR #1143, which removed this functionality originally.