### PR TITLE
New options for sushi init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Options:
 
 Commands:
   build [options] [path-to-fsh-project]                build a SUSHI project
-  init [options]                                       initialize a SUSHI project
+  init [options] [name]                                initialize a SUSHI project
   update-dependencies [options] [path-to-fsh-project]  update FHIR packages in project configuration
   help [command]                                       display help for command
 ```
@@ -46,19 +46,17 @@ Usage: sushi build [options] [path-to-fsh-project]
 
 build a SUSHI project
 
+Arguments:
+  path-to-fsh-project      path to your FSH project (default: ".")
+
 Options:
   -l, --log-level <level>  specify the level of log messages (default: "info") (choices: "error", "warn", "info", "debug")
-  -o, --out <out>          the path to the output folder
+  -o, --out <out>          the path to the output folder (default: "fsh-generated")
   -p, --preprocessed       output FSH produced by preprocessing steps
   -r, --require-latest     exit with error if this is not the latest version of SUSHI (default: false)
   -s, --snapshot           generate snapshot in Structure Definition output (default: false)
+  -c, --config <config>    override elements in sushi-config.yaml (supported: 'version', 'status', 'releaselabel') (eg: --config status:draft)
   -h, --help               display help for command
-
-Additional information:
-  [path-to-fsh-project]
-    Default: "."
-  -o, --out <out>
-    Default: "fsh-generated"
 ```
 
 See the [SUSHI documentation](https://fshschool.org/docs/sushi/) for detailed information on using SUSHI.

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,14 +57,14 @@ async function app() {
   program
     .command('build', { isDefault: true })
     .description('build a SUSHI project')
-    .argument('[path-to-fsh-project]')
+    .argument('[path-to-fsh-project]', 'path to your FSH project (default: ".")')
     .addOption(
       new Option(
         '-l, --log-level <level>',
         'specify the level of log messages (default: "info")'
       ).choices(['error', 'warn', 'info', 'debug'])
     )
-    .option('-o, --out <out>', 'the path to the output folder')
+    .option('-o, --out <out>', 'the path to the output folder (default: "fsh-generated")')
     .option('-p, --preprocessed', 'output FSH produced by preprocessing steps')
     .option(
       '-r, --require-latest',
@@ -83,14 +83,6 @@ async function app() {
     .action(async function (projectPath, options) {
       setLogLevel(options);
       await runBuild(projectPath, options, program.helpInformation()).catch(logUnexpectedError);
-    })
-    .on('--help', () => {
-      console.log('');
-      console.log('Additional information:');
-      console.log('  [path-to-fsh-project]');
-      console.log('    Default: "."');
-      console.log('  -o, --out <out>');
-      console.log('    Default: "fsh-generated"');
     })
     // NOTE: This option is included give a nice error message when the old init option is used while we support
     // backwards compatibility of the build command.
@@ -135,12 +127,11 @@ async function app() {
         'specify the level of log messages (default: "info")'
       ).choices(['error', 'warn', 'info', 'debug'])
     )
-    .on('--help', () => {
-      console.log();
-      console.log(
-        'Note: all options used to set properties in sushi-config.yaml are optional. If not provided, you will be prompted for the information.'
-      );
-    })
+    .addHelpText(
+      'afterAll',
+      `
+Note: all options used to set properties in sushi-config.yaml are optional. If not provided, you will be prompted for the information.`
+    )
     .action(async function (projectName, options) {
       setLogLevel(options);
       await init(projectName, options).catch(logUnexpectedError);
@@ -150,7 +141,7 @@ async function app() {
   program
     .command('update-dependencies')
     .description('update FHIR packages in project configuration')
-    .argument('[path-to-fsh-project]')
+    .argument('[path-to-fsh-project]', 'path to your FSH project (default: ".")')
     .addOption(
       new Option(
         '-l, --log-level <level>',
@@ -161,12 +152,6 @@ async function app() {
       setLogLevel(options);
       await runUpdateDependencies(projectPath).catch(logUnexpectedError);
       process.exit(0);
-    })
-    .on('--help', () => {
-      console.log('');
-      console.log('Additional information:');
-      console.log('  [path-to-fsh-project]');
-      console.log('    Default: "."');
     });
 
   program.parse(process.argv).opts();

--- a/src/app.ts
+++ b/src/app.ts
@@ -117,6 +117,7 @@ async function app() {
     .option('-n, --version <version>', 'specify the version')
     .option('-p, --publisher-name <publisher-name>', 'specify the publisher name')
     .option('-u, --publisher-url <publisher-url>', 'specify the publisher URL')
+    .option('-d, --default', 'accept all remaining defaults')
     .option(
       '-a, --auto-initialize',
       'automatically initialize the SUSHI project in the current directory'

--- a/src/app.ts
+++ b/src/app.ts
@@ -80,6 +80,7 @@ async function app() {
         return Object.assign(previous, { [k]: v.join(':') });
       }
     )
+    .allowExcessArguments(false)
     .action(async function (projectPath, options) {
       setLogLevel(options);
       await runBuild(projectPath, options, program.helpInformation()).catch(logUnexpectedError);
@@ -123,6 +124,7 @@ async function app() {
         'specify the level of log messages (default: "info")'
       ).choices(['error', 'warn', 'info', 'debug'])
     )
+    .allowExcessArguments(false)
     .action(async function (projectName, options) {
       setLogLevel(options);
       await init(projectName, options).catch(logUnexpectedError);

--- a/src/app.ts
+++ b/src/app.ts
@@ -111,15 +111,39 @@ async function app() {
   program
     .command('init')
     .description('initialize a SUSHI project')
+    .argument('[name]', 'project name')
+    .option('-i, --id <id>', 'specify the id')
+    .option('-c, --canonical <canonical>', 'specify the canonical URL')
+    .addOption(
+      new Option('-s, --status <status>', 'specify the status').choices([
+        'draft',
+        'active',
+        'retired',
+        'unknown'
+      ])
+    )
+    .option('-n, --version <version>', 'specify the version')
+    .option('-p, --publisher-name <publisher-name>', 'specify the publisher name')
+    .option('-u, --publisher-url <publisher-url>', 'specify the publisher URL')
+    .option(
+      '-a, --auto-initialize',
+      'automatically initialize the SUSHI project in the current directory'
+    )
     .addOption(
       new Option(
         '-l, --log-level <level>',
         'specify the level of log messages (default: "info")'
       ).choices(['error', 'warn', 'info', 'debug'])
     )
-    .action(async function (options) {
+    .on('--help', () => {
+      console.log();
+      console.log(
+        'Note: all options used to set properties in sushi-config.yaml are optional. If not provided, you will be prompted for the information.'
+      );
+    })
+    .action(async function (projectName, options) {
       setLogLevel(options);
-      await init().catch(logUnexpectedError);
+      await init(projectName, options).catch(logUnexpectedError);
       process.exit(0);
     });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -104,19 +104,14 @@ async function app() {
     .command('init')
     .description('initialize a SUSHI project')
     .argument('[name]', 'project name')
-    .option('-i, --id <id>', 'specify the id')
-    .option('-c, --canonical <canonical>', 'specify the canonical URL')
-    .addOption(
-      new Option('-s, --status <status>', 'specify the status').choices([
-        'draft',
-        'active',
-        'retired',
-        'unknown'
-      ])
+    .option(
+      '-c, --config <config>',
+      "configure a specific property for the project (supported: 'id', 'canonical', 'status', 'version', 'releaselabel', 'publisher-name', 'publisher-url') (eg: --config status:draft)",
+      (value: string, previous = {}) => {
+        const [k, ...v] = value.split(':');
+        return Object.assign(previous, { [k.toLowerCase()]: v.join(':') });
+      }
     )
-    .option('-n, --version <version>', 'specify the version')
-    .option('-p, --publisher-name <publisher-name>', 'specify the publisher name')
-    .option('-u, --publisher-url <publisher-url>', 'specify the publisher URL')
     .option('-d, --default', 'accept all remaining defaults')
     .option(
       '-a, --auto-initialize',

--- a/src/app.ts
+++ b/src/app.ts
@@ -123,11 +123,6 @@ async function app() {
         'specify the level of log messages (default: "info")'
       ).choices(['error', 'warn', 'info', 'debug'])
     )
-    .addHelpText(
-      'afterAll',
-      `
-Note: all options used to set properties in sushi-config.yaml are optional. If not provided, you will be prompted for the information.`
-    )
     .action(async function (projectName, options) {
       setLogLevel(options);
       await init(projectName, options).catch(logUnexpectedError);

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -708,6 +708,8 @@ export async function init(name: string = null, options: OptionValues = {}): Pro
       // name is an argument on the CLI (not an option) so handle it separately
       userValue = name;
       console.log(`Name: ${name}`);
+    } else if (options.default) {
+      console.log(`${upperFirst(field)}: ${configDoc.get(field)}`);
     } else {
       userValue = readlineSync.question(
         `${upperFirst(field)} (Default: ${configDoc.get(field)}): `
@@ -730,6 +732,8 @@ export async function init(name: string = null, options: OptionValues = {}): Pro
     if (options[`publisher${upperFirst(field)}`] != null) {
       userValue = options[`publisher${upperFirst(field)}`];
       console.log(`Publisher ${upperFirst(field)}: ${options[`publisher${upperFirst(field)}`]}`);
+    } else if (options.default) {
+      console.log(`${upperFirst(field)}: ${configDoc.get('publisher').get(field)}`);
     } else {
       userValue = readlineSync.question(
         `Publisher ${upperFirst(field)} (Default: ${configDoc.get('publisher').get(field)}): `
@@ -747,10 +751,9 @@ export async function init(name: string = null, options: OptionValues = {}): Pro
   // Write init directory out, including user made sushi-config.yaml, files in utils/init-project, and build scripts from ig/files
   const outputDir = path.resolve('.', projectName);
   const initProjectDir = path.join(__dirname, 'init-project');
-  if (
-    !options.autoInitialize &&
-    !readlineSync.keyInYN(`Initialize SUSHI project in ${outputDir}?`)
-  ) {
+  if (options.autoInitialize) {
+    console.log(`Initializing SUSHI project in ${outputDir}`);
+  } else if (!readlineSync.keyInYN(`Initialize SUSHI project in ${outputDir}?`)) {
     console.log('\nAborting Initialization.\n');
     return;
   }

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -2370,6 +2370,7 @@ describe('Processing', () => {
         ['Canonical (Default: http://example.org): '],
         ['Status (Default: draft): '],
         ['Version (Default: 0.1.0): '],
+        ['Release Label (Default: ci-build): '],
         ['Publisher Name (Default: Example Publisher): '],
         ['Publisher Url (Default: http://example.org/example-publisher): ']
       ]);
@@ -2430,6 +2431,8 @@ describe('Processing', () => {
           return 'active';
         } else if (question.startsWith('Version')) {
           return '2.0.0';
+        } else if (question.startsWith('Release Label')) {
+          return 'qa-preview';
         } else if (question.startsWith('Publisher Name')) {
           return 'SUSHI Chefs';
         } else if (question.startsWith('Publisher Url')) {
@@ -2443,6 +2446,7 @@ describe('Processing', () => {
         ['Canonical (Default: http://example.org): '],
         ['Status (Default: draft): '],
         ['Version (Default: 0.1.0): '],
+        ['Release Label (Default: ci-build): '],
         ['Publisher Name (Default: Example Publisher): '],
         ['Publisher Url (Default: http://example.org/example-publisher): ']
       ]);
@@ -2502,6 +2506,7 @@ describe('Processing', () => {
         ['Canonical (Default: http://example.org): '],
         ['Status (Default: draft): '],
         ['Version (Default: 0.1.0): '],
+        ['Release Label (Default: ci-build): '],
         ['Publisher Name (Default: Example Publisher): '],
         ['Publisher Url (Default: http://example.org/example-publisher): ']
       ]);
@@ -2513,14 +2518,17 @@ describe('Processing', () => {
       expect(consoleSpy.mock.calls.slice(-1)[0]).toEqual(['\nAborting Initialization.\n']);
     });
 
-    it('should initialize a project when the user provides all options on the command line and allows auto-initializing', async () => {
+    it('should initialize a project when the user provides all config options on the command line and allows auto-initializing', async () => {
       await init('MyCLIOptionProject', {
-        id: 'foo.bar.baz',
-        canonical: 'http://foo.bar.baz.com',
-        status: 'active',
-        version: '2.0.0',
-        publisherName: 'Foo Bar Baz Inc.',
-        publisherUrl: 'http://foo.org',
+        config: {
+          id: 'foo.bar.baz',
+          canonical: 'http://foo.bar.baz.com',
+          status: 'active',
+          version: '2.0.0',
+          releaselabel: 'ballot',
+          'publisher-name': 'Foo Bar Baz Inc.',
+          'publisher-url': 'http://foo.org'
+        },
         autoInitialize: true
       });
       expect(readlineSpy.mock.calls).toHaveLength(0);
@@ -2570,28 +2578,33 @@ describe('Processing', () => {
       expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
     });
 
-    it('should prompt for and accept inputs for any option not already set with a command line option', async () => {
+    it('should prompt for and accept inputs for any option not already set with a command line config option', async () => {
       readlineSpy.mockImplementation((question: string) => {
         if (question.startsWith('Status')) {
           return 'active';
         } else if (question.startsWith('Version')) {
           return '2.0.0';
+        } else if (question.startsWith('Release Label')) {
+          return 'trial-use';
         } else if (question.startsWith('Publisher Name')) {
           return 'Foo Two';
         }
       });
 
       await init('MySemiCLIOptionProject', {
-        id: 'foo.bar.baz',
-        canonical: 'http://foo.bar.baz.com',
-        // status, version, publisherName all not specified so will need prompts
-        publisherUrl: 'http://foo.org'
+        config: {
+          id: 'foo.bar.baz',
+          canonical: 'http://foo.bar.baz.com',
+          // status, version, releaseLabel, publisherName all not specified so will need prompts
+          'publisher-url': 'http://foo.org'
+        }
         // autoInitialize not used so need to prompt to initialize
       });
       // Only prompt for the fields not specified in CLI options
       expect(readlineSpy.mock.calls).toEqual([
         ['Status (Default: draft): '],
         ['Version (Default: 0.1.0): '],
+        ['Release Label (Default: ci-build): '],
         ['Publisher Name (Default: Example Publisher): ']
       ]);
       // Need to confirm initialization
@@ -2644,12 +2657,14 @@ describe('Processing', () => {
       expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
     });
 
-    it('should accept remaining defaults without prompting for any options not already set with a command line option with default option is used', async () => {
+    it('should accept remaining defaults without prompting for any options not already set with a command line config option when default option is used', async () => {
       await init('MyCLIOptionWithDefaultsProject', {
-        id: 'foo.bar.baz',
-        canonical: 'http://foo.bar.baz.com',
-        // status, version, publisherName all not specified so will use defaults
-        publisherUrl: 'http://foo.org',
+        config: {
+          id: 'foo.bar.baz',
+          canonical: 'http://foo.bar.baz.com',
+          // status, version, releaseLabel, publisherName all not specified so will use defaults
+          'publisher-url': 'http://foo.org'
+        },
         default: true, // use defaults for any unspecified fields
         autoInitialize: true
       });

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -2643,6 +2643,67 @@ describe('Processing', () => {
       expect(writeSpy.mock.calls[6][0]).toMatch(/.*_updatePublisher\.sh/);
       expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
     });
+
+    it('should accept remaining defaults without prompting for any options not already set with a command line option with default option is used', async () => {
+      await init('MyCLIOptionWithDefaultsProject', {
+        id: 'foo.bar.baz',
+        canonical: 'http://foo.bar.baz.com',
+        // status, version, publisherName all not specified so will use defaults
+        publisherUrl: 'http://foo.org',
+        default: true, // use defaults for any unspecified fields
+        autoInitialize: true
+      });
+
+      expect(readlineSpy.mock.calls).toHaveLength(0);
+      expect(yesNoSpy.mock.calls).toHaveLength(0);
+
+      expect(ensureDirSpy.mock.calls).toHaveLength(2);
+      expect(ensureDirSpy.mock.calls[0][0]).toMatch(
+        /.*MyCLIOptionWithDefaultsProject.*input.*pagecontent/
+      );
+      expect(ensureDirSpy.mock.calls[1][0]).toMatch(/.*MyCLIOptionWithDefaultsProject.*input.*fsh/);
+
+      expect(writeSpy.mock.calls).toHaveLength(7);
+      expect(writeSpy.mock.calls[0][0]).toMatch(/.*index\.md/);
+      expect(writeSpy.mock.calls[0][1]).toMatch(/# MyCLIOptionWithDefaultsProject/);
+      expect(writeSpy.mock.calls[1][0]).toMatch(/.*ig\.ini/);
+      expect(writeSpy.mock.calls[1][1]).toMatch(/foo\.bar\.baz/);
+      expect(writeSpy.mock.calls[2][0]).toMatch(/.*sushi-config\.yaml/);
+      expect(writeSpy.mock.calls[2][1].replace(/[\n\r]/g, '')).toBe(
+        fs
+          .readFileSync(
+            path.join(__dirname, 'fixtures', 'init-config', 'cli-input-with-defaults-config.yaml'),
+            'utf-8'
+          )
+          .replace(/[\n\r]/g, '')
+          .replace('${YEAR}', String(new Date().getFullYear()))
+      );
+
+      expect(copyFileSpy.mock.calls).toHaveLength(3);
+      expect(copyFileSpy.mock.calls[0][1]).toMatch(
+        /.*MyCLIOptionWithDefaultsProject.*fsh.*patient.fsh/
+      );
+      expect(copyFileSpy.mock.calls[1][1]).toMatch(/.*MyCLIOptionWithDefaultsProject.*\.gitignore/);
+      expect(copyFileSpy.mock.calls[2][1]).toMatch(
+        /.*MyCLIOptionWithDefaultsProject.*input.*ignoreWarnings\.txt/
+      );
+
+      expect(getSpy.mock.calls).toHaveLength(4);
+      const base = 'https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
+      expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
+      expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
+      expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
+      expect(getSpy.mock.calls[3][0]).toBe(base + '_updatePublisher.sh');
+
+      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_genonce\.bat/);
+      expect(writeSpy.mock.calls[3][1]).toMatch(/_genonce\.bat/);
+      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_genonce\.sh/);
+      expect(writeSpy.mock.calls[4][1]).toMatch(/_genonce\.sh/);
+      expect(writeSpy.mock.calls[5][0]).toMatch(/.*_updatePublisher\.bat/);
+      expect(writeSpy.mock.calls[5][1]).toMatch(/_updatePublisher\.bat/);
+      expect(writeSpy.mock.calls[6][0]).toMatch(/.*_updatePublisher\.sh/);
+      expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
+    });
   });
 
   describe('#getLatestSushiVersion()', () => {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -2492,7 +2492,7 @@ describe('Processing', () => {
       expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
     });
 
-    it('should abort initalizing a project when the user does not confirm', async () => {
+    it('should abort initializing a project when the user does not confirm', async () => {
       yesNoSpy.mockImplementation(() => false);
 
       await init();
@@ -2511,6 +2511,137 @@ describe('Processing', () => {
       expect(writeSpy.mock.calls).toHaveLength(0);
       expect(copyFileSpy.mock.calls).toHaveLength(0);
       expect(consoleSpy.mock.calls.slice(-1)[0]).toEqual(['\nAborting Initialization.\n']);
+    });
+
+    it('should initialize a project when the user provides all options on the command line and allows auto-initializing', async () => {
+      await init('MyCLIOptionProject', {
+        id: 'foo.bar.baz',
+        canonical: 'http://foo.bar.baz.com',
+        status: 'active',
+        version: '2.0.0',
+        publisherName: 'Foo Bar Baz Inc.',
+        publisherUrl: 'http://foo.org',
+        autoInitialize: true
+      });
+      expect(readlineSpy.mock.calls).toHaveLength(0);
+      expect(yesNoSpy.mock.calls).toHaveLength(0);
+
+      expect(ensureDirSpy.mock.calls).toHaveLength(2);
+      expect(ensureDirSpy.mock.calls[0][0]).toMatch(/.*MyCLIOptionProject.*input.*pagecontent/);
+      expect(ensureDirSpy.mock.calls[1][0]).toMatch(/.*MyCLIOptionProject.*input.*fsh/);
+
+      expect(writeSpy.mock.calls).toHaveLength(7);
+      expect(writeSpy.mock.calls[0][0]).toMatch(/.*index\.md/);
+      expect(writeSpy.mock.calls[0][1]).toMatch(/# MyCLIOptionProject/);
+      expect(writeSpy.mock.calls[1][0]).toMatch(/.*ig\.ini/);
+      expect(writeSpy.mock.calls[1][1]).toMatch(/foo\.bar\.baz/);
+      expect(writeSpy.mock.calls[2][0]).toMatch(/.*sushi-config\.yaml/);
+      expect(writeSpy.mock.calls[2][1].replace(/[\n\r]/g, '')).toBe(
+        fs
+          .readFileSync(
+            path.join(__dirname, 'fixtures', 'init-config', 'cli-input-config.yaml'),
+            'utf-8'
+          )
+          .replace(/[\n\r]/g, '')
+          .replace('${YEAR}', String(new Date().getFullYear()))
+      );
+
+      expect(copyFileSpy.mock.calls).toHaveLength(3);
+      expect(copyFileSpy.mock.calls[0][1]).toMatch(/.*MyCLIOptionProject.*fsh.*patient.fsh/);
+      expect(copyFileSpy.mock.calls[1][1]).toMatch(/.*MyCLIOptionProject.*\.gitignore/);
+      expect(copyFileSpy.mock.calls[2][1]).toMatch(
+        /.*MyCLIOptionProject.*input.*ignoreWarnings\.txt/
+      );
+
+      expect(getSpy.mock.calls).toHaveLength(4);
+      const base = 'https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
+      expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
+      expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
+      expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
+      expect(getSpy.mock.calls[3][0]).toBe(base + '_updatePublisher.sh');
+
+      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_genonce\.bat/);
+      expect(writeSpy.mock.calls[3][1]).toMatch(/_genonce\.bat/);
+      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_genonce\.sh/);
+      expect(writeSpy.mock.calls[4][1]).toMatch(/_genonce\.sh/);
+      expect(writeSpy.mock.calls[5][0]).toMatch(/.*_updatePublisher\.bat/);
+      expect(writeSpy.mock.calls[5][1]).toMatch(/_updatePublisher\.bat/);
+      expect(writeSpy.mock.calls[6][0]).toMatch(/.*_updatePublisher\.sh/);
+      expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
+    });
+
+    it('should prompt for and accept inputs for any option not already set with a command line option', async () => {
+      readlineSpy.mockImplementation((question: string) => {
+        if (question.startsWith('Status')) {
+          return 'active';
+        } else if (question.startsWith('Version')) {
+          return '2.0.0';
+        } else if (question.startsWith('Publisher Name')) {
+          return 'Foo Two';
+        }
+      });
+
+      await init('MySemiCLIOptionProject', {
+        id: 'foo.bar.baz',
+        canonical: 'http://foo.bar.baz.com',
+        // status, version, publisherName all not specified so will need prompts
+        publisherUrl: 'http://foo.org'
+        // autoInitialize not used so need to prompt to initialize
+      });
+      // Only prompt for the fields not specified in CLI options
+      expect(readlineSpy.mock.calls).toEqual([
+        ['Status (Default: draft): '],
+        ['Version (Default: 0.1.0): '],
+        ['Publisher Name (Default: Example Publisher): ']
+      ]);
+      // Need to confirm initialization
+      expect(yesNoSpy.mock.calls).toHaveLength(1);
+      expect(yesNoSpy.mock.calls[0][0]).toMatch(
+        /Initialize SUSHI project in .*MySemiCLIOptionProject/
+      );
+
+      expect(ensureDirSpy.mock.calls).toHaveLength(2);
+      expect(ensureDirSpy.mock.calls[0][0]).toMatch(/.*MySemiCLIOptionProject.*input.*pagecontent/);
+      expect(ensureDirSpy.mock.calls[1][0]).toMatch(/.*MySemiCLIOptionProject.*input.*fsh/);
+
+      expect(writeSpy.mock.calls).toHaveLength(7);
+      expect(writeSpy.mock.calls[0][0]).toMatch(/.*index\.md/);
+      expect(writeSpy.mock.calls[0][1]).toMatch(/# MySemiCLIOptionProject/);
+      expect(writeSpy.mock.calls[1][0]).toMatch(/.*ig\.ini/);
+      expect(writeSpy.mock.calls[1][1]).toMatch(/foo\.bar\.baz/);
+      expect(writeSpy.mock.calls[2][0]).toMatch(/.*sushi-config\.yaml/);
+      expect(writeSpy.mock.calls[2][1].replace(/[\n\r]/g, '')).toBe(
+        fs
+          .readFileSync(
+            path.join(__dirname, 'fixtures', 'init-config', 'semi-cli-input-config.yaml'),
+            'utf-8'
+          )
+          .replace(/[\n\r]/g, '')
+          .replace('${YEAR}', String(new Date().getFullYear()))
+      );
+
+      expect(copyFileSpy.mock.calls).toHaveLength(3);
+      expect(copyFileSpy.mock.calls[0][1]).toMatch(/.*MySemiCLIOptionProject.*fsh.*patient.fsh/);
+      expect(copyFileSpy.mock.calls[1][1]).toMatch(/.*MySemiCLIOptionProject.*\.gitignore/);
+      expect(copyFileSpy.mock.calls[2][1]).toMatch(
+        /.*MySemiCLIOptionProject.*input.*ignoreWarnings\.txt/
+      );
+
+      expect(getSpy.mock.calls).toHaveLength(4);
+      const base = 'https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
+      expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
+      expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
+      expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
+      expect(getSpy.mock.calls[3][0]).toBe(base + '_updatePublisher.sh');
+
+      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_genonce\.bat/);
+      expect(writeSpy.mock.calls[3][1]).toMatch(/_genonce\.bat/);
+      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_genonce\.sh/);
+      expect(writeSpy.mock.calls[4][1]).toMatch(/_genonce\.sh/);
+      expect(writeSpy.mock.calls[5][0]).toMatch(/.*_updatePublisher\.bat/);
+      expect(writeSpy.mock.calls[5][1]).toMatch(/_updatePublisher\.bat/);
+      expect(writeSpy.mock.calls[6][0]).toMatch(/.*_updatePublisher\.sh/);
+      expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
     });
   });
 

--- a/test/utils/fixtures/init-config/cli-input-config.yaml
+++ b/test/utils/fixtures/init-config/cli-input-config.yaml
@@ -1,0 +1,213 @@
+# ╭─────────────────────────Commonly Used ImplementationGuide Properties───────────────────────────╮
+# │  The properties below are used to create the ImplementationGuide resource. The most commonly   │
+# │  used properties are included. For a list of all supported properties and their functions,     │
+# │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+id: foo.bar.baz
+canonical: http://foo.bar.baz.com
+name: MyCLIOptionProject
+# title: Example Title
+# description: Example Implementation Guide for getting started with SUSHI
+status: active # draft | active | retired | unknown
+version: 2.0.0
+fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
+copyrightYear: 2024+
+releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+# license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
+# jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
+publisher:
+  name: Foo Bar Baz Inc.
+  url: http://foo.org
+  # email: test@example.org
+
+# The dependencies property corresponds to IG.dependsOn. The key is the
+# package id and the value is the version (or dev/current). For advanced
+# use cases, the value can be an object with keys for id, uri, and version.
+#
+# dependencies:
+#   hl7.fhir.us.core: 3.1.0
+#   hl7.fhir.us.mcode:
+#     id: mcode
+#     uri: http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode
+#     version: 1.0.0
+#
+#
+# The pages property corresponds to IG.definition.page. SUSHI can
+# auto-generate the page list, but if the author includes pages in
+# this file, it is assumed that the author will fully manage the
+# pages section and SUSHI will not generate any page entries.
+# The page file name is used as the key. If title is not provided,
+# then the title will be generated from the file name.  If a
+# generation value is not provided, it will be inferred from the
+# file name extension.  Any subproperties that are valid filenames
+# with supported extensions (e.g., .md/.xml) will be treated as
+# sub-pages.
+#
+# pages:
+#   index.md:
+#     title: Example Home
+#   implementation.xml:
+#   examples.xml:
+#     title: Examples Overview
+#     simpleExamples.xml:
+#     complexExamples.xml:
+#
+#
+# The parameters property represents IG.definition.parameter. Rather
+# than a list of code/value pairs (as in the ImplementationGuide
+# resource), the code is the YAML key. If a parameter allows repeating
+# values, the value in the YAML should be a sequence/array.
+# For parameters defined by core FHIR see:
+# http://build.fhir.org/codesystem-guide-parameter-code.html
+# For parameters defined by the FHIR Tools IG see:
+# http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
+#
+# parameters:
+#   excludettl: true
+#   validation: [allow-any-extensions, no-broken-links]
+#
+# ╭────────────────────────────────────────────menu.xml────────────────────────────────────────────╮
+# │ The menu property will be used to generate the input/menu.xml file. The menu is represented    │
+# │ as a simple structure where the YAML key is the menu item name and the value is the URL.       │
+# │ The IG publisher currently only supports one level deep on sub-menus. To provide a             │
+# │ custom menu.xml file, do not include this property and include a `menu.xml` file in            │
+# │ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              │
+# │ property below.                                                                                │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+menu:
+  Home: index.html
+  Artifacts: artifacts.html
+
+# ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
+# │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │
+# │  resource. These properties are less commonly needed than those above.                         │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+#
+# Those who need more control or want to add additional details to the contact values can use
+# contact directly and follow the format outlined in the ImplementationGuide resource and
+# ContactDetail.
+#
+# contact:
+#   - name: Bob Smith
+#     telecom:
+#       - system: email # phone | fax | email | pager | url | sms | other
+#         value: bobsmith@example.org
+#         use: work
+#
+#
+# The global property corresponds to the IG.global property, but it
+# uses the type as the YAML key and the profile as its value. Since
+# FHIR does not explicitly disallow more than one profile per type,
+# neither do we; the value can be a single profile URL or an array
+# of profile URLs. If a value is an id or name, SUSHI will replace
+# it with the correct canonical when generating the IG JSON.
+#
+# global:
+#   Patient: http://example.org/fhir/StructureDefinition/my-patient-profile
+#   Encounter: http://example.org/fhir/StructureDefinition/my-encounter-profile
+#
+#
+# The resources property corresponds to IG.definition.resource.
+# SUSHI can auto-generate all of the resource entries based on
+# the FSH definitions and/or information in any user-provided
+# JSON or XML resource files. If the generated entries are not
+# sufficient or complete, however, the author can add entries
+# here. If the reference matches a generated entry, it will
+# replace the generated entry. If it doesn't match any generated
+# entries, it will be added to the generated entries. The format
+# follows IG.definition.resource with the following differences:
+#   * use IG.definition.resource.reference.reference as the YAML key.
+#   * if the key is an id or name, SUSHI will replace it with the
+#     correct URL when generating the IG JSON.
+#   * specify "omit" to omit a FSH-generated resource from the
+#     resource list.
+#   * if the exampleCanonical is an id or name, SUSHI will replace
+#     it with the correct canonical when generating the IG JSON.
+#   * groupingId can be used, but top-level groups syntax may be a
+#     better option (see below).
+# The following are simple examples to demonstrate what this might
+# look like:
+#
+# resources:
+#   Patient/my-example-patient:
+#     name: My Example Patient
+#     description: An example Patient
+#     exampleBoolean: true
+#   Patient/bad-example: omit
+#
+#
+# Groups can control certain aspects of the IG generation.  The IG
+# documentation recommends that authors use the default groups that
+# are provided by the templating framework, but if authors want to
+# use their own instead, they can use the mechanism below.  This will
+# create IG.definition.grouping entries and associate the individual
+# resource entries with the corresponding groupIds. If a resource
+# is specified by id or name, SUSHI will replace it with the correct
+# URL when generating the IG JSON.
+#
+# groups:
+#   GroupA:
+#     name: Group A
+#     description: The Alpha Group
+#     resources:
+#     - StructureDefinition/animal-patient
+#     - StructureDefinition/arm-procedure
+#   GroupB:
+#     name: Group B
+#     description: The Beta Group
+#     resources:
+#     - StructureDefinition/bark-control
+#     - StructureDefinition/bee-sting
+#
+#
+# The ImplementationGuide resource defines several other properties
+# not represented above. These properties can be used as-is and
+# should follow the format defined in ImplementationGuide:
+# * date
+# * meta
+# * implicitRules
+# * language
+# * text
+# * contained
+# * extension
+# * modifierExtension
+# * experimental
+# * useContext
+# * copyright
+# * packageId
+#
+#
+# ╭──────────────────────────────────────────SUSHI flags───────────────────────────────────────────╮
+# │  The flags below configure aspects of how SUSHI processes FSH.                                 │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+# The FSHOnly flag indicates if only FSH resources should be exported.
+# If set to true, no IG related content will be generated.
+# The default value for this property is false.
+#
+# FSHOnly: false
+#
+#
+# When set to true, the "short" and "definition" field on the root element of an Extension will
+# be set to the "Title" and "Description" of that Extension. Default is true.
+#
+# applyExtensionMetadataToRoot: true
+#
+#
+# The instanceOptions property is used to configure certain aspects of how SUSHI processes instances.
+# See the individual option definitions below for more detail.
+#
+instanceOptions:
+  # When set to true, slices must be referred to by name and not only by a numeric index in order to be used
+  # in an Instance's assignment rule. All slices appear in the order in which they are specified in FSH rules.
+  # While SUSHI defaults to false for legacy reasons, manualSliceOrding is recommended for new projects.
+  manualSliceOrdering: true # true | false
+  # Determines for which types of Instances SUSHI will automatically set meta.profile
+  # if InstanceOf references a profile:
+  #
+  # setMetaProfile: always # always | never | inline-only | standalone-only
+  #
+  #
+  # Determines for which types of Instances SUSHI will automatically set id
+  # if InstanceOf references a profile:
+  #
+  # setId: always # always | standalone-only

--- a/test/utils/fixtures/init-config/cli-input-config.yaml
+++ b/test/utils/fixtures/init-config/cli-input-config.yaml
@@ -11,8 +11,8 @@ name: MyCLIOptionProject
 status: active # draft | active | retired | unknown
 version: 2.0.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
-copyrightYear: 2024+
-releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+copyrightYear: ${YEAR}+
+releaseLabel: ballot # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:

--- a/test/utils/fixtures/init-config/cli-input-with-defaults-config.yaml
+++ b/test/utils/fixtures/init-config/cli-input-with-defaults-config.yaml
@@ -11,7 +11,7 @@ name: MyCLIOptionWithDefaultsProject
 status: draft # draft | active | retired | unknown
 version: 0.1.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
-copyrightYear: 2024+
+copyrightYear: ${YEAR}+
 releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html

--- a/test/utils/fixtures/init-config/cli-input-with-defaults-config.yaml
+++ b/test/utils/fixtures/init-config/cli-input-with-defaults-config.yaml
@@ -1,0 +1,213 @@
+# ╭─────────────────────────Commonly Used ImplementationGuide Properties───────────────────────────╮
+# │  The properties below are used to create the ImplementationGuide resource. The most commonly   │
+# │  used properties are included. For a list of all supported properties and their functions,     │
+# │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+id: foo.bar.baz
+canonical: http://foo.bar.baz.com
+name: MyCLIOptionWithDefaultsProject
+# title: Example Title
+# description: Example Implementation Guide for getting started with SUSHI
+status: draft # draft | active | retired | unknown
+version: 0.1.0
+fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
+copyrightYear: 2024+
+releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+# license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
+# jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
+publisher:
+  name: Example Publisher
+  url: http://foo.org
+  # email: test@example.org
+
+# The dependencies property corresponds to IG.dependsOn. The key is the
+# package id and the value is the version (or dev/current). For advanced
+# use cases, the value can be an object with keys for id, uri, and version.
+#
+# dependencies:
+#   hl7.fhir.us.core: 3.1.0
+#   hl7.fhir.us.mcode:
+#     id: mcode
+#     uri: http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode
+#     version: 1.0.0
+#
+#
+# The pages property corresponds to IG.definition.page. SUSHI can
+# auto-generate the page list, but if the author includes pages in
+# this file, it is assumed that the author will fully manage the
+# pages section and SUSHI will not generate any page entries.
+# The page file name is used as the key. If title is not provided,
+# then the title will be generated from the file name.  If a
+# generation value is not provided, it will be inferred from the
+# file name extension.  Any subproperties that are valid filenames
+# with supported extensions (e.g., .md/.xml) will be treated as
+# sub-pages.
+#
+# pages:
+#   index.md:
+#     title: Example Home
+#   implementation.xml:
+#   examples.xml:
+#     title: Examples Overview
+#     simpleExamples.xml:
+#     complexExamples.xml:
+#
+#
+# The parameters property represents IG.definition.parameter. Rather
+# than a list of code/value pairs (as in the ImplementationGuide
+# resource), the code is the YAML key. If a parameter allows repeating
+# values, the value in the YAML should be a sequence/array.
+# For parameters defined by core FHIR see:
+# http://build.fhir.org/codesystem-guide-parameter-code.html
+# For parameters defined by the FHIR Tools IG see:
+# http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
+#
+# parameters:
+#   excludettl: true
+#   validation: [allow-any-extensions, no-broken-links]
+#
+# ╭────────────────────────────────────────────menu.xml────────────────────────────────────────────╮
+# │ The menu property will be used to generate the input/menu.xml file. The menu is represented    │
+# │ as a simple structure where the YAML key is the menu item name and the value is the URL.       │
+# │ The IG publisher currently only supports one level deep on sub-menus. To provide a             │
+# │ custom menu.xml file, do not include this property and include a `menu.xml` file in            │
+# │ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              │
+# │ property below.                                                                                │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+menu:
+  Home: index.html
+  Artifacts: artifacts.html
+
+# ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
+# │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │
+# │  resource. These properties are less commonly needed than those above.                         │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+#
+# Those who need more control or want to add additional details to the contact values can use
+# contact directly and follow the format outlined in the ImplementationGuide resource and
+# ContactDetail.
+#
+# contact:
+#   - name: Bob Smith
+#     telecom:
+#       - system: email # phone | fax | email | pager | url | sms | other
+#         value: bobsmith@example.org
+#         use: work
+#
+#
+# The global property corresponds to the IG.global property, but it
+# uses the type as the YAML key and the profile as its value. Since
+# FHIR does not explicitly disallow more than one profile per type,
+# neither do we; the value can be a single profile URL or an array
+# of profile URLs. If a value is an id or name, SUSHI will replace
+# it with the correct canonical when generating the IG JSON.
+#
+# global:
+#   Patient: http://example.org/fhir/StructureDefinition/my-patient-profile
+#   Encounter: http://example.org/fhir/StructureDefinition/my-encounter-profile
+#
+#
+# The resources property corresponds to IG.definition.resource.
+# SUSHI can auto-generate all of the resource entries based on
+# the FSH definitions and/or information in any user-provided
+# JSON or XML resource files. If the generated entries are not
+# sufficient or complete, however, the author can add entries
+# here. If the reference matches a generated entry, it will
+# replace the generated entry. If it doesn't match any generated
+# entries, it will be added to the generated entries. The format
+# follows IG.definition.resource with the following differences:
+#   * use IG.definition.resource.reference.reference as the YAML key.
+#   * if the key is an id or name, SUSHI will replace it with the
+#     correct URL when generating the IG JSON.
+#   * specify "omit" to omit a FSH-generated resource from the
+#     resource list.
+#   * if the exampleCanonical is an id or name, SUSHI will replace
+#     it with the correct canonical when generating the IG JSON.
+#   * groupingId can be used, but top-level groups syntax may be a
+#     better option (see below).
+# The following are simple examples to demonstrate what this might
+# look like:
+#
+# resources:
+#   Patient/my-example-patient:
+#     name: My Example Patient
+#     description: An example Patient
+#     exampleBoolean: true
+#   Patient/bad-example: omit
+#
+#
+# Groups can control certain aspects of the IG generation.  The IG
+# documentation recommends that authors use the default groups that
+# are provided by the templating framework, but if authors want to
+# use their own instead, they can use the mechanism below.  This will
+# create IG.definition.grouping entries and associate the individual
+# resource entries with the corresponding groupIds. If a resource
+# is specified by id or name, SUSHI will replace it with the correct
+# URL when generating the IG JSON.
+#
+# groups:
+#   GroupA:
+#     name: Group A
+#     description: The Alpha Group
+#     resources:
+#     - StructureDefinition/animal-patient
+#     - StructureDefinition/arm-procedure
+#   GroupB:
+#     name: Group B
+#     description: The Beta Group
+#     resources:
+#     - StructureDefinition/bark-control
+#     - StructureDefinition/bee-sting
+#
+#
+# The ImplementationGuide resource defines several other properties
+# not represented above. These properties can be used as-is and
+# should follow the format defined in ImplementationGuide:
+# * date
+# * meta
+# * implicitRules
+# * language
+# * text
+# * contained
+# * extension
+# * modifierExtension
+# * experimental
+# * useContext
+# * copyright
+# * packageId
+#
+#
+# ╭──────────────────────────────────────────SUSHI flags───────────────────────────────────────────╮
+# │  The flags below configure aspects of how SUSHI processes FSH.                                 │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+# The FSHOnly flag indicates if only FSH resources should be exported.
+# If set to true, no IG related content will be generated.
+# The default value for this property is false.
+#
+# FSHOnly: false
+#
+#
+# When set to true, the "short" and "definition" field on the root element of an Extension will
+# be set to the "Title" and "Description" of that Extension. Default is true.
+#
+# applyExtensionMetadataToRoot: true
+#
+#
+# The instanceOptions property is used to configure certain aspects of how SUSHI processes instances.
+# See the individual option definitions below for more detail.
+#
+instanceOptions:
+  # When set to true, slices must be referred to by name and not only by a numeric index in order to be used
+  # in an Instance's assignment rule. All slices appear in the order in which they are specified in FSH rules.
+  # While SUSHI defaults to false for legacy reasons, manualSliceOrding is recommended for new projects.
+  manualSliceOrdering: true # true | false
+  # Determines for which types of Instances SUSHI will automatically set meta.profile
+  # if InstanceOf references a profile:
+  #
+  # setMetaProfile: always # always | never | inline-only | standalone-only
+  #
+  #
+  # Determines for which types of Instances SUSHI will automatically set id
+  # if InstanceOf references a profile:
+  #
+  # setId: always # always | standalone-only

--- a/test/utils/fixtures/init-config/semi-cli-input-config.yaml
+++ b/test/utils/fixtures/init-config/semi-cli-input-config.yaml
@@ -11,8 +11,8 @@ name: MySemiCLIOptionProject
 status: active # draft | active | retired | unknown
 version: 2.0.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
-copyrightYear: 2024+
-releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+copyrightYear: ${YEAR}+
+releaseLabel: trial-use # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:

--- a/test/utils/fixtures/init-config/semi-cli-input-config.yaml
+++ b/test/utils/fixtures/init-config/semi-cli-input-config.yaml
@@ -1,0 +1,213 @@
+# ╭─────────────────────────Commonly Used ImplementationGuide Properties───────────────────────────╮
+# │  The properties below are used to create the ImplementationGuide resource. The most commonly   │
+# │  used properties are included. For a list of all supported properties and their functions,     │
+# │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+id: foo.bar.baz
+canonical: http://foo.bar.baz.com
+name: MySemiCLIOptionProject
+# title: Example Title
+# description: Example Implementation Guide for getting started with SUSHI
+status: active # draft | active | retired | unknown
+version: 2.0.0
+fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
+copyrightYear: 2024+
+releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+# license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
+# jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
+publisher:
+  name: Foo Two
+  url: http://foo.org
+  # email: test@example.org
+
+# The dependencies property corresponds to IG.dependsOn. The key is the
+# package id and the value is the version (or dev/current). For advanced
+# use cases, the value can be an object with keys for id, uri, and version.
+#
+# dependencies:
+#   hl7.fhir.us.core: 3.1.0
+#   hl7.fhir.us.mcode:
+#     id: mcode
+#     uri: http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode
+#     version: 1.0.0
+#
+#
+# The pages property corresponds to IG.definition.page. SUSHI can
+# auto-generate the page list, but if the author includes pages in
+# this file, it is assumed that the author will fully manage the
+# pages section and SUSHI will not generate any page entries.
+# The page file name is used as the key. If title is not provided,
+# then the title will be generated from the file name.  If a
+# generation value is not provided, it will be inferred from the
+# file name extension.  Any subproperties that are valid filenames
+# with supported extensions (e.g., .md/.xml) will be treated as
+# sub-pages.
+#
+# pages:
+#   index.md:
+#     title: Example Home
+#   implementation.xml:
+#   examples.xml:
+#     title: Examples Overview
+#     simpleExamples.xml:
+#     complexExamples.xml:
+#
+#
+# The parameters property represents IG.definition.parameter. Rather
+# than a list of code/value pairs (as in the ImplementationGuide
+# resource), the code is the YAML key. If a parameter allows repeating
+# values, the value in the YAML should be a sequence/array.
+# For parameters defined by core FHIR see:
+# http://build.fhir.org/codesystem-guide-parameter-code.html
+# For parameters defined by the FHIR Tools IG see:
+# http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
+#
+# parameters:
+#   excludettl: true
+#   validation: [allow-any-extensions, no-broken-links]
+#
+# ╭────────────────────────────────────────────menu.xml────────────────────────────────────────────╮
+# │ The menu property will be used to generate the input/menu.xml file. The menu is represented    │
+# │ as a simple structure where the YAML key is the menu item name and the value is the URL.       │
+# │ The IG publisher currently only supports one level deep on sub-menus. To provide a             │
+# │ custom menu.xml file, do not include this property and include a `menu.xml` file in            │
+# │ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              │
+# │ property below.                                                                                │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+menu:
+  Home: index.html
+  Artifacts: artifacts.html
+
+# ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
+# │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │
+# │  resource. These properties are less commonly needed than those above.                         │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+#
+# Those who need more control or want to add additional details to the contact values can use
+# contact directly and follow the format outlined in the ImplementationGuide resource and
+# ContactDetail.
+#
+# contact:
+#   - name: Bob Smith
+#     telecom:
+#       - system: email # phone | fax | email | pager | url | sms | other
+#         value: bobsmith@example.org
+#         use: work
+#
+#
+# The global property corresponds to the IG.global property, but it
+# uses the type as the YAML key and the profile as its value. Since
+# FHIR does not explicitly disallow more than one profile per type,
+# neither do we; the value can be a single profile URL or an array
+# of profile URLs. If a value is an id or name, SUSHI will replace
+# it with the correct canonical when generating the IG JSON.
+#
+# global:
+#   Patient: http://example.org/fhir/StructureDefinition/my-patient-profile
+#   Encounter: http://example.org/fhir/StructureDefinition/my-encounter-profile
+#
+#
+# The resources property corresponds to IG.definition.resource.
+# SUSHI can auto-generate all of the resource entries based on
+# the FSH definitions and/or information in any user-provided
+# JSON or XML resource files. If the generated entries are not
+# sufficient or complete, however, the author can add entries
+# here. If the reference matches a generated entry, it will
+# replace the generated entry. If it doesn't match any generated
+# entries, it will be added to the generated entries. The format
+# follows IG.definition.resource with the following differences:
+#   * use IG.definition.resource.reference.reference as the YAML key.
+#   * if the key is an id or name, SUSHI will replace it with the
+#     correct URL when generating the IG JSON.
+#   * specify "omit" to omit a FSH-generated resource from the
+#     resource list.
+#   * if the exampleCanonical is an id or name, SUSHI will replace
+#     it with the correct canonical when generating the IG JSON.
+#   * groupingId can be used, but top-level groups syntax may be a
+#     better option (see below).
+# The following are simple examples to demonstrate what this might
+# look like:
+#
+# resources:
+#   Patient/my-example-patient:
+#     name: My Example Patient
+#     description: An example Patient
+#     exampleBoolean: true
+#   Patient/bad-example: omit
+#
+#
+# Groups can control certain aspects of the IG generation.  The IG
+# documentation recommends that authors use the default groups that
+# are provided by the templating framework, but if authors want to
+# use their own instead, they can use the mechanism below.  This will
+# create IG.definition.grouping entries and associate the individual
+# resource entries with the corresponding groupIds. If a resource
+# is specified by id or name, SUSHI will replace it with the correct
+# URL when generating the IG JSON.
+#
+# groups:
+#   GroupA:
+#     name: Group A
+#     description: The Alpha Group
+#     resources:
+#     - StructureDefinition/animal-patient
+#     - StructureDefinition/arm-procedure
+#   GroupB:
+#     name: Group B
+#     description: The Beta Group
+#     resources:
+#     - StructureDefinition/bark-control
+#     - StructureDefinition/bee-sting
+#
+#
+# The ImplementationGuide resource defines several other properties
+# not represented above. These properties can be used as-is and
+# should follow the format defined in ImplementationGuide:
+# * date
+# * meta
+# * implicitRules
+# * language
+# * text
+# * contained
+# * extension
+# * modifierExtension
+# * experimental
+# * useContext
+# * copyright
+# * packageId
+#
+#
+# ╭──────────────────────────────────────────SUSHI flags───────────────────────────────────────────╮
+# │  The flags below configure aspects of how SUSHI processes FSH.                                 │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+# The FSHOnly flag indicates if only FSH resources should be exported.
+# If set to true, no IG related content will be generated.
+# The default value for this property is false.
+#
+# FSHOnly: false
+#
+#
+# When set to true, the "short" and "definition" field on the root element of an Extension will
+# be set to the "Title" and "Description" of that Extension. Default is true.
+#
+# applyExtensionMetadataToRoot: true
+#
+#
+# The instanceOptions property is used to configure certain aspects of how SUSHI processes instances.
+# See the individual option definitions below for more detail.
+#
+instanceOptions:
+  # When set to true, slices must be referred to by name and not only by a numeric index in order to be used
+  # in an Instance's assignment rule. All slices appear in the order in which they are specified in FSH rules.
+  # While SUSHI defaults to false for legacy reasons, manualSliceOrding is recommended for new projects.
+  manualSliceOrdering: true # true | false
+  # Determines for which types of Instances SUSHI will automatically set meta.profile
+  # if InstanceOf references a profile:
+  #
+  # setMetaProfile: always # always | never | inline-only | standalone-only
+  #
+  #
+  # Determines for which types of Instances SUSHI will automatically set id
+  # if InstanceOf references a profile:
+  #
+  # setId: always # always | standalone-only

--- a/test/utils/fixtures/init-config/user-input-config.yaml
+++ b/test/utils/fixtures/init-config/user-input-config.yaml
@@ -12,7 +12,7 @@ status: active # draft | active | retired | unknown
 version: 2.0.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: ${YEAR}+
-releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: qa-preview # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:


### PR DESCRIPTION
Fixes #1445 

This PR updates the `sushi init` command with the following new arguments and options:
- `name` argument: allows you to give the name of the project you are creating. If provided, `sushi init` will not prompt you for a project name.
- `-c, --config`: similar to the new option for `sushi build`, this option lets you specify the value for any of the prompts in `sushi init`. Specifying a value with this option will no longer prompt you for that question and instead will just log the value you set.
- `-d, --default`: if provided, any values not specified value using `-c, --config` will just use the default value. No prompts will be asked, and instead, the default values are logged.
- `-a, --auto-initialize`: If provided, the project will automatically be initialized once all prompts are answered and/or all values are set using `-c` or `-d`. The y/n prompt for initializing is skipped.

I also simplified the `--help` text for `build` and `init` by moving the defaults for the `path-to-fsh-project` and `out` onto the same line as the description of that argument/option and removing the `.on('--help', ...)` portion. I'm not entirely sure why we didn't do that from the beginning (maybe it wasn't possible when we first wrote that?), but if there was a reason I forgot about, I can revert that change.