### PR TITLE
Remove releaseLabel coded options from `sushi-config.yaml` created by `sushi init`

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -721,11 +721,6 @@ export async function init(
         const node = YAML.createNode(userValue);
         node.comment = ' draft | active | retired | unknown';
         configDoc.set(field, node);
-      } else if (field === 'releaseLabel') {
-        const node = YAML.createNode(userValue);
-        node.comment =
-          ' ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use';
-        configDoc.set(field, node);
       } else {
         configDoc.set(field, userValue);
       }

--- a/src/utils/init-project/sushi-config.yaml
+++ b/src/utils/init-project/sushi-config.yaml
@@ -12,7 +12,7 @@ status: draft # draft | active | retired | unknown
 version: 0.1.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2020+
-releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: ci-build
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:

--- a/test/utils/fixtures/init-config/cli-input-config.yaml
+++ b/test/utils/fixtures/init-config/cli-input-config.yaml
@@ -12,7 +12,7 @@ status: active # draft | active | retired | unknown
 version: 2.0.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: ${YEAR}+
-releaseLabel: ballot # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: ballot
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:

--- a/test/utils/fixtures/init-config/cli-input-with-defaults-config.yaml
+++ b/test/utils/fixtures/init-config/cli-input-with-defaults-config.yaml
@@ -12,7 +12,7 @@ status: draft # draft | active | retired | unknown
 version: 0.1.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: ${YEAR}+
-releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: ci-build
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:

--- a/test/utils/fixtures/init-config/default-config.yaml
+++ b/test/utils/fixtures/init-config/default-config.yaml
@@ -12,7 +12,7 @@ status: draft # draft | active | retired | unknown
 version: 0.1.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: ${YEAR}+
-releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: ci-build
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:

--- a/test/utils/fixtures/init-config/semi-cli-input-config.yaml
+++ b/test/utils/fixtures/init-config/semi-cli-input-config.yaml
@@ -12,7 +12,7 @@ status: active # draft | active | retired | unknown
 version: 2.0.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: ${YEAR}+
-releaseLabel: trial-use # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: trial-use
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:

--- a/test/utils/fixtures/init-config/user-input-config.yaml
+++ b/test/utils/fixtures/init-config/user-input-config.yaml
@@ -12,7 +12,7 @@ status: active # draft | active | retired | unknown
 version: 2.0.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: ${YEAR}+
-releaseLabel: qa-preview # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: qa-preview
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:


### PR DESCRIPTION
This PR removes the comment that is included when you generate a `sushi-config.yaml` file using `sushi init`. Because `releaselabel` has recently been clarified to be any string value, we no longer need to include coded options for this property. 

Best practices will be documented on FSH School. We haven't fully explained other basic properties, like `copyrightyYear` or `fhirVersion`, within the config file itself, so I opted to not explain the best practices for `releaseLabel` directly in the config file either. However, if anyone thinks it would be useful to still include a comment with some options of values, let me know.

Fixes #1461 