### PR TITLE
Warn when config does not include menu and there is no menu.xml

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -665,16 +665,17 @@ export class IGExporter {
   /**
    * Adds menu.xml
    * A user can define a menu in sushi-config.yaml or provide one in ./input/includes.
-   * If neither is provided, the static one SUSHI provides will be used.
+   * If neither is provided, a warning is issued to the user.
    *
    * @param {string} igPath - the path where the IG is exported to
    */
   addMenuXML(igPath: string): void {
     const menuXMLDefaultPath = path.join(this.inputPath, 'input', 'includes', 'menu.xml');
     const menuXMLOutputPath = path.join(igPath, 'fsh-generated', 'includes', 'menu.xml');
+    const menuXMLExists = existsSync(menuXMLDefaultPath);
 
     // If user provided file and config, log a warning but prefer the file.
-    if (existsSync(menuXMLDefaultPath) && this.config.menu) {
+    if (menuXMLExists && this.config.menu) {
       const filePathString = path.join(
         path.basename(this.inputPath),
         'input',
@@ -715,6 +716,14 @@ export class IGExporter {
         ]
       );
       outputFileSync(menuXMLOutputPath, `${warning}${menu}`, 'utf8');
+    }
+
+    // If user did not provide file or config, log a warning.
+    if (!menuXMLExists && !this.config.menu) {
+      const filePathString = path.join('input', 'includes');
+      logger.warn(
+        `No "menu" property or file was found. Generate a menu.xml in the ${filePathString} folder or specify a "menu" property in ${this.configName}`
+      );
     }
   }
 

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -722,7 +722,7 @@ export class IGExporter {
     if (!menuXMLExists && !this.config.menu) {
       const filePathString = path.join('input', 'includes');
       logger.warn(
-        `No "menu" property or file was found. Generate a menu.xml in the ${filePathString} folder or specify a "menu" property in ${this.configName}`
+        `No "menu" property or file was found. Generate a menu.xml in the ${filePathString} folder or specify a "menu" property in ${this.configName}.`
       );
     }
   }

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -1913,6 +1913,10 @@ describe('IGExporter', () => {
       loggerSpy.reset();
       tempOut = temp.mkdirSync('sushi-test');
       config = cloneDeep(minimalConfig);
+      config.menu = [
+        { name: 'Home', url: 'index.html' },
+        { name: 'Artifacts', url: 'artifacts.html' }
+      ];
       config.resources = [
         {
           reference: { reference: 'Patient/BazPatient' },
@@ -2928,6 +2932,10 @@ describe('IGExporter', () => {
       loggerSpy.reset();
       tempOut = temp.mkdirSync('sushi-test');
       config = cloneDeep(minimalConfig);
+      config.menu = [
+        { name: 'Home', url: 'index.html' },
+        { name: 'Artifacts', url: 'artifacts.html' }
+      ];
       config.parameters = [];
       config.parameters.push({
         code: 'path-resource',
@@ -3020,6 +3028,10 @@ describe('IGExporter', () => {
 
     it('should not warn on deeply nested resources that are included in the path-resource parameter with a directory and wildcard', () => {
       const config = cloneDeep(minimalConfig);
+      config.menu = [
+        { name: 'Home', url: 'index.html' },
+        { name: 'Artifacts', url: 'artifacts.html' }
+      ];
       config.parameters = [];
       config.parameters.push({
         code: 'path-resource',
@@ -3040,6 +3052,10 @@ describe('IGExporter', () => {
 
     it('should warn on deeply nested resources that are included in the path-resource parameter with a directory but NO wildcard', () => {
       const config = cloneDeep(minimalConfig);
+      config.menu = [
+        { name: 'Home', url: 'index.html' },
+        { name: 'Artifacts', url: 'artifacts.html' }
+      ];
       config.parameters = [];
       config.parameters.push({
         code: 'path-resource',
@@ -3082,6 +3098,10 @@ describe('IGExporter', () => {
       loggerSpy.reset();
       tempOut = temp.mkdirSync('sushi-test');
       config = cloneDeep(minimalConfig);
+      config.menu = [
+        { name: 'Home', url: 'index.html' },
+        { name: 'Artifacts', url: 'artifacts.html' }
+      ];
       config.resources = [
         {
           reference: {
@@ -3241,6 +3261,10 @@ describe('IGExporter', () => {
       loggerSpy.reset();
       tempOut = temp.mkdirSync('sushi-test');
       config = cloneDeep(minimalConfig);
+      config.menu = [
+        { name: 'Home', url: 'index.html' },
+        { name: 'Artifacts', url: 'artifacts.html' }
+      ];
       config.resources = [
         {
           reference: {
@@ -3347,6 +3371,10 @@ describe('IGExporter', () => {
           }
         ]
       };
+      config.menu = [
+        { name: 'Home', url: 'index.html' },
+        { name: 'Artifacts', url: 'artifacts.html' }
+      ];
       pkg = new Package(config);
 
       // Profile: StructureDefinition/sample-patient

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -17,6 +17,7 @@ import { FHIRDefinitions, loadCustomResources } from '../../src/fhirdefs';
 import { loggerSpy, TestFisher } from '../testhelpers';
 import { cloneDeep } from 'lodash';
 import { minimalConfig } from '../utils/minimalConfig';
+import { minimalConfigWithMenu } from '../utils/minimalConfigWithMenu';
 
 describe('IGExporter', () => {
   temp.track();
@@ -1912,11 +1913,7 @@ describe('IGExporter', () => {
     beforeEach(() => {
       loggerSpy.reset();
       tempOut = temp.mkdirSync('sushi-test');
-      config = cloneDeep(minimalConfig);
-      config.menu = [
-        { name: 'Home', url: 'index.html' },
-        { name: 'Artifacts', url: 'artifacts.html' }
-      ];
+      config = cloneDeep(minimalConfigWithMenu);
       config.resources = [
         {
           reference: { reference: 'Patient/BazPatient' },
@@ -2931,11 +2928,7 @@ describe('IGExporter', () => {
     beforeEach(() => {
       loggerSpy.reset();
       tempOut = temp.mkdirSync('sushi-test');
-      config = cloneDeep(minimalConfig);
-      config.menu = [
-        { name: 'Home', url: 'index.html' },
-        { name: 'Artifacts', url: 'artifacts.html' }
-      ];
+      config = cloneDeep(minimalConfigWithMenu);
       config.parameters = [];
       config.parameters.push({
         code: 'path-resource',
@@ -3027,11 +3020,7 @@ describe('IGExporter', () => {
     });
 
     it('should not warn on deeply nested resources that are included in the path-resource parameter with a directory and wildcard', () => {
-      const config = cloneDeep(minimalConfig);
-      config.menu = [
-        { name: 'Home', url: 'index.html' },
-        { name: 'Artifacts', url: 'artifacts.html' }
-      ];
+      const config = cloneDeep(minimalConfigWithMenu);
       config.parameters = [];
       config.parameters.push({
         code: 'path-resource',
@@ -3051,11 +3040,7 @@ describe('IGExporter', () => {
     });
 
     it('should warn on deeply nested resources that are included in the path-resource parameter with a directory but NO wildcard', () => {
-      const config = cloneDeep(minimalConfig);
-      config.menu = [
-        { name: 'Home', url: 'index.html' },
-        { name: 'Artifacts', url: 'artifacts.html' }
-      ];
+      const config = cloneDeep(minimalConfigWithMenu);
       config.parameters = [];
       config.parameters.push({
         code: 'path-resource',
@@ -3097,11 +3082,7 @@ describe('IGExporter', () => {
     beforeEach(() => {
       loggerSpy.reset();
       tempOut = temp.mkdirSync('sushi-test');
-      config = cloneDeep(minimalConfig);
-      config.menu = [
-        { name: 'Home', url: 'index.html' },
-        { name: 'Artifacts', url: 'artifacts.html' }
-      ];
+      config = cloneDeep(minimalConfigWithMenu);
       config.resources = [
         {
           reference: {
@@ -3260,11 +3241,7 @@ describe('IGExporter', () => {
     beforeEach(() => {
       loggerSpy.reset();
       tempOut = temp.mkdirSync('sushi-test');
-      config = cloneDeep(minimalConfig);
-      config.menu = [
-        { name: 'Home', url: 'index.html' },
-        { name: 'Artifacts', url: 'artifacts.html' }
-      ];
+      config = cloneDeep(minimalConfigWithMenu);
       config.resources = [
         {
           reference: {
@@ -3369,12 +3346,12 @@ describe('IGExporter', () => {
             code: 'releaselabel',
             value: 'CI Build'
           }
+        ],
+        menu: [
+          { name: 'Home', url: 'index.html' },
+          { name: 'Artifacts', url: 'artifacts.html' }
         ]
       };
-      config.menu = [
-        { name: 'Home', url: 'index.html' },
-        { name: 'Artifacts', url: 'artifacts.html' }
-      ];
       pkg = new Package(config);
 
       // Profile: StructureDefinition/sample-patient

--- a/test/ig/IGExporter.menu-xml.test.ts
+++ b/test/ig/IGExporter.menu-xml.test.ts
@@ -38,7 +38,9 @@ describe('IGExporter', () => {
       const menuPath = path.join(tempOut, 'input', 'includes', 'menu.xml');
       expect(fs.existsSync(menuPath)).toBeFalsy();
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
-      expect(loggerSpy.getLastMessage()).toMatch(/No "menu" property or file was found\./s);
+      expect(loggerSpy.getLastMessage()).toMatch(
+        /No "menu" property or file was found\. .*input[\/\\]includes folder.* or .* in sushi-config\.yaml/s
+      );
     });
 
     it('should use but not copy user-provided menu.xml when config.menu is not defined', () => {

--- a/test/ig/IGExporter.menu-xml.test.ts
+++ b/test/ig/IGExporter.menu-xml.test.ts
@@ -30,14 +30,15 @@ describe('IGExporter', () => {
       temp.cleanupSync();
     });
 
-    it('should do nothing when config.menu is undefined and none provided', () => {
+    it('should log a warning when config.menu is undefined and none provided', () => {
       const pkg = new Package(minimalConfig);
       const igDataPath = path.resolve(__dirname, 'fixtures', 'simple-ig');
       const exporter = new IGExporter(pkg, null, igDataPath);
       exporter.addMenuXML(tempOut);
       const menuPath = path.join(tempOut, 'input', 'includes', 'menu.xml');
       expect(fs.existsSync(menuPath)).toBeFalsy();
-      expect(loggerSpy.getAllMessages()).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage()).toMatch(/No "menu" property or file was found\./s);
     });
 
     it('should use but not copy user-provided menu.xml when config.menu is not defined', () => {
@@ -63,7 +64,7 @@ describe('IGExporter', () => {
 
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage()).toMatch(
-        /Found both a "menu" property in sushi-config.yaml and a menu.xml file.*File: .*menu.xml/s
+        /Found both a "menu" property in sushi-config\.yaml and a menu\.xml file.*File: .*menu.xml/s
       );
       expect(loggerSpy.getLastMessage()).toMatch(
         /the "menu" property in the sushi-config\.yaml will be ignored/s

--- a/test/utils/minimalConfigWithMenu.ts
+++ b/test/utils/minimalConfigWithMenu.ts
@@ -1,0 +1,15 @@
+import { Configuration } from '../../src/fshtypes';
+
+export const minimalConfigWithMenu: Configuration = {
+  filePath: 'sushi-config.yaml',
+  id: 'fhir.us.minimal',
+  canonical: 'http://hl7.org/fhir/us/minimal',
+  name: 'MinimalIG',
+  status: 'draft',
+  version: '1.0.0',
+  fhirVersion: ['4.0.1'],
+  menu: [
+    { name: 'Home', url: 'index.html' },
+    { name: 'Artifacts', url: 'artifacts.html' }
+  ]
+};


### PR DESCRIPTION
Fixes #1161

This PR includes a check if there is a config.menu or menu.xml, and if not issues a warning to the user. Tests affected by this addition of a warning message were modified to include a config.menu.

