### PR TITLE
Issue #1128 - add snapshot option to FshToFhir

### DIFF
--- a/src/run/FshToFhir.ts
+++ b/src/run/FshToFhir.ts
@@ -48,6 +48,8 @@ export async function fshToFhir(
     logger.level = options.logLevel;
   }
 
+  const snapshot = options.snapshot ?? false;
+
   // set up a config so that sushi can run
   const config = {
     canonical: options.canonical ?? 'http://example.org',
@@ -87,7 +89,7 @@ export async function fshToFhir(
     ] as const
   ).forEach(artifactType => {
     outPackage[artifactType].forEach((artifact: { toJSON: (snapshot: boolean) => any }) => {
-      fhir.push(artifact.toJSON(false));
+      fhir.push(artifact.toJSON(snapshot));
     });
   });
 
@@ -104,6 +106,7 @@ type fshToFhirOptions = {
   fhirVersion?: string;
   dependencies?: ImplementationGuideDependsOn[];
   logLevel?: Level;
+  snapshot?: boolean;
 };
 
 // Winston levels: https://github.com/winstonjs/winston#logging-levels plus a silent option

--- a/src/run/FshToFhir.ts
+++ b/src/run/FshToFhir.ts
@@ -100,6 +100,11 @@ export async function fshToFhir(
   };
 }
 
+// *** WARNING ***
+// The 'snapshot' option, when set to true, triggers the generation of StructureDefinition.snapshot data elements.
+// Use of this option should be considered EXPERIMENTAL! The StructureDefinition.snapshot data elements generated
+// by SUSHI are likely not perfect and differ from the snapshots that the IG Publisher and/or Simplifier would create.
+// If you plan to publish these resources, it would be better to use one of those other tools to generate the snapshots.
 type fshToFhirOptions = {
   canonical?: string;
   version?: string;

--- a/test/run/FshToFhir.test.ts
+++ b/test/run/FshToFhir.test.ts
@@ -163,7 +163,7 @@ describe('#FshToFhir', () => {
       expect(results.fhir[0].id).toBe('MyPatient');
       const name = results.fhir[0].differential.element.find((e: any) => e.id == 'Patient.name');
       expect(name.mustSupport).toBe(true);
-      expect(results.fhir[0].snapshot).not.toBeDefined();
+      expect(results.fhir[0].snapshot).toBeUndefined();
     });
 
     it('should convert valid FSH into FHIR with several inputs', async () => {
@@ -185,13 +185,13 @@ describe('#FshToFhir', () => {
       expect(results.fhir[0].id).toBe('MyPatient1');
       const name = results.fhir[0].differential.element.find((e: any) => e.id == 'Patient.name');
       expect(name.mustSupport).toBe(true);
-      expect(results.fhir[0].snapshot).not.toBeDefined();
+      expect(results.fhir[0].snapshot).toBeUndefined();
       expect(results.fhir[1].id).toBe('MyPatient2');
       const gender = results.fhir[1].differential.element.find(
         (e: any) => e.id == 'Patient.gender'
       );
       expect(gender.mustSupport).toBe(true);
-      expect(results.fhir[1].snapshot).not.toBeDefined();
+      expect(results.fhir[1].snapshot).toBeUndefined();
     });
 
     it('should trace errors back to the originating input when multiple inputs are given', async () => {
@@ -254,7 +254,7 @@ describe('#FshToFhir', () => {
 
       expect(results.fhir).toHaveLength(1);
       expect(results.fhir[0].id).toBe('MyPatient');
-      expect(results.fhir[0].snapshot).not.toBeDefined();
+      expect(results.fhir[0].snapshot).toBeUndefined();
     });
   });
 });

--- a/test/run/FshToFhir.test.ts
+++ b/test/run/FshToFhir.test.ts
@@ -163,6 +163,7 @@ describe('#FshToFhir', () => {
       expect(results.fhir[0].id).toBe('MyPatient');
       const name = results.fhir[0].differential.element.find((e: any) => e.id == 'Patient.name');
       expect(name.mustSupport).toBe(true);
+      expect(results.fhir[0].snapshot).not.toBeDefined();
     });
 
     it('should convert valid FSH into FHIR with several inputs', async () => {
@@ -184,11 +185,13 @@ describe('#FshToFhir', () => {
       expect(results.fhir[0].id).toBe('MyPatient1');
       const name = results.fhir[0].differential.element.find((e: any) => e.id == 'Patient.name');
       expect(name.mustSupport).toBe(true);
+      expect(results.fhir[0].snapshot).not.toBeDefined();
       expect(results.fhir[1].id).toBe('MyPatient2');
       const gender = results.fhir[1].differential.element.find(
         (e: any) => e.id == 'Patient.gender'
       );
       expect(gender.mustSupport).toBe(true);
+      expect(results.fhir[1].snapshot).not.toBeDefined();
     });
 
     it('should trace errors back to the originating input when multiple inputs are given', async () => {
@@ -212,6 +215,46 @@ describe('#FshToFhir', () => {
       expect(results.warnings).toHaveLength(0);
       expect(results.fhir).toHaveLength(0);
       expect(results.fhir).toEqual([]);
+    });
+
+    it('should honor snapshot option = true when converting valid FSH into FHIR', async () => {
+      const results = await fshToFhir(
+        leftAlign(`
+      Profile: MyPatient
+      Parent: Patient
+      * name MS
+       `),
+        {
+          snapshot: true
+        }
+      );
+      expect(results.errors).toHaveLength(0);
+      expect(results.warnings).toHaveLength(0);
+
+      expect(results.fhir).toHaveLength(1);
+      expect(results.fhir[0].id).toBe('MyPatient');
+      expect(results.fhir[0].snapshot).toBeDefined();
+      const nameSnap = results.fhir[0].snapshot.element.find((e: any) => e.id == 'Patient.name');
+      expect(nameSnap.mustSupport).toBe(true);
+    });
+
+    it('should honor snapshot option = false when converting valid FSH into FHIR', async () => {
+      const results = await fshToFhir(
+        leftAlign(`
+      Profile: MyPatient
+      Parent: Patient
+      * name MS
+       `),
+        {
+          snapshot: false
+        }
+      );
+      expect(results.errors).toHaveLength(0);
+      expect(results.warnings).toHaveLength(0);
+
+      expect(results.fhir).toHaveLength(1);
+      expect(results.fhir[0].id).toBe('MyPatient');
+      expect(results.fhir[0].snapshot).not.toBeDefined();
     });
   });
 });


### PR DESCRIPTION
Issue #1128 - Enable sushiClient (FshToFhir) to create StructureDefinitions with the snapshot data element