### PR TITLE
Versioned instances

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -746,7 +746,13 @@ export class InstanceExporter implements Fishable {
   }
 
   exportInstance(fshDefinition: Instance): InstanceDefinition {
-    if (this.pkg.instances.some(i => i._instanceMeta.name === fshDefinition.name)) {
+    if (
+      this.pkg.instances.some(
+        i =>
+          i._instanceMeta.name === fshDefinition.name &&
+          i._instanceMeta.versionId === fshDefinition.versionId
+      )
+    ) {
       return;
     }
 
@@ -955,8 +961,7 @@ export class InstanceExporter implements Fishable {
           instanceDef.resourceType === instance.resourceType &&
           (instanceDef.id ?? instanceDef._instanceMeta.name) ===
             (instance.id ?? instance._instanceMeta.name) &&
-          (instanceDef.versionId) ===
-            (instance.versionId)  &&
+          instanceDef._instanceMeta.versionId === instance._instanceMeta.versionId &&
           instanceDef !== instance
       )
     ) {

--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -815,6 +815,9 @@ export class InstanceExporter implements Fishable {
     if (fshDefinition.title) {
       instanceDef._instanceMeta.title = fshDefinition.title;
     }
+    if (fshDefinition.versionId) {
+      instanceDef._instanceMeta.versionId = fshDefinition.versionId;
+    }
     if (fshDefinition.description) {
       instanceDef._instanceMeta.description = fshDefinition.description;
     }
@@ -952,6 +955,8 @@ export class InstanceExporter implements Fishable {
           instanceDef.resourceType === instance.resourceType &&
           (instanceDef.id ?? instanceDef._instanceMeta.name) ===
             (instance.id ?? instance._instanceMeta.name) &&
+          (instanceDef.versionId) ===
+            (instance.versionId)  &&
           instanceDef !== instance
       )
     ) {

--- a/src/fhirtypes/InstanceDefinition.ts
+++ b/src/fhirtypes/InstanceDefinition.ts
@@ -26,7 +26,9 @@ export class InstanceDefinition {
   getFileName(): string {
     // Logical instances should use Binary type. See: https://fshschool.org/docs/sushi/tips/#instances-of-logical-models
     const type = this._instanceMeta.sdKind === 'logical' ? 'Binary' : this.resourceType;
-    return sanitize(`${type}-${this.id ?? this._instanceMeta.name}.json`, {
+    let versionString = (this._instanceMeta.versionId) ? `_v${this._instanceMeta.versionId}` :  ``
+    let filename = `${type}-${this.id ?? this._instanceMeta.name}${versionString}.json`;
+    return sanitize(filename, {
       replacement: '-'
     });
   }
@@ -61,6 +63,7 @@ type InstanceMeta = {
   sdType?: string;
   sdKind?: string;
   instanceOfUrl?: string;
+  versionId?: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/fhirtypes/InstanceDefinition.ts
+++ b/src/fhirtypes/InstanceDefinition.ts
@@ -26,8 +26,8 @@ export class InstanceDefinition {
   getFileName(): string {
     // Logical instances should use Binary type. See: https://fshschool.org/docs/sushi/tips/#instances-of-logical-models
     const type = this._instanceMeta.sdKind === 'logical' ? 'Binary' : this.resourceType;
-    let versionString = (this._instanceMeta.versionId) ? `_v${this._instanceMeta.versionId}` :  ``
-    let filename = `${type}-${this.id ?? this._instanceMeta.name}${versionString}.json`;
+    const versionString = this._instanceMeta.versionId ? `_v${this._instanceMeta.versionId}` : '';
+    const filename = `${type}-${this.id ?? this._instanceMeta.name}${versionString}.json`;
     return sanitize(filename, {
       replacement: '-'
     });

--- a/src/fshtypes/Instance.ts
+++ b/src/fshtypes/Instance.ts
@@ -10,6 +10,7 @@ export class Instance extends FshEntity {
   instanceOf: string;
   description?: string;
   usage?: InstanceUsage;
+  versionId?: string;
   rules: (AssignmentRule | InsertRule | PathRule)[];
 
   constructor(public name: string) {
@@ -17,6 +18,7 @@ export class Instance extends FshEntity {
     this.id = name; // init same as name
     this.rules = [];
     this.usage = 'Example'; // init to Example (default)
+    this.versionId = undefined; // init to undefined (default)
   }
 
   get constructorName() {

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -448,15 +448,17 @@ export class FSHImporter extends FSHVisitor {
     const instance = new Instance(ctx.name().getText())
       .withLocation(location)
       .withFile(this.currentFile);
-    if (this.docs.some(doc => doc.instances.has(instance.name))) {
-      logger.error(`Skipping Instance: an Instance named ${instance.name} already exists.`, {
-        file: this.currentFile,
-        location
-      });
-    } else {
+    {
       try {
         this.parseInstance(instance, location, ctx.instanceMetadata(), ctx.instanceRule());
-        this.currentDoc.instances.set(instance.name, instance);
+        if (this.docs.some(doc => (doc.instances.has(instance.name) && (Array.from(doc.instances.values()).some(entity => entity.name === instance.name && entity.versionId === instance.versionId))))) {
+          logger.error(`Skipping Instance: an Instance named ${instance.name} with versionId ${instance.versionId} already exists.`, {
+            file: this.currentFile,
+            location
+          });
+        } else {
+          this.currentDoc.instances.set(instance.name, instance);
+        }
       } catch (e) {
         logger.error(e.message, instance.sourceInfo);
         if (e.stack) {
@@ -518,6 +520,9 @@ export class FSHImporter extends FSHVisitor {
       const rule = this.visitInstanceRule(instanceRule);
       if (rule) {
         instance.rules.push(rule);
+        if (rule instanceof AssignmentRule && rule.path === `meta.versionId`) {
+          instance.versionId = rule.value.toString();
+        }
       }
     });
   }

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -451,11 +451,23 @@ export class FSHImporter extends FSHVisitor {
     {
       try {
         this.parseInstance(instance, location, ctx.instanceMetadata(), ctx.instanceRule());
-        if (this.docs.some(doc => (doc.instances.has(instance.name) && (Array.from(doc.instances.values()).some(entity => entity.name === instance.name && entity.versionId === instance.versionId))))) {
-          logger.error(`Skipping Instance: an Instance named ${instance.name} with versionId ${instance.versionId} already exists.`, {
-            file: this.currentFile,
-            location
-          });
+        if (
+          this.docs.some(
+            doc =>
+              doc.instances.has(instance.name) &&
+              Array.from(doc.instances.values()).some(
+                entity => entity.name === instance.name && entity.versionId === instance.versionId
+              )
+          )
+        ) {
+          const versionString = instance.versionId ? `with versionId ${instance.versionId} ` : '';
+          logger.error(
+            `Skipping Instance: an Instance named ${instance.name} ${versionString}already exists.`,
+            {
+              file: this.currentFile,
+              location
+            }
+          );
         } else {
           this.currentDoc.instances.set(instance.name, instance);
         }
@@ -520,7 +532,7 @@ export class FSHImporter extends FSHVisitor {
       const rule = this.visitInstanceRule(instanceRule);
       if (rule) {
         instance.rules.push(rule);
-        if (rule instanceof AssignmentRule && rule.path === `meta.versionId`) {
+        if (rule instanceof AssignmentRule && rule.path === 'meta.versionId') {
           instance.versionId = rule.value.toString();
         }
       }

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -550,6 +550,7 @@ export function writeFHIRResources(
       toJSON: (snapshot: boolean) => any;
       url?: string;
       id?: string;
+      versionId?: string;
       resourceType?: string;
     }[]
   ) => {
@@ -560,7 +561,8 @@ export function writeFHIRResources(
           predef =>
             predef.url === resource.url &&
             predef.resourceType === resource.resourceType &&
-            predef.id === resource.id
+            predef.id === resource.id &&
+            predef.versionId === resource.versionId
         )
       ) {
         checkNullValuesOnArray(resource);


### PR DESCRIPTION
**Description:**
Allows multiple copies of the same instance, as long as the meta.versionId is unique.
Includes a new test for the instance generation.
It does not seem to break any of the current tests.

pattern for filenames changed to accomodate the changes:
- no versionId -> Patient-id.json
- versionId eg "2" -> -> Patient-id_v2.json

**Related Issue:**
https://github.com/FHIR/sushi/issues/1494