### PR TITLE
Maintaining trailing zeros for decimal precision in json output

### DIFF
--- a/src/export/InstanceExporter.ts
+++ b/src/export/InstanceExporter.ts
@@ -178,13 +178,15 @@ export class InstanceExporter implements Fishable {
             value = `#${matchingContainedReferenceId}`;
           }
         }
+        let rawValue = (rule instanceof AssignmentRule) ? rule.rawValue : null
         const validatedRule = instanceOfStructureDefinition.validateValueAtPath(
           rule.path,
           value,
           this.fisher,
           inlineResourceTypes,
           rule.sourceInfo,
-          manualSliceOrdering
+          manualSliceOrdering,
+          rawValue
         );
         // Record each valid rule in a map
         // Choice elements on an instance must use a specific type, so if the path still has an unchosen choice element,

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1830,7 +1830,7 @@ export class ElementDefinition {
    * @throws {ValueAlreadyAssignedError} when the value is already assigned to a different value
    * @throws {MismatchedTypeError} when the value does not match the type of the ElementDefinition
    */
-  assignValue(value: AssignmentValueType, exactly = false, fisher?: Fishable): void {
+  assignValue(value: AssignmentValueType, exactly = false, fisher?: Fishable, rawValue: any = null): void {
     let type: string;
     if (value instanceof FshCode) {
       type = 'Code';
@@ -1870,7 +1870,7 @@ export class ElementDefinition {
         this.assignFHIRValue(value.toString(), value, exactly, 'boolean');
         break;
       case 'number':
-        this.assignNumber(value as number, exactly);
+        this.assignNumber(value as number, exactly, rawValue);
         break;
       case 'string':
         this.assignString(value as string, exactly);
@@ -2230,14 +2230,17 @@ export class ElementDefinition {
    * @throws {ValueAlreadyAssignedError} when the value is already assigned to a different value
    * @throws {MismatchedTypeError} when the value does not match the type of the ElementDefinition
    */
-  private assignNumber(value: number | bigint, exactly = false): void {
+  private assignNumber(value: number | bigint, exactly = false, rawValue: any = null): void {
     const type = this.type[0].code;
     const valueAsNumber = Number(value);
-    if (
-      type === 'decimal' ||
-      (type === 'integer' && Number.isInteger(valueAsNumber)) ||
-      (type === 'unsignedInt' && Number.isInteger(valueAsNumber) && valueAsNumber >= 0) ||
-      (type === 'positiveInt' && Number.isInteger(valueAsNumber) && valueAsNumber > 0)
+    // In case of 
+    if (type === 'decimal' && !isNaN(Number(rawValue)) && /^\d+\.0+$/.test(rawValue)) {
+      this.assignFHIRValue(rawValue.toString(), rawValue.toString(), exactly, type);
+    } else if (
+        type === 'decimal' ||
+        (type === 'integer' && Number.isInteger(valueAsNumber)) ||
+        (type === 'unsignedInt' && Number.isInteger(valueAsNumber) && valueAsNumber >= 0) ||
+        (type === 'positiveInt' && Number.isInteger(valueAsNumber) && valueAsNumber > 0)
     ) {
       this.assignFHIRValue(value.toString(), valueAsNumber, exactly, type);
     } else if (type === 'integer64' && typeof value === 'bigint') {

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -593,7 +593,8 @@ export class StructureDefinition {
     fisher: Fishable,
     inlineResourceTypes: string[] = [],
     sourceInfo: SourceInfo = null,
-    manualSliceOrdering = false
+    manualSliceOrdering = false,
+    rawValue: any = null
   ): { assignedValue: any; pathParts: PathPart[]; childPath?: string } {
     const pathParts = parseFSHPath(path);
     let currentPath = '';
@@ -773,7 +774,7 @@ export class StructureDefinition {
       // assignValue will throw if it fails, but skip the check if value is null
       if (value != null) {
         // exactly must be true so that we always test assigning with the more strict fixed[x] approach
-        currentElement.assignValue(value, true, fisher);
+        currentElement.assignValue(value, true, fisher, rawValue);
       }
       // If there is a fixedValue or patternValue, find it and return it
       const key = Object.keys(currentElement).find(

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -564,9 +564,21 @@ export function writeFHIRResources(
         )
       ) {
         checkNullValuesOnArray(resource);
-        fs.outputJSONSync(path.join(exportDir, resource.getFileName()), resource.toJSON(snapshot), {
-          spaces: 2
-        });
+        const replacer = (key: any, value: string) => {
+          if (typeof value === "string" && !isNaN(Number(value))) {
+            // Format the number while keeping the exact number of zeros after the decimal point
+            const numValue = Number(value);
+            return value.includes('.') ? numValue.toFixed(value.split('.')[1].length) : numValue;
+          }
+          return value;
+        };
+        const jsonString = JSON.stringify(resource.toJSON(snapshot), replacer, 2);
+
+        // Manually format the JSON string to maintain number type with precision
+        const formattedJsonString = jsonString.replace(/"(\d+\.\d+)"|"\d+"/g, (match) => match.replace(/"/g, ''));
+
+        // Write the modified JSON string directly to a file
+        fs.outputFileSync(path.join(exportDir, resource.getFileName()), formattedJsonString);
         count++;
       } else {
         logger.error(


### PR DESCRIPTION
**Description:**
This PR attempts to address the issue of trailing zeros for decimal numbers which are omitted when using Typescript and JSON  tooling.
The main idea for solving this issue are twofold:
1. In case of decimals the rawValue as string is being used for assignment
2. When outputting the JSON content a regex replaces Numbers with trailing zeros that are strings to exclude the strings

There was no 'elegant' way that I could see to solve this issue as numbers in Typescript with trailing zeros are represented as plain numbers and fs.outputJSONsync transforms the number 19.00 to 19 as well.

Would be interested if we could work with that solution. If I missed other side effects please let me know.

**Testing Instructions:**
Run Sushi with this FSH File:
```
Instance: ObservationExample
InstanceOf: Observation
Usage: #example
* id = "example-xxx"
* extension[+]
  * url = "decimal-test-round"
  * valueDecimal = 19.00
* extension[+]
  * url = "decimal-test-off"
  * valueDecimal = 19.01
* extension[+]
  * url = "money-test-round"
  * valueMoney.value = 19.00
* extension[+]
  * url = "money-test-off"
  * valueMoney.value = 19.01
* status = #final
* code = http://loinc.org#11557-6
```

Before the commit the output would be ` "valueDecimal": 19`
Afterwards it is ` "valueDecimal": 19.00`

**Related Issue:**
#1215 
