### PR TITLE
Minor Code Cleanup

### DIFF
--- a/antlr/README.md
+++ b/antlr/README.md
@@ -2,9 +2,12 @@
 
 The FSH Grammar is defined using [ANTLR4](https://www.antlr.org/).
 
-To edit the grammar, edit the file:
+To edit the grammar, edit the files:
 ```
 ./src/main/antlr/FSH.g4
+./src/main/antlr/FSHLexer.g4
+./src/main/antlr/MiniFSH.g4
+./src/main/antlr/MiniFSHLexer.g4
 ```
 
 You may want to install the [ANTLR4 grammar syntax support](https://marketplace.visualstudio.com/items?itemName=mike-lischke.vscode-antlr4) VS Code extension to help w/ editing and debugging.

--- a/package.json
+++ b/package.json
@@ -44,10 +44,8 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*.{js,json,d.ts}",
-    "dist/ig/files/**/*",
     "dist/utils/init-project/**/*",
-    "antlr/**/*.g4",
-    "dev/fixAntlr4.js"
+    "antlr/**/*.g4"
   ],
   "license": "Apache-2.0",
   "devDependencies": {

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -310,28 +310,9 @@ export class ElementDefinition {
    */
   set id(id: string) {
     this._privateId = id;
-    // After setting the id, we should re-set the path, which is based on the id
-    this.path = this._privateId
-      .split('.')
-      .map(s => {
-        // Usually the path part is just the name without the slice.
-        const [name] = s.split(':', 2);
-        // The spec is unclear on if there is an exception in parts representing
-        // a specific choice type, in which case, the path is the slice name (e.g., ) if the id is
-        // Observation.value[x]:valueQuantity, then path is Observation.valueQuantity.
-        // The code to make the exception is commented below, and will remain until we can clarify
-        // const [name, slice] = s.split(':', 2);
-        // if (
-        //   slice &&
-        //   name.endsWith('[x]') &&
-        //   this.type &&
-        //   this.type.some(t => slice === `${name.slice(0, -3)}${capitalize(t.code)}`)
-        // ) {
-        //   return slice;
-        // }
-        return name;
-      })
-      .join('.');
+    // After setting the id, we should re-set the path, which is based on the id but with all
+    // slice names removed (e.g., Observation.component:abc.code --> Observation.component.code)
+    this.path = this._privateId.replace(/(\.[^.:]+):[^.]+/g, '$1');
   }
 
   validate(): ValidationError[] {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -749,7 +749,7 @@ export async function init(
   configDoc.set('copyrightYear', `${new Date().getFullYear()}+`);
   const projectName = configDoc.get('name');
 
-  // Write init directory out, including user made sushi-config.yaml, files in utils/init-project, and build scripts from ig/files
+  // Write init directory out, including user made sushi-config.yaml and files in utils/init-project
   const outputDir = path.resolve('.', projectName);
   const initProjectDir = path.join(__dirname, 'init-project');
   if (options.autoInitialize) {


### PR DESCRIPTION
**Description:** This PR contains minor code cleanup based on things I noticed while preparing the "Developing SUSHI" knowledge sharing session. These include:
* Simplified the path setting logic now that we know we'll never need choice type renaming
* Removed an outdated code comment about choice type renaming
* Removed comment about copying IG scripts (we download them now)
* Updated the `package.json` file list to remove files that no longer exist
* Updated the ANTLR README to refer to _all_ of the grammar files

**Testing Instructions:** Basic tests to ensure nothing breaks. This passed a regression with a full-year lookback.