### PR TITLE
Add optional argument for making clone of predefined resources

### DIFF
--- a/src/fhirdefs/FHIRDefinitions.ts
+++ b/src/fhirdefs/FHIRDefinitions.ts
@@ -35,8 +35,12 @@ export class FHIRDefinitions extends BaseFHIRDefinitions implements Fishable {
     return flatten(Array.from(this.supplementalFHIRDefinitions.keys()));
   }
 
-  allPredefinedResources(): any[] {
-    return Array.from(this.predefinedResources.values()).map(v => cloneDeep(v));
+  allPredefinedResources(makeClone = true): any[] {
+    if (makeClone) {
+      return Array.from(this.predefinedResources.values()).map(v => cloneDeep(v));
+    } else {
+      return Array.from(this.predefinedResources.values());
+    }
   }
 
   add(definition: any): void {
@@ -81,7 +85,7 @@ export class FHIRDefinitions extends BaseFHIRDefinitions implements Fishable {
     const resource = this.fishForFHIR(item, ...types);
     if (
       resource &&
-      this.allPredefinedResources().find(
+      this.allPredefinedResources(false).find(
         predefResource =>
           predefResource.id === resource.id &&
           predefResource.resourceType === resource.resourceType &&

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -774,11 +774,12 @@ export class ElementDefinition {
 
   getSlices() {
     if (this.sliceName) {
-      return this.structDef.elements.filter(
+      // this.parent() should never be undefined if this element has a sliceName, but code defensively just in case
+      return (this.parent()?.children(true) ?? this.structDef.elements).filter(
         e => e.id !== this.id && e.path === this.path && e.id.startsWith(`${this.id}/`)
       );
     } else {
-      return this.structDef.elements.filter(
+      return (this.parent()?.children(true) ?? this.structDef.elements).filter(
         e => e.id !== this.id && e.path === this.path && e.id.startsWith(`${this.id}:`)
       );
     }
@@ -898,12 +899,14 @@ export class ElementDefinition {
     const slicedElement = this.slicedElement();
     if (slicedElement) {
       const parentSlice = this.findParentSlice();
-      const sliceSiblings = this.structDef.elements.filter(
-        el =>
-          this !== el &&
-          slicedElement === el.slicedElement() &&
-          parentSlice === el.findParentSlice()
-      );
+      const sliceSiblings = this.parent()
+        .children(true)
+        .filter(
+          el =>
+            this !== el &&
+            slicedElement === el.slicedElement() &&
+            parentSlice === el.findParentSlice()
+        );
       const newParentMin = min + sliceSiblings.reduce((sum, el) => sum + el.min, 0);
       // if this is a reslice, the parent element will also be a slice of the sliced element.
       // if this is not a reslice, the parent element is the sliced element.
@@ -985,8 +988,9 @@ export class ElementDefinition {
           return parentNameParts.slice(0, i + 1).join('/');
         })
         .reverse();
+      const elementsToSearch = this.parent()?.children(true) ?? this.structDef.elements;
       for (const parentName of potentialParentNames) {
-        const potentialParent = this.structDef.elements.find(el => {
+        const potentialParent = elementsToSearch.find(el => {
           return el.sliceName === parentName && el.slicedElement() === slicedElement;
         });
         if (potentialParent) {
@@ -2586,7 +2590,9 @@ export class ElementDefinition {
    */
   slicedElement(): ElementDefinition | undefined {
     if (this.sliceName) {
-      return this.structDef.elements.find(e => e.id === this.id.slice(0, this.id.lastIndexOf(':')));
+      return (this.parent()?.children(true) ?? this.structDef.elements).find(
+        e => e.id === this.id.slice(0, this.id.lastIndexOf(':'))
+      );
     }
   }
 

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -543,7 +543,7 @@ export function writeFHIRResources(
   logger.info('Exporting FHIR resources as JSON...');
   let count = 0;
   const skippedResources: string[] = [];
-  const predefinedResources = defs.allPredefinedResources();
+  const predefinedResources = defs.allPredefinedResources(false);
   const writeResources = (
     resources: {
       getFileName: () => string;


### PR DESCRIPTION
This PR applies to task [CIMPL-1250](https://standardhealthrecord.atlassian.net/browse/CIMPL-1250).

The FHIRDefinitions class provides a public method to return all predefined resources. Hypothetically, the caller of this method could alter the predefined resources, which is why it could be useful to return a clone of these resources. However, in all places this method is called by SUSHI, the resources are used for a search, not for any modifications. By not cloning the resources for the search, significant time savings are possible. Just in case someone else is using SUSHI as a dependency and calling this method and expecting to receive a clone, the default behavior is to return a clone.

When searching for slices, the slice of an element is always a sibling of that element. Therefore, it is preferable to search the smaller list containing only the element's parent's children, when possible. This takes advantage of the underlying ElementDefinition tree. Because the root element's parent is undefined, use the full element list when working with the root element. This shouldn't be possible in most cases, as revealed by the test coverage, but the implementation is defensive just in case something unusual has happened to the root element.

A regression test of public FSH projects updated within the last year indicated no changes. The initial test run indicated changes in two repos, but both of those repos produced identical results in a second run without any code changes. The changes to `allPredefinedResources` are most visible in projects with many StructureDefinitions. The changes to `ElementDefinition` are most visible in projects with many Instance definitions. The impact of the `ElementDefinition` changes is relatively small, but the `allPredefinedResources` changes are significant for some FSH projects.

The regression test results summary is attached as html. Three projects showed increased run times, but all of those projects are relatively small, with the longest run time being 61 seconds. Some larger projects showed meaningful decreases in run time. As a few examples:
* [fhir-fi/finnish-base-profiles#master](https://github.com/fhir-fi/finnish-base-profiles/tree/master/) decreased from 224 seconds to 15 seconds
* [hl7-it/lab-report#master](https://github.com/hl7-it/lab-report/tree/master/) decreased from 865 seconds to 31 seconds
* [HL7/US-Core#master](https://github.com/HL7/US-Core/tree/master/) decreased from 187 seconds to 99 seconds

While these are just a few examples I've picked out, and not every project has changes that are so dramatic, I think the overall effect is meaningfully positive without adding an odious amount of complexity to the implementation.

[Regression summary HTML](https://github.com/user-attachments/files/16576371/index.html.txt)
