### PR TITLE
Correct date in DEPENDENCY-NOTES.md

### DIFF
--- a/DEPENDENCY-NOTES.md
+++ b/DEPENDENCY-NOTES.md
@@ -1,4 +1,4 @@
-As of 2024 June 17:
+As of 2024 August 27:
 
 The `npm outdated` command reports some dependencies as outdated. They are not being updated at this time for the reasons given below:
 


### PR DESCRIPTION
**Description:** When I updated the dependency notes on August 27, I forgot to update the date in the text of the DEPENDENCY-NOTES.md file. This corrects the date.

**Testing Instructions:** Read the DEPENDENCY-NOTES.md. Do they indicate the as-of date as being August 27, 2024? Yes? Good.

**Related Issue:** N/A
