### PR TITLE
Assign date or dateTime that contains only year

### DIFF
--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -1231,6 +1231,92 @@ describe('CodeSystemExporter', () => {
     );
   });
 
+  it('should assign a date that was parsed as a number', () => {
+    // CodeSystem: CaretCodeSystem
+    // * #someCode "Some Code"
+    // * ^extension[0].url = "http://example.org/SomeExt"
+    // * ^extension[0].valueDate = 2023
+    const codeSystem = new FshCodeSystem('CaretCodeSystem');
+    const someCode = new ConceptRule('someCode', 'Some Code');
+    const extensionUrl = new CaretValueRule('');
+    extensionUrl.caretPath = 'extension[0].url';
+    extensionUrl.value = 'http://example.org/SomeExt';
+    const extensionValue = new CaretValueRule('');
+    extensionValue.caretPath = 'extension[0].valueDate';
+    extensionValue.value = BigInt(2023);
+    extensionValue.rawValue = '2023';
+    codeSystem.rules.push(someCode, extensionUrl, extensionValue);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+
+    const exported = exporter.export().codeSystems;
+    expect(exported.length).toBe(1);
+    expect(exported[0]).toEqual({
+      resourceType: 'CodeSystem',
+      id: 'CaretCodeSystem',
+      name: 'CaretCodeSystem',
+      content: 'complete',
+      url: 'http://hl7.org/fhir/us/minimal/CodeSystem/CaretCodeSystem',
+      count: 1,
+      status: 'draft',
+      extension: [
+        {
+          url: 'http://example.org/SomeExt',
+          valueDate: '2023'
+        }
+      ],
+      concept: [
+        {
+          code: 'someCode',
+          display: 'Some Code'
+        }
+      ]
+    });
+  });
+
+  it('should assign a dateTime that was parsed as a number', () => {
+    // CodeSystem: CaretCodeSystem
+    // * #someCode "Some Code"
+    // * #someCode ^property[0].code = #standard
+    // * #someCode ^property[0].valueDateTime = 0081
+    const codeSystem = new FshCodeSystem('CaretCodeSystem');
+    const someCode = new ConceptRule('someCode', 'Some Code');
+    const propertyCode = new CaretValueRule('');
+    propertyCode.pathArray = ['#someCode'];
+    propertyCode.caretPath = 'property[0].code';
+    propertyCode.value = new FshCode('standard');
+    const propertyValue = new CaretValueRule('');
+    propertyValue.pathArray = ['#someCode'];
+    propertyValue.caretPath = 'property[0].valueDateTime';
+    propertyValue.value = BigInt(81);
+    propertyValue.rawValue = '0081';
+    codeSystem.rules.push(someCode, propertyCode, propertyValue);
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+
+    const exported = exporter.export().codeSystems;
+    expect(exported.length).toBe(1);
+    expect(exported[0]).toEqual({
+      resourceType: 'CodeSystem',
+      id: 'CaretCodeSystem',
+      name: 'CaretCodeSystem',
+      content: 'complete',
+      url: 'http://hl7.org/fhir/us/minimal/CodeSystem/CaretCodeSystem',
+      count: 1,
+      status: 'draft',
+      concept: [
+        {
+          code: 'someCode',
+          display: 'Some Code',
+          property: [
+            {
+              code: 'standard',
+              valueDateTime: '0081'
+            }
+          ]
+        }
+      ]
+    });
+  });
+
   describe('#insertRules', () => {
     let cs: FshCodeSystem;
     let ruleSet: RuleSet;

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -10117,6 +10117,37 @@ describe('InstanceExporter', () => {
       });
     });
 
+    it('should assign a date that was parsed as a number', () => {
+      // Instance: ExampleObs
+      // InstanceOf: Observation
+      // * extension[0].url = "http://example.org/SomeExt"
+      // * extension[0].valueDate = 2055
+      const observation = new Instance('ExampleObs');
+      observation.instanceOf = 'Observation';
+      const extensionUrl = new AssignmentRule('extension[0].url');
+      extensionUrl.value = 'http://example.org/SomeExt';
+      const extensionValue = new AssignmentRule('extension[0].valueDate');
+      extensionValue.value = BigInt(2055);
+      extensionValue.rawValue = '2055';
+      observation.rules.push(extensionUrl, extensionValue);
+      const exportedInstance = exportInstance(observation);
+      expect(exportedInstance.extension[0].valueDate).toEqual('2055');
+    });
+
+    it('should assign a dateTime that was parsed as a number', () => {
+      // Instance: ExampleObs
+      // InstanceOf: Observation
+      // * valueDateTime = 0895
+      const observation = new Instance('ExampleObs');
+      observation.instanceOf = 'Observation';
+      const assignmentRule = new AssignmentRule('valueDateTime');
+      assignmentRule.value = BigInt(895);
+      assignmentRule.rawValue = '0895';
+      observation.rules.push(assignmentRule);
+      const exportedInstance = exportInstance(observation);
+      expect(exportedInstance.valueDateTime).toEqual('0895');
+    });
+
     describe('#TimeTravelingResources', () => {
       it('should export a R5 ActorDefinition in a R4 IG', () => {
         // Instance: AD1

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -1852,6 +1852,49 @@ describe('ValueSetExporter', () => {
     );
   });
 
+  it('should assign a date that was parsed as a number', () => {
+    // ValueSet: BreakfastVS
+    // Title: "Breakfast Values"
+    // * ^extension[0].url = "http://example.org/SomeExt"
+    // * ^extension[0].valueDate = 2023
+    const valueSet = new FshValueSet('BreakfastVS');
+    valueSet.title = 'Breakfast Values';
+    const extensionUrl = new CaretValueRule('');
+    extensionUrl.caretPath = 'extension[0].url';
+    extensionUrl.value = 'http://example.org/SomeExt';
+    const extensionValue = new CaretValueRule('');
+    extensionValue.caretPath = 'extension[0].valueDate';
+    extensionValue.value = BigInt(2023);
+    extensionValue.rawValue = '2023';
+    valueSet.rules.push(extensionUrl, extensionValue);
+    doc.valueSets.set(valueSet.name, valueSet);
+
+    const exported = exporter.export().valueSets;
+    expect(exported.length).toBe(1);
+    expect(exported[0].extension[0]).toEqual({
+      url: 'http://example.org/SomeExt',
+      valueDate: '2023'
+    });
+  });
+
+  it('should assign a dateTime that was parsed as a number', () => {
+    // ValueSet: BreakfastVS
+    // Title: "Breakfast Values"
+    // * ^date = 2024
+    const valueSet = new FshValueSet('BreakfastVS');
+    valueSet.title = 'Breakfast Values';
+    const dateRule = new CaretValueRule('');
+    dateRule.caretPath = 'date';
+    dateRule.value = BigInt(2024);
+    dateRule.rawValue = '2024';
+    valueSet.rules.push(dateRule);
+    doc.valueSets.set(valueSet.name, valueSet);
+
+    const exported = exporter.export().valueSets;
+    expect(exported.length).toBe(1);
+    expect(exported[0].date).toEqual('2024');
+  });
+
   it('should export a value set with an extension', () => {
     const valueSet = new FshValueSet('BreakfastVS');
     valueSet.title = 'Breakfast Values';


### PR DESCRIPTION
**Description:**
A FHIR date or dateTime may be 4-digit year. The FSH parser will assign this value a NUMBER token type. When assigning to a date or dateTime element, if a type mismatch occurs, and the original value is a number, try to assign the raw value. If it is a valid 4-digit year, it will be assigned successfully. Otherwise, the original error will be thrown and logged.

I don't really like my implementation here: it's very similar code in all four exporters. I didn't manage to come up with a good way to isolate the "retry with another value" code, but I think it would be better if it looked like that.

**Testing Instructions:**
Tests are added to exporter classes to demonstrate assignment of these values.

**Related Issue:**
Fixes #1483