### PR TITLE
Allow 6.x versions of FHIR

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -85,9 +85,9 @@ export const AUTOMATIC_DEPENDENCIES: AutomaticDependency[] = [
 ];
 
 export function isSupportedFHIRVersion(version: string): boolean {
-  // For now, allow current or any 4.x/5.x version of FHIR except 4.0.0. This is a quick check; not a guarantee.  If a user passes
+  // For now, allow current or any 4.x/5.x/6.x version of FHIR except 4.0.0. This is a quick check; not a guarantee.  If a user passes
   // in an invalid version that passes this test (e.g., 4.99.0), it is still expected to fail when we load dependencies.
-  return version !== '4.0.0' && /^(current|[45]\.\d+.\d+(-.+)?)$/.test(version);
+  return version !== '4.0.0' && /^(current|[456]\.\d+.\d+(-.+)?)$/.test(version);
 }
 
 export function ensureInputDir(input: string): string {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -426,6 +426,12 @@ describe('Processing', () => {
       expect(config.fhirVersion).toEqual(['4.5.0']);
     });
 
+    it('should allow FHIR R6', () => {
+      const input = path.join(__dirname, 'fixtures', 'fhir-r6');
+      const config = readConfig(input);
+      expect(config.fhirVersion).toEqual(['6.0.0-ballot2']);
+    });
+
     it('should allow FHIR current', () => {
       const input = path.join(__dirname, 'fixtures', 'fhir-current');
       const config = readConfig(input);

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -426,10 +426,16 @@ describe('Processing', () => {
       expect(config.fhirVersion).toEqual(['4.5.0']);
     });
 
-    it('should allow FHIR R6', () => {
-      const input = path.join(__dirname, 'fixtures', 'fhir-r6');
+    it('should allow FHIR R6 prerelease', () => {
+      const input = path.join(__dirname, 'fixtures', 'fhir-r6-prerelease');
       const config = readConfig(input);
       expect(config.fhirVersion).toEqual(['6.0.0-ballot2']);
+    });
+
+    it('should allow FHIR R6 full release', () => {
+      const input = path.join(__dirname, 'fixtures', 'fhir-r6');
+      const config = readConfig(input);
+      expect(config.fhirVersion).toEqual(['6.0.0']);
     });
 
     it('should allow FHIR current', () => {

--- a/test/utils/fixtures/fhir-r6-prerelease/sushi-config.yaml
+++ b/test/utils/fixtures/fhir-r6-prerelease/sushi-config.yaml
@@ -3,7 +3,7 @@ canonical: http://hl7.org/fhir/us/minimal
 name: MinimalIG
 status: draft
 version: 1.0.0
-fhirVersion: 6.0.0
+fhirVersion: 6.0.0-ballot2
 copyrightYear: 2020+
 releaseLabel: Build CI
 template: hl7.fhir.template#0.0.5

--- a/test/utils/fixtures/fhir-r6/sushi-config.yaml
+++ b/test/utils/fixtures/fhir-r6/sushi-config.yaml
@@ -1,0 +1,9 @@
+id: fhir.us.minimal
+canonical: http://hl7.org/fhir/us/minimal
+name: MinimalIG
+status: draft
+version: 1.0.0
+fhirVersion: 6.0.0-ballot2
+copyrightYear: 2020+
+releaseLabel: Build CI
+template: hl7.fhir.template#0.0.5


### PR DESCRIPTION
**Description:**
FHIR version 6 is currently in balloting stages. It does not appear that any code changes are needed yet for allowing an R6 IG. The usual warning about prerelease versions will be shown when one of the ballot versions is used.

**Testing Instructions:**
The main question here is whether supporting R6 is actually as simple as I think it is. Having looked over [information about the R6 ballot changes](https://hl7.org/fhir/6.0.0-ballot2/ballot-intro.html), I don't think there's anything that will need special handling. 

The new datatype [RelativeTime](https://hl7.org/fhir/6.0.0-ballot2/datatypes.html#RelativeTime) is complex enough that it doesn't make sense to try to support assigning it in a single rule. But, it may be worth considering if we want to support checking [its invariants](https://hl7.org/fhir/6.0.0-ballot2/datatypes-definitions.html#RelativeTime). rlt-1 is a very simple check, and rlt-2 isn't too much more complicated. We do something like this for Extensions for their [ext-1 invariant](https://hl7.org/fhir/extensibility-definitions.html#Extension).

**Related Issue:**
#1485 