### PR TITLE
Only return FshType id from rule value if the value is a string

### DIFF
--- a/src/fshtypes/FshCodeSystem.ts
+++ b/src/fshtypes/FshCodeSystem.ts
@@ -25,8 +25,8 @@ export class FshCodeSystem extends FshEntity {
 
   get id() {
     const assignedId = getNonInstanceValueFromRules(this, 'id', '', 'id');
-    if (assignedId) {
-      return assignedId.toString();
+    if (typeof assignedId === 'string') {
+      return assignedId;
     }
     return this._id;
   }

--- a/src/fshtypes/FshStructure.ts
+++ b/src/fshtypes/FshStructure.ts
@@ -22,8 +22,8 @@ export abstract class FshStructure extends FshEntity {
 
   get id() {
     const assignedId = getNonInstanceValueFromRules(this, 'id', '', 'id');
-    if (assignedId) {
-      return assignedId.toString();
+    if (typeof assignedId === 'string') {
+      return assignedId;
     }
     return this._id;
   }

--- a/src/fshtypes/FshValueSet.ts
+++ b/src/fshtypes/FshValueSet.ts
@@ -25,8 +25,8 @@ export class FshValueSet extends FshEntity {
 
   get id() {
     const assignedId = getNonInstanceValueFromRules(this, 'id', '', 'id');
-    if (assignedId) {
-      return assignedId.toString();
+    if (typeof assignedId === 'string') {
+      return assignedId;
     }
     return this._id;
   }

--- a/src/fshtypes/Instance.ts
+++ b/src/fshtypes/Instance.ts
@@ -25,8 +25,8 @@ export class Instance extends FshEntity {
 
   get id() {
     const assignedId = getNonInstanceValueFromRules(this, 'id', '', 'id');
-    if (assignedId) {
-      return assignedId.toString();
+    if (typeof assignedId === 'string') {
+      return assignedId;
     }
     return this._id;
   }

--- a/test/fshtypes/FshCodeSystem.test.ts
+++ b/test/fshtypes/FshCodeSystem.test.ts
@@ -1,9 +1,9 @@
 import 'jest-extended';
 import { FshCodeSystem } from '../../src/fshtypes/FshCodeSystem';
-import { ConceptRule } from '../../src/fshtypes/rules';
+import { CaretValueRule, ConceptRule } from '../../src/fshtypes/rules';
 import { EOL } from 'os';
 
-describe('CodeSystem', () => {
+describe('FshCodeSystem', () => {
   describe('#constructor', () => {
     it('should set initial properties correctly', () => {
       const cs = new FshCodeSystem('MyCodeSystem');
@@ -12,6 +12,37 @@ describe('CodeSystem', () => {
       expect(cs.title).toBeUndefined();
       expect(cs.description).toBeUndefined();
       expect(cs.rules).toBeEmpty();
+    });
+  });
+
+  describe('#id', () => {
+    it('should return an id set by a string caret rule', () => {
+      const p = new FshCodeSystem('MyCodeSystem');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = 'different-id';
+      p.rules.push(idRule);
+      expect(p.id).toBe('different-id');
+    });
+
+    it('should not return an id set by a non-string caret rule', () => {
+      const p = new FshCodeSystem('MyCodeSystem');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = BigInt(23456);
+      idRule.rawValue = '23456';
+      p.rules.push(idRule);
+      expect(p.id).toBe('MyCodeSystem');
+    });
+
+    it('should not return an id set by an instance caret rule', () => {
+      const p = new FshCodeSystem('MyCodeSystem');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = 'different-id';
+      idRule.isInstance = true;
+      p.rules.push(idRule);
+      expect(p.id).toBe('MyCodeSystem');
     });
   });
 

--- a/test/fshtypes/FshValueSet.test.ts
+++ b/test/fshtypes/FshValueSet.test.ts
@@ -2,6 +2,7 @@ import 'jest-extended';
 import { FshValueSet } from '../../src/fshtypes/FshValueSet';
 import { EOL } from 'os';
 import {
+  CaretValueRule,
   ValueSetConceptComponentRule,
   ValueSetFilterComponentRule
 } from '../../src/fshtypes/rules';
@@ -16,6 +17,37 @@ describe('ValueSet', () => {
       expect(vs.title).toBeUndefined();
       expect(vs.description).toBeUndefined();
       expect(vs.rules).toBeEmpty();
+    });
+  });
+
+  describe('#id', () => {
+    it('should return an id set by a string caret rule', () => {
+      const p = new FshValueSet('MyValueSet');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = 'different-id';
+      p.rules.push(idRule);
+      expect(p.id).toBe('different-id');
+    });
+
+    it('should not return an id set by a non-string caret rule', () => {
+      const p = new FshValueSet('MyValueSet');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = BigInt(23456);
+      idRule.rawValue = '23456';
+      p.rules.push(idRule);
+      expect(p.id).toBe('MyValueSet');
+    });
+
+    it('should not return an id set by an instance caret rule', () => {
+      const p = new FshValueSet('MyValueSet');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = 'different-id';
+      idRule.isInstance = true;
+      p.rules.push(idRule);
+      expect(p.id).toBe('MyValueSet');
     });
   });
 

--- a/test/fshtypes/Instance.test.ts
+++ b/test/fshtypes/Instance.test.ts
@@ -24,6 +24,16 @@ describe('Instance', () => {
       expect(p.id).toBe('different-id');
     });
 
+    it('should not return an id set by a non-string assignment rule', () => {
+      const p = new Instance('MyInstance');
+      const idRule = new AssignmentRule('id');
+      idRule.value = BigInt(12345);
+      idRule.rawValue = '12345';
+      p.rules.push(idRule);
+      // the id is still the default
+      expect(p.id).toBe('MyInstance');
+    });
+
     it('should not return an id set by an instance assignment rule', () => {
       const p = new Instance('MyInstance');
       const idRule = new AssignmentRule('id');

--- a/test/fshtypes/Profile.test.ts
+++ b/test/fshtypes/Profile.test.ts
@@ -29,6 +29,16 @@ describe('Profile', () => {
       expect(p.id).toBe('different-id');
     });
 
+    it('should not return an id set by a non-string caret rule', () => {
+      const p = new Profile('MyObservation');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = BigInt(23456);
+      idRule.rawValue = '23456';
+      p.rules.push(idRule);
+      expect(p.id).toBe('MyObservation');
+    });
+
     it('should not return an id set by an instance caret rule', () => {
       const p = new Profile('MyObservation');
       const idRule = new CaretValueRule('');


### PR DESCRIPTION
**Description:**
When getting the id for a FshType, rules are checked to see if there is one that will set the id and does not refer to an instance. A value that is not a string will not be valid and not be applied. Therefore, only return the value if it is a string.

Rename test file for FshCodeSystem to match name of source file.

**Testing Instructions:**
Confirm that using a non-string value in a rule that sets an entity's `id` does not allow for other rules to fish up that entity using that id. The sample FSH from the issue is an example of this on an Instance:
```
Instance: requireddataforantimicro-response
InstanceOf: Questionnaire
Usage: #example
* id = 3193360
```
In this case, an error will be logged for the `id` rule since it is the wrong type, and there should not be a call stack overflow as described in the linked issue. Behavior should be the same for Profile, Extension, Logical, Resource, CodeSystem, and ValueSet, although these entities will set `id` using a caret rule, not an assignment rule.

**Related Issue:**
Fixes #1519.