### PR TITLE
v3.12.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "fsh-sushi",
-  "version": "3.11.1",
+  "version": "3.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fsh-sushi",
-      "version": "3.11.1",
+      "version": "3.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "3.11.1",
+  "version": "3.12.0",
   "description": "Sushi Unshortens Short Hand Inputs (FSH Compiler)",
   "scripts": {
     "build": "del-cli dist && tsc && copyfiles -u 3 \"src/utils/init-project/*\" dist/utils/init-project",

--- a/src/app.ts
+++ b/src/app.ts
@@ -36,7 +36,7 @@ import {
   updateConfig
 } from './utils';
 
-const FSH_VERSION = '3.0.0-ballot';
+const FSH_VERSION = '3.0.0';
 
 function logUnexpectedError(e: Error) {
   logger.error(`SUSHI encountered the following unexpected error: ${e.message}`);


### PR DESCRIPTION
**Description:** Bump the version to 3.12.0 (minor version bump, since we added support for FHIR R6) and update `FSH_VERSION` to `3.0.0` since FSH 3.0.0 has recently been published.

**Testing Instructions:** Run a quick test to make sure SUSHI works. Ideally try running against a project with `fhirVersion: 6.0.0-ballot2` in the `sushi-config.yaml`.

**Related Issue:** N/A
