### PR TITLE
Load automatic dependencies for FHIR R6 versions

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -70,7 +70,7 @@ export const AUTOMATIC_DEPENDENCIES: AutomaticDependency[] = [
   {
     packageId: 'hl7.terminology.r5',
     version: 'latest',
-    fhirVersions: ['R5']
+    fhirVersions: ['R5', 'R6']
   },
   {
     packageId: 'hl7.fhir.uv.extensions.r4',
@@ -80,7 +80,7 @@ export const AUTOMATIC_DEPENDENCIES: AutomaticDependency[] = [
   {
     packageId: 'hl7.fhir.uv.extensions.r5',
     version: 'latest',
-    fhirVersions: ['R5']
+    fhirVersions: ['R5', 'R6']
   }
 ];
 

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -1339,6 +1339,19 @@ describe('Processing', () => {
       });
     });
 
+    it('should load each automatic dependency for FHIR R6 prerelease', () => {
+      const config = cloneDeep(minimalConfig);
+      config.dependencies = [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }];
+      const defs = new FHIRDefinitions();
+      return loadAutomaticDependencies('6.0.0-ballot2', config.dependencies, defs).then(() => {
+        expect(loadedPackages).toHaveLength(3);
+        expect(loadedPackages).toContain('hl7.fhir.uv.tools#current');
+        expect(loadedPackages).toContain('hl7.terminology.r5#1.2.3-test');
+        expect(loadedPackages).toContain('hl7.fhir.uv.extensions.r5#4.5.6-test');
+        expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+      });
+    });
+
     it('should should use the package server query to get the terminology version', () => {
       // Change the version to 2.4.6-test just to be sure
       nock.removeInterceptor(termR4NockScope);
@@ -1544,6 +1557,20 @@ describe('Processing', () => {
       config.dependencies = [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }];
       const defs = new FHIRDefinitions();
       return loadAutomaticDependencies('5.0.0', config.dependencies, defs).then(() => {
+        expect(loadedPackages).toHaveLength(3);
+        expect(loadedPackages).toContain('hl7.fhir.uv.tools#current');
+        expect(loadedPackages).toContain('hl7.terminology.r5#1.2.3-test');
+        expect(loadedPackages).toContain('hl7.fhir.uv.extensions.r5#4.5.6-test');
+        expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+      });
+    });
+
+    it('should load each automatic dependency for FHIR R6 prerelease from a custom registry', () => {
+      process.env.FPL_REGISTRY = 'https://custom-registry.example.org';
+      const config = cloneDeep(minimalConfig);
+      config.dependencies = [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }];
+      const defs = new FHIRDefinitions();
+      return loadAutomaticDependencies('6.0.0-ballot2', config.dependencies, defs).then(() => {
         expect(loadedPackages).toHaveLength(3);
         expect(loadedPackages).toContain('hl7.fhir.uv.tools#current');
         expect(loadedPackages).toContain('hl7.terminology.r5#1.2.3-test');


### PR DESCRIPTION
**Description:**
R6 prerelease versions of FHIR are available, but R6 versions of the terminology and extension packages are not yet available. Load the R5 versions of this packages when an R6 version of FHIR is used.

**Testing Instructions:**
Confirm that tests pass. Run SUSHI on a project that uses R6 prerelease FHIR along with official extensions and confirm that no errors are produced.

**Related Issue:**
Fixes #1533.