### PR TITLE
v3.12.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "fsh-sushi",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fsh-sushi",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Sushi Unshortens Short Hand Inputs (FSH Compiler)",
   "scripts": {
     "build": "del-cli dist && tsc && copyfiles -u 3 \"src/utils/init-project/*\" dist/utils/init-project",


### PR DESCRIPTION
**Description:**
Bump version to v3.12.1. This is a patch version, since we're fixing the automatic extension issue for R6 that was introduced in v3.12.0.

**Testing Instructions:**
Run SUSHI to build a project that uses an R6 ballot version, has no configured dependencies, and makes use of extensions in the [core registry](https://hl7.org/fhir/extensions/extension-registry.html). These extensions should be automatically loaded, so there should be no errors.

**Related Issue:**
N/A