### PR TITLE
place fsh-index.json in the data folder

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -634,7 +634,9 @@ export function writeFSHIndex(
   fs.outputFileSync(path.join(outDir, 'fsh-generated', 'fsh-index.txt'), table(textIndex));
   // write json for machine usage. Use the fsh-generated/data folder for the template to pick it up. Ensure the folder exists
   fs.ensureDirSync(path.join(outDir, 'fsh-generated', 'data'));
-  fs.outputJsonSync(path.join(outDir, 'fsh-generated', 'data', 'fsh-index.json'), jsonIndex, { spaces: 2 });
+  fs.outputJsonSync(path.join(outDir, 'fsh-generated', 'data', 'fsh-index.json'), jsonIndex, {
+    spaces: 2
+  });
 }
 
 export function writePreprocessedFSH(outDir: string, inDir: string, tank: FSHTank) {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -632,7 +632,8 @@ export function writeFSHIndex(
   // write txt with nice formatting
   textIndex.unshift(['Output File', 'Name', 'Type', 'FSH File', 'Lines']);
   fs.outputFileSync(path.join(outDir, 'fsh-generated', 'fsh-index.txt'), table(textIndex));
-  // write json for machine usage
+  // write json for machine usage. Use the fsh-generated/data folder for the template to pick it up. Ensure the folder exists
+  fs.ensureDirSync(path.join(outDir, 'fsh-generated', 'data'));
   fs.outputJsonSync(path.join(outDir, 'fsh-generated', 'data', 'fsh-index.json'), jsonIndex, { spaces: 2 });
 }
 

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -633,7 +633,7 @@ export function writeFSHIndex(
   textIndex.unshift(['Output File', 'Name', 'Type', 'FSH File', 'Lines']);
   fs.outputFileSync(path.join(outDir, 'fsh-generated', 'fsh-index.txt'), table(textIndex));
   // write json for machine usage
-  fs.outputJsonSync(path.join(outDir, 'fsh-generated', 'fsh-index.json'), jsonIndex, { spaces: 2 });
+  fs.outputJsonSync(path.join(outDir, 'fsh-generated', 'data', 'fsh-index.json'), jsonIndex, { spaces: 2 });
 }
 
 export function writePreprocessedFSH(outDir: string, inDir: string, tank: FSHTank) {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -1675,7 +1675,7 @@ describe('Processing', () => {
     it('should create text and json index files that contain each resource in the package', () => {
       writeFSHIndex(tempIGPubRoot, outPackage, fshRoot, []);
       const textIndex = path.join(tempIGPubRoot, 'fsh-generated', 'fsh-index.txt');
-      const jsonIndex = path.join(tempIGPubRoot, 'fsh-generated', 'fsh-index.json');
+      const jsonIndex = path.join(tempIGPubRoot, 'fsh-generated', 'data', 'fsh-index.json');
       expect(fs.existsSync(textIndex)).toBeTrue();
       expect(fs.existsSync(jsonIndex)).toBeTrue();
 
@@ -1734,7 +1734,7 @@ describe('Processing', () => {
     it('should sort the list of resources by output file name', () => {
       writeFSHIndex(tempIGPubRoot, outPackage, fshRoot, []);
       const textIndex = path.join(tempIGPubRoot, 'fsh-generated', 'fsh-index.txt');
-      const jsonIndex = path.join(tempIGPubRoot, 'fsh-generated', 'fsh-index.json');
+      const jsonIndex = path.join(tempIGPubRoot, 'fsh-generated', 'data', 'fsh-index.json');
       expect(fs.existsSync(textIndex)).toBeTrue();
       expect(fs.existsSync(jsonIndex)).toBeTrue();
 
@@ -1757,7 +1757,7 @@ describe('Processing', () => {
     it('should not include a resource in the package if it is in the list of resources to skip', () => {
       writeFSHIndex(tempIGPubRoot, outPackage, fshRoot, ['StructureDefinition-my-extension.json']);
       const textIndex = path.join(tempIGPubRoot, 'fsh-generated', 'fsh-index.txt');
-      const jsonIndex = path.join(tempIGPubRoot, 'fsh-generated', 'fsh-index.json');
+      const jsonIndex = path.join(tempIGPubRoot, 'fsh-generated', 'data', 'fsh-index.json');
       expect(fs.existsSync(textIndex)).toBeTrue();
       expect(fs.existsSync(jsonIndex)).toBeTrue();
 


### PR DESCRIPTION
**Description:**
This PR puts the fsh-index.json not in fsh-generated but in fsh-generated/data. This way, it is possible to allow the IG Publisher to consider this an additional data folder, and use this in rendering. This was originally requested and discussed in Zulip here:[#ig publishing requirements > sushi index file location @ 💬](https://chat.fhir.org/#narrow/channel/196008-ig-publishing-requirements/topic/sushi.20index.20file.20location/near/491302989)

**Testing Instructions:**
When running sushi, the fsh-index.json should be in fsh-generated/data