### PR TITLE
Allow base types as profiles in type constraint rules

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1048,7 +1048,7 @@ export class ElementDefinition {
    * @throws {SliceTypeRemovalError} when a rule would eliminate all types on a slice
    */
   constrainType(rule: OnlyRule | AddElementRule, fisher: Fishable, target?: string): void {
-    const types = rule.types;
+    const types = uniqWith(rule.types, isEqual);
     // Establish the target types (if applicable)
     const targetType = this.getTargetType(target, fisher);
     const targetTypes: ElementDefinitionType[] = targetType ? [targetType] : this.type;
@@ -1523,7 +1523,7 @@ export class ElementDefinition {
     const matchedProfiles: string[] = [];
     const matchedTargetProfiles: string[] = [];
     for (const match of matches) {
-      if (match.metadata.id === newType.code) {
+      if (match.metadata.id === newType.code && matches.length === 1) {
         continue;
       } else if (isReferenceType(match.code) && !isReferenceType(match.metadata.sdType)) {
         matchedTargetProfiles.push(match.metadata.url);

--- a/test/fhirtypes/ElementDefinition.constrainType.test.ts
+++ b/test/fhirtypes/ElementDefinition.constrainType.test.ts
@@ -16,7 +16,7 @@ import { FSHTank } from '../../src/import';
 import cloneDeep from 'lodash/cloneDeep';
 import omit from 'lodash/omit';
 
-describe.only('ElementDefinition', () => {
+describe('ElementDefinition', () => {
   let defs: TestFHIRDefinitions;
   let observation: StructureDefinition;
   let jsonModifiedObservation: any;

--- a/test/fhirtypes/ElementDefinition.constrainType.test.ts
+++ b/test/fhirtypes/ElementDefinition.constrainType.test.ts
@@ -16,7 +16,7 @@ import { FSHTank } from '../../src/import';
 import cloneDeep from 'lodash/cloneDeep';
 import omit from 'lodash/omit';
 
-describe('ElementDefinition', () => {
+describe.only('ElementDefinition', () => {
   let defs: TestFHIRDefinitions;
   let observation: StructureDefinition;
   let jsonModifiedObservation: any;
@@ -195,6 +195,27 @@ describe('ElementDefinition', () => {
         new ElementDefinitionType('Quantity').withProfiles(
           'http://hl7.org/fhir/StructureDefinition/SimpleQuantity',
           'http://hl7.org/fhir/StructureDefinition/MoneyQuantity'
+        )
+      );
+      expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);
+      expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
+    });
+
+    it('should allow a resource type to be constrained to multiple profiles and itself', () => {
+      const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');
+      const valueConstraint = new OnlyRule('value[x]');
+      valueConstraint.types = [
+        { type: 'SimpleQuantity' },
+        { type: 'MoneyQuantity' },
+        { type: 'Quantity' }
+      ];
+      valueX.constrainType(valueConstraint, fisher);
+      expect(valueX.type).toHaveLength(1);
+      expect(valueX.type[0]).toEqual(
+        new ElementDefinitionType('Quantity').withProfiles(
+          'http://hl7.org/fhir/StructureDefinition/SimpleQuantity',
+          'http://hl7.org/fhir/StructureDefinition/MoneyQuantity',
+          'http://hl7.org/fhir/StructureDefinition/Quantity'
         )
       );
       expect(loggerSpy.getAllLogs('warn')).toHaveLength(0);


### PR DESCRIPTION
**Description:**
Provides the ability to specify both a profile and the base type as a given only-rule. Previously, when calculating the intersection between types and profiles, if the profile === type, it was just dropped. Now it will be included as an additional profile, but only if it was not the only instance of that type  (e.g. setting `* resource only Observation` will still only set the type to be only "Observation", but `* resource only CustomProfile or Observation` will set the type as Observation and the profile as a 2-element array containing CustomProfile and Observation.

Found a failing test re: duplicate types after attempting my monkey-patch. I'm not sure if there was more that the test was expecting, but throwing a warning for duplicate types seems to be a side-effect of the code area I changed. To more specifically prevent this, I added a `uniqWith` on the initial line of `constrainType` so truly duplicate entries will be filtered (and then later the warning will trigger because the counts are different).

**Testing Instructions:**
Tests should continue to pass. Can create a simple IG with a field that contains both a profile and its type in the only list and verify that the type appears as profile alongside the specified profile.

**Related Issue:**
https://github.com/FHIR/sushi/issues/1564