### PR TITLE
correct misleading directory creation prompt

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -786,8 +786,8 @@ export async function init(
   const outputDir = path.resolve('.', projectName);
   const initProjectDir = path.join(__dirname, 'init-project');
   if (options.autoInitialize) {
-    console.log(`Initializing SUSHI project in ${outputDir}`);
-  } else if (!readlineSync.keyInYN(`Initialize SUSHI project in ${outputDir}?`)) {
+    console.log(`SUSHI project will be created in ${outputDir}`);
+  } else if (!readlineSync.keyInYN(`SUSHI project will be created in ${outputDir}. Proceed?`)) {
     console.log('\nAborting Initialization.\n');
     return;
   }

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -2064,7 +2064,7 @@ describe('Processing', () => {
         ['Publisher Url (Default: http://example.org/example-publisher): ']
       ]);
       expect(yesNoSpy.mock.calls).toHaveLength(1);
-      expect(yesNoSpy.mock.calls[0][0]).toMatch(/Initialize SUSHI project in .*ExampleIG/);
+      expect(yesNoSpy.mock.calls[0][0]).toMatch(/SUSHI project will be created in .*ExampleIG/);
 
       expect(ensureDirSpy.mock.calls).toHaveLength(2);
       expect(ensureDirSpy.mock.calls[0][0]).toMatch(/.*ExampleIG.*input.*pagecontent/);
@@ -2140,7 +2140,7 @@ describe('Processing', () => {
         ['Publisher Url (Default: http://example.org/example-publisher): ']
       ]);
       expect(yesNoSpy.mock.calls).toHaveLength(1);
-      expect(yesNoSpy.mock.calls[0][0]).toMatch(/Initialize SUSHI project in .*MyNonDefaultName/);
+      expect(yesNoSpy.mock.calls[0][0]).toMatch(/SUSHI project will be created in .*MyNonDefaultName/);
 
       expect(ensureDirSpy.mock.calls).toHaveLength(2);
       expect(ensureDirSpy.mock.calls[0][0]).toMatch(/.*MyNonDefaultName.*input.*pagecontent/);
@@ -2200,7 +2200,7 @@ describe('Processing', () => {
         ['Publisher Url (Default: http://example.org/example-publisher): ']
       ]);
       expect(yesNoSpy.mock.calls).toHaveLength(1);
-      expect(yesNoSpy.mock.calls[0][0]).toMatch(/Initialize SUSHI project in .*ExampleIG/);
+      expect(yesNoSpy.mock.calls[0][0]).toMatch(/SUSHI project will be created in .*ExampleIG/);
       expect(ensureDirSpy.mock.calls).toHaveLength(0);
       expect(writeSpy.mock.calls).toHaveLength(0);
       expect(copyFileSpy.mock.calls).toHaveLength(0);
@@ -2299,7 +2299,7 @@ describe('Processing', () => {
       // Need to confirm initialization
       expect(yesNoSpy.mock.calls).toHaveLength(1);
       expect(yesNoSpy.mock.calls[0][0]).toMatch(
-        /Initialize SUSHI project in .*MySemiCLIOptionProject/
+        /SUSHI project will be created in .*MySemiCLIOptionProject/
       );
 
       expect(ensureDirSpy.mock.calls).toHaveLength(2);


### PR DESCRIPTION
**Description:**
Clarified misleading prompt to initialize project in directory. 
**Testing Instructions:**
Create new project, observe changed prompt.

**Related Issue:**
#1592 