### PR TITLE
Only check for deprecated config file if none with the current naming was found

### DIFF
--- a/src/import/ensureConfigurationFile.ts
+++ b/src/import/ensureConfigurationFile.ts
@@ -1,5 +1,5 @@
-import path from 'path';
 import fs from 'fs-extra';
+import path from 'path';
 import { logger } from '../utils/FSHLogger';
 
 /**
@@ -18,15 +18,18 @@ export function ensureConfiguration(root: string): string {
     logger.info(`Using configuration file: ${path.resolve(configPath)}`);
   }
 
-  const deprecatedConfigPath = [path.join(root, 'config.yaml'), path.join(root, 'config.yml')].find(
-    fs.existsSync
-  );
-  if (deprecatedConfigPath) {
-    logger.error(
-      `Use of ${path.basename(
-        deprecatedConfigPath
-      )} is no longer supported. Please rename configuration file to "sushi-config.yaml" in order to use this configuration file.`
-    );
+  if (!configPath) {
+    const deprecatedConfigPath = [
+      path.join(root, 'config.yaml'),
+      path.join(root, 'config.yml')
+    ].find(fs.existsSync);
+    if (deprecatedConfigPath) {
+      logger.error(
+        `Use of ${path.basename(
+          deprecatedConfigPath
+        )} is no longer supported. Please rename configuration file to "sushi-config.yaml" in order to use this configuration file.`
+      );
+    }
   }
 
   return configPath; // Return the path to the config or undefined if it wasn't found


### PR DESCRIPTION
Modifies the behavior of the config file detection in that way that the detection of deprecated config file names is only performed if none is found with the current naming scheme.

This fixes issues with other config files being present in the same directory.

fixes #1595 