### PR TITLE
Fix regression to better handle aborted repos and symlinks

### DIFF
--- a/regression/run.ts
+++ b/regression/run.ts
@@ -656,14 +656,15 @@ function prepareJsonChunk(jsonChunk: string): string {
 }
 
 async function getFilesRecursive(dir: string): Promise<string[]> {
-  const isDirectory = await (await fs.stat(dir)).isDirectory();
-  if (isDirectory) {
+  const stat = await fs.lstat(dir);
+  if (stat.isDirectory()) {
     const children = await fs.readdir(dir);
     const ancestors = await Promise.all(children.map(f => getFilesRecursive(path.join(dir, f))));
     return ([] as string[]).concat(...ancestors);
-  } else {
+  } else if (stat.isFile()) {
     return [dir];
   }
+  return [];
 }
 
 async function readFile(file: string): Promise<string> {


### PR DESCRIPTION
**Description:** This fixes the regression script so it doesn't crash processing repos that were aborted (usually due to download errors). Previously it crashed when trying to reference stats on those repos. Now we initialize stats on aborted repos so the rest of the code can safely assume stats are always there. This also adds a new row in the summary for aborted repos.

In addition, this fixes handling of symlinks in repos. Previously, symlinks could cause processing the diffs to fail. Now symlinks are ignored since SUSHI doesn't produce symlinks in its output and we only care about changes to output.

**Testing Instructions:**

Run a simple regression with a repo that fails download. The regression should complete and the output report should note that one repo was aborted. E.g.
```
npm run regression -- run -a gh:master -b local --repo phuse-org/draft-study-design-to-rdf#master IHE/pharm-supply#master
```

To test handling of symlinks, run a simple regression of repos that have symlinks and ensure there are no issues (previously it would produce a diff file that contained an error in it). E.g.,
```
npm run regression -- run -a gh:master -b local --repo HL7-cr/terminology#main WorldHealthOrganization/smart-immunizations#main
```

**Related Issue:** N/A
