### PR TITLE
Handle finding IG URLs for release-specific packages with incorrect packageIds

### DIFF
--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -320,6 +320,31 @@ export class IGExporter {
             'dev' === resolvedVersion)
       );
       dependsOn.uri = dependencyIG?.url;
+      if (dependsOn.uri == null && /\.r\d+$/.test(realPackageId)) {
+        // Some release-specific packages (e.g., hl7.fhir.eu.extensions.r4) don't include the correct packageId;
+        // they might have a package id like hl7.fhir.eu.extensions.4.0.1 and an id like hl7.fhir.eu.extensions.
+        // See: https://chat.fhir.org/#narrow/channel/215610-shorthand/topic/ImplementationGuide.20URL.20missing/near/576162330
+        const fallBackIG = igs.find(ig => {
+          const packageIdPrefix = realPackageId.replace(/\.r\d+$/, '.');
+          if (ig.packageId?.startsWith(packageIdPrefix)) {
+            // Grab version suffix like 4.0.1
+            const versionSuffix = ig.packageId.slice(packageIdPrefix.length);
+            // Convert version suffix to release suffix like r4 (also converting DSTU2 to r2 and STU3 to r3)
+            const releaseSuffix = getFHIRVersionInfo(versionSuffix)
+              ?.name.toLowerCase()
+              .replace(/^[^0-9]+/, 'r');
+            // Put the package id back together with the fixed suffix
+            const fixedPackageId = ig.packageId.slice(0, packageIdPrefix.length) + releaseSuffix;
+            return (
+              fixedPackageId === realPackageId &&
+              (ig.version === resolvedVersion ||
+                'current' === resolvedVersion ||
+                'dev' === resolvedVersion)
+            );
+          }
+        });
+        dependsOn.uri = fallBackIG?.url;
+      }
       if (dependsOn.uri == null) {
         // there may be a package.json that can help us here
         const dependencyPackageJson = this.fhirDefs.findPackageJSON(realPackageId, resolvedVersion);

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -455,10 +455,46 @@ describe('IGExporter', () => {
       ]);
     });
 
+    // See: https://chat.fhir.org/#narrow/channel/215610-shorthand/topic/ImplementationGuide.20URL.20missing/near/576162330
+    it('should fall back to release-agnostic IG when it cannot find a release-specific dependency implementation guide', () => {
+      config.dependencies = [
+        { packageId: 'hl7.fhir.eu.extensions.r4', version: '1.2.0' },
+        { packageId: 'hl7.fhir.us.core', version: '3.1.0' }
+      ];
+      exporter.export(tempOut);
+      const igPath = path.join(
+        tempOut,
+        'fsh-generated',
+        'resources',
+        'ImplementationGuide-sushi-test.json'
+      );
+      expect(fs.existsSync(igPath)).toBeTruthy();
+      const content = fs.readJSONSync(igPath);
+      const dependencies: ImplementationGuideDependsOn[] = content.dependsOn;
+      expect(loggerSpy.getAllLogs('error')).toHaveLength(0);
+      // ensure both packages are in the dependencies
+      expect(dependencies).toEqual([
+        {
+          id: 'hl7_fhir_eu_extensions_r4',
+          uri: 'http://hl7.eu/fhir/extensions/ImplementationGuide/hl7.fhir.eu.extensions',
+          packageId: 'hl7.fhir.eu.extensions.r4',
+          version: '1.2.0'
+        },
+        {
+          id: 'hl7_fhir_us_core',
+          uri: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core',
+          packageId: 'hl7.fhir.us.core',
+          version: '3.1.0'
+        }
+      ]);
+    });
+
     it('should use a default url format when a dependency url cannot be inferred', () => {
       config.dependencies = [
         // NOTE: Will not find mCODE IG URL because we didn't load the mcode IG
         { packageId: 'hl7.fhir.us.mcode', version: '1.0.0' },
+        // NOTE: Test release-specific that isn't found to ensure fallback code doesn't trigger
+        { packageId: 'hl7.fhir.us.something.r4', version: '2.0.0' },
         { packageId: 'hl7.fhir.us.core', version: '3.1.0' }
       ];
       exporter.export(tempOut);
@@ -479,6 +515,12 @@ describe('IGExporter', () => {
           uri: 'http://fhir.org/packages/hl7.fhir.us.mcode/ImplementationGuide/hl7.fhir.us.mcode',
           packageId: 'hl7.fhir.us.mcode',
           version: '1.0.0'
+        },
+        {
+          id: 'hl7_fhir_us_something_r4',
+          uri: 'http://fhir.org/packages/hl7.fhir.us.something.r4/ImplementationGuide/hl7.fhir.us.something.r4',
+          packageId: 'hl7.fhir.us.something.r4',
+          version: '2.0.0'
         },
         {
           id: 'hl7_fhir_us_core',

--- a/test/testhelpers/testdefs/r4-definitions/package/ImplementationGuide-hl7.fhir.eu.extensions.json
+++ b/test/testhelpers/testdefs/r4-definitions/package/ImplementationGuide-hl7.fhir.eu.extensions.json
@@ -1,0 +1,694 @@
+{
+  "resourceType": "ImplementationGuide",
+  "id": "hl7.fhir.eu.extensions",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: ImplementationGuide hl7.fhir.eu.extensions</b></p><a name=\"hl7.fhir.eu.extensions\"> </a><a name=\"hchl7.fhir.eu.extensions\"> </a><h2>Hl7EuExtensions</h2><p>The official URL for this implementation guide is: </p><pre>http://hl7.eu/fhir/extensions/ImplementationGuide/hl7.fhir.eu.extensions</pre><div><p>This guide lists the extensions specified for the European REALM.</p>\n</div></div>"
+  },
+  "url": "http://hl7.eu/fhir/extensions/ImplementationGuide/hl7.fhir.eu.extensions",
+  "version": "1.2.0",
+  "name": "Hl7EuExtensions",
+  "title": "HL7 Europe Extensions",
+  "status": "active",
+  "date": "2025-12-19T11:52:02+01:00",
+  "publisher": "HL7 Europe",
+  "contact": [{ "name": "HL7 Europe", "telecom": [{ "system": "url", "value": "http://hl7.eu" }] }],
+  "description": "This guide lists the extensions specified for the European REALM.",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "http://unstats.un.org/unsd/methods/m49/m49.htm",
+          "code": "150",
+          "display": "Europe"
+        }
+      ]
+    }
+  ],
+  "copyright": "Copyright HL7 Europe. Licensed under Creative Commons public domain (CC0 1.0).",
+  "packageId": "hl7.fhir.eu.extensions.4.0.1",
+  "license": "CC0-1.0",
+  "fhirVersion": ["5.0.0"],
+  "dependsOn": [
+    {
+      "id": "hl7tx",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/tools/StructureDefinition/implementationguide-dependency-comment",
+          "valueMarkdown": "Automatically added as a dependency - all IGs depend on HL7 Terminology"
+        }
+      ],
+      "uri": "http://terminology.hl7.org/ImplementationGuide/hl7.terminology",
+      "packageId": "hl7.terminology.r5",
+      "version": "7.0.1"
+    },
+    {
+      "id": "hl7ext",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/tools/StructureDefinition/implementationguide-dependency-comment",
+          "valueMarkdown": "Automatically added as a dependency - all IGs depend on the HL7 Extension Pack"
+        }
+      ],
+      "uri": "http://hl7.org/fhir/extensions/ImplementationGuide/hl7.fhir.uv.extensions",
+      "packageId": "hl7.fhir.uv.extensions.r5",
+      "version": "5.2.0"
+    }
+  ],
+  "definition": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-internal-dependency",
+        "valueCode": "hl7.fhir.uv.tools.r5#0.9.0"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "copyrightyear" },
+          { "url": "value", "valueString": "2023+" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "releaselabel" },
+          { "url": "value", "valueString": "trial-use" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "generate-version" },
+          { "url": "value", "valueString": "r4" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "generate-version" },
+          { "url": "value", "valueString": "r5" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "special-url" },
+          {
+            "url": "value",
+            "valueString": "http://hl7.eu/fhir/StructureDefinition/information-recipient"
+          }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "special-url" },
+          {
+            "url": "value",
+            "valueString": "http://hl7.eu/fhir/StructureDefinition/composition-basedOn-order-or-requisition"
+          }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "special-url" },
+          {
+            "url": "value",
+            "valueString": "http://hl7.eu/fhir/StructureDefinition/medication-package-type"
+          }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "special-url" },
+          {
+            "url": "value",
+            "valueString": "http://hl7.eu/fhir/StructureDefinition/consent-relatedCondition"
+          }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "special-url" },
+          {
+            "url": "value",
+            "valueString": "http://hl7.eu/fhir/StructureDefinition/encounter-legalStatus"
+          }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "special-url" },
+          { "url": "value", "valueString": "http://hl7.eu/fhir/StructureDefinition/presentedForm" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "apply-contact" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "apply-jurisdiction" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "apply-publisher" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "apply-version" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "show-inherited-invariants" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "usage-stats-opt-out" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "autoload-resources" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "path-liquid" },
+          { "url": "value", "valueString": "template/liquid" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "path-liquid" },
+          { "url": "value", "valueString": "input/liquid" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "path-qa" },
+          { "url": "value", "valueString": "temp/qa" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "path-temp" },
+          { "url": "value", "valueString": "temp/pages" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "path-output" },
+          { "url": "value", "valueString": "output" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "path-suppressed-warnings" },
+          { "url": "value", "valueString": "input/ignoreWarnings.txt" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "path-history" },
+          { "url": "value", "valueString": "http://hl7.eu/fhir/extensions/history.html" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "template-html" },
+          { "url": "value", "valueString": "template-page.html" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "template-md" },
+          { "url": "value", "valueString": "template-page-md.html" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "apply-context" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "apply-copyright" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "apply-license" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "apply-wg" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "active-tables" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "fmm-definition" },
+          { "url": "value", "valueString": "http://hl7.org/fhir/versions.html#maturity" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "propagate-status" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "excludelogbinaryformat" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      },
+      {
+        "extension": [
+          { "url": "code", "valueCode": "tabbed-snapshots" },
+          { "url": "value", "valueString": "true" }
+        ],
+        "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+      }
+    ],
+    "resource": [
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "StructureDefinition:extension"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "StructureDefinition-composition-basedOn-order-or-requisition.html"
+          }
+        ],
+        "reference": {
+          "reference": "StructureDefinition/composition-basedOn-order-or-requisition"
+        },
+        "name": "Composition: Based On Order",
+        "description": "This extension provides a link to the order [(Reference(ServiceRequest)] or requisition [ServiceRequest.requisition (i.e., 'Request.groupIdentifier')] that this report document is based on and fulfills.",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "Composition"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "Composition-comp-example.html"
+          }
+        ],
+        "reference": { "reference": "Composition/comp-example" },
+        "name": "Composition: example with extensions",
+        "description": "Example of Composition with InformationRecipient and CompositionBasedOnOrderOrRequisition extensions.",
+        "exampleBoolean": true
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "StructureDefinition:extension"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "StructureDefinition-information-recipient.html"
+          }
+        ],
+        "reference": { "reference": "StructureDefinition/information-recipient" },
+        "name": "Composition: Information recipient",
+        "description": "This extension applies to the Composition resource and is used to represent an intended recipient of the composition.",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "Condition"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "Condition-condition-example.html"
+          }
+        ],
+        "reference": { "reference": "Condition/condition-example" },
+        "name": "Condition: example with extensions",
+        "description": "Example of Condition with periodOfLife extensions.",
+        "exampleBoolean": true
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "Consent"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "Consent-consent-example.html"
+          }
+        ],
+        "reference": { "reference": "Consent/consent-example" },
+        "name": "Consent: example with extensions",
+        "description": "Example of Consent with related condition.",
+        "exampleBoolean": true
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "StructureDefinition:extension"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "StructureDefinition-consent-relatedCondition.html"
+          }
+        ],
+        "reference": { "reference": "StructureDefinition/consent-relatedCondition" },
+        "name": "Consent: Related Condition",
+        "description": "The problem or disorder to which the living will applies.",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "StructureDefinition:extension"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "StructureDefinition-composition-diagnosticReportReference.html"
+          }
+        ],
+        "reference": { "reference": "StructureDefinition/composition-diagnosticReportReference" },
+        "name": "Document DiagnosticReport Reference",
+        "description": "This extension provides a reference to the DiagnosticReport instance that is associated with this Composition.",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "Encounter"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "Encounter-enc-example.html"
+          }
+        ],
+        "reference": { "reference": "Encounter/enc-example" },
+        "name": "Encounter: example with extensions.",
+        "description": "Example of Encounter with legal status.",
+        "exampleBoolean": true
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "StructureDefinition:extension"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "StructureDefinition-encounter-legalStatus.html"
+          }
+        ],
+        "reference": { "reference": "StructureDefinition/encounter-legalStatus" },
+        "name": "Encounter: Legal Status",
+        "description": "Legal status/situation at admission. This extension may be used for representing the basis on which the patient is staying in a healthcare organisation. This can be either voluntary or involuntary. A patient can also receive healthcare based on a forensic status. (voluntary, involuntary, admission by legal authority).",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "ValueSet"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "ValueSet-example-legal-status-vs.html"
+          }
+        ],
+        "reference": { "reference": "ValueSet/example-legal-status-vs" },
+        "name": "Example of Legal Status at admission Value Set",
+        "description": "This is an example value set representing the Legal status / Situation at admission.",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "StructureDefinition:extension"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "StructureDefinition-periods-of-life.html"
+          }
+        ],
+        "reference": { "reference": "StructureDefinition/periods-of-life" },
+        "name": "Many: Periods of Life",
+        "description": "Extensions used to indicate a time period in a person's life as a reference to a coded value for that life period.",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "Medication"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "Medication-04A-FirmagonBranded.html"
+          }
+        ],
+        "reference": { "reference": "Medication/04A-FirmagonBranded" },
+        "name": "Medication: example with extensions.",
+        "description": "Example of Medication resource implementing the MPD extensions documented in this guide.",
+        "exampleBoolean": true
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "StructureDefinition:extension"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "StructureDefinition-medication-package-type.html"
+          }
+        ],
+        "reference": { "reference": "StructureDefinition/medication-package-type" },
+        "name": "Medication: Package type",
+        "description": "This extension applies to Medication and expresses the type of the container for the product (e.g. bottle, unit-dose blister, pre-filled pen).",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "ValueSet"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+            "valueUri": "ValueSet-periods-of-life-vs.html"
+          }
+        ],
+        "reference": { "reference": "ValueSet/periods-of-life-vs" },
+        "name": "Periods of Life Value Set",
+        "description": "A value set of periods of life extension ([SNOMED tree](https://browser.ihtsdotools.org/?perspective=full&conceptId1=767023003&edition=MAIN/2025-04-01&release=&languages=en)).",
+        "exampleBoolean": false
+      }
+    ],
+    "page": {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+          "valueUrl": "toc.html"
+        }
+      ],
+      "nameUrl": "toc.html",
+      "title": "Table of Contents",
+      "generation": "html",
+      "page": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+              "valueUrl": "index.html"
+            }
+          ],
+          "nameUrl": "index.html",
+          "title": "Home",
+          "generation": "markdown"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+              "valueUrl": "authors.html"
+            }
+          ],
+          "nameUrl": "authors.html",
+          "title": "Authors and Contributors",
+          "generation": "markdown"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+              "valueUrl": "copyright.html"
+            }
+          ],
+          "nameUrl": "copyright.html",
+          "title": "Copyright",
+          "generation": "markdown"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+              "valueUrl": "crossversionanalysis.html"
+            }
+          ],
+          "nameUrl": "crossversionanalysis.html",
+          "title": "Cross-version Analysis",
+          "generation": "markdown"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+              "valueUrl": "downloads.html"
+            }
+          ],
+          "nameUrl": "downloads.html",
+          "title": "Downloads",
+          "generation": "markdown"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+              "valueUrl": "dependencies.html"
+            }
+          ],
+          "nameUrl": "dependencies.html",
+          "title": "Dependencies",
+          "generation": "markdown"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+              "valueUrl": "knownissues.html"
+            }
+          ],
+          "nameUrl": "knownissues.html",
+          "title": "Known Issues",
+          "generation": "markdown"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+              "valueUrl": "scope.html"
+            }
+          ],
+          "nameUrl": "scope.html",
+          "title": "Scope and Content",
+          "generation": "markdown"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+              "valueUrl": "changes.html"
+            }
+          ],
+          "nameUrl": "changes.html",
+          "title": "Change Log",
+          "generation": "markdown"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-page-name",
+              "valueUrl": "design.html"
+            }
+          ],
+          "nameUrl": "design.html",
+          "title": "Design Choices",
+          "generation": "markdown"
+        }
+      ]
+    },
+    "parameter": [
+      { "code": "path-resource", "value": "input/capabilities" },
+      { "code": "path-resource", "value": "input/examples" },
+      { "code": "path-resource", "value": "input/extensions" },
+      { "code": "path-resource", "value": "input/models" },
+      { "code": "path-resource", "value": "input/operations" },
+      { "code": "path-resource", "value": "input/profiles" },
+      { "code": "path-resource", "value": "input/resources" },
+      { "code": "path-resource", "value": "input/vocabulary" },
+      { "code": "path-resource", "value": "input/maps" },
+      { "code": "path-resource", "value": "input/testing" },
+      { "code": "path-resource", "value": "input/history" },
+      { "code": "path-resource", "value": "fsh-generated/resources" },
+      { "code": "path-pages", "value": "template/config" },
+      { "code": "path-pages", "value": "input/images" },
+      { "code": "path-tx-cache", "value": "input-cache/txcache" }
+    ]
+  }
+}


### PR DESCRIPTION
**Description:** Some release-specific packages (e.g., hl7.fhir.eu.extensions.r4) don't include the correct packageId in their `ImplementationGuide` resource; they might have a packageId like `hl7.fhir.eu.extensions.4.0.1`. Update the IG Exporter to handle this case so it can still find the correct IG URL for affected release-specific package dependencies.

**Testing Instructions:** Unit tests demonstrate the fix. You can also try setting up a simple SUSHI project with `hl7.fhir.eu.extensions.r4` as a dependency. The currently released SUSHI will export an IG with the dependency's URL as `http://hl7.eu/fhir/extensions`. This PR branch will export an IG with the dependency's URL as `http://hl7.eu/fhir/extensions/ImplementationGuide/hl7.fhir.eu.extensions` (which is correct).

**Related Issue:** https://chat.fhir.org/#narrow/channel/215610-shorthand/topic/ImplementationGuide.20URL.20missing/near/576162330
