### PR TITLE
Replace _updatePubliser/_genonce w/ _build in sushi init

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -330,18 +330,9 @@ async function runBuild(input: string, program: OptionValues, helpText: string) 
     const igExporter = new IGExporter(outPackage, defs, igFilesPath);
     igExporter.export(outDir);
     logger.info('Assembled Implementation Guide sources; ready for IG Publisher.');
-    if (
-      !fs
-        .readdirSync(outDir)
-        .some(
-          file =>
-            file.startsWith('_genonce') ||
-            file.startsWith('_updatePublisher') ||
-            file.startsWith('_build')
-        )
-    ) {
+    if (!fs.readdirSync(outDir).some(file => file.startsWith('_build'))) {
       logger.info(
-        'The sample-ig located at https://github.com/FHIR/sample-ig contains scripts useful for downloading and running the IG Publisher.'
+        'The _build script hosted at https://github.com/HL7/ig-publisher-scripts is useful for downloading and running the IG Publisher.'
       );
     }
   }

--- a/src/ig/IGExporter.ts
+++ b/src/ig/IGExporter.ts
@@ -1508,7 +1508,7 @@ export class IGExporter {
         );
       }
       if (inputIni.IG.template == null) {
-        const templateValue = 'fhir.base.template';
+        const templateValue = 'fhir2.base.template';
         inputIni.IG.template = templateValue;
         logger.error(
           `The ig.ini file must have a "template" property. Please update ${filePathString} to include ` +

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -879,14 +879,9 @@ export async function init(
     path.join(initProjectDir, 'ignoreWarnings.txt'),
     path.join(outputDir, 'input', 'ignoreWarnings.txt')
   );
-  // Add the _updatePublisher, _genonce, and _gencontinuous scripts
-  console.log('Downloading publisher scripts from https://github.com/HL7/ig-publisher-scripts');
-  for (const script of [
-    '_genonce.bat',
-    '_genonce.sh',
-    '_updatePublisher.bat',
-    '_updatePublisher.sh'
-  ]) {
+  // Add the _build script
+  console.log('Downloading _build scripts from https://github.com/HL7/ig-publisher-scripts');
+  for (const script of ['_build.bat', '_build.sh']) {
     const url = `https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/${script}`;
     try {
       const res = await axiosGet(url);

--- a/src/utils/init-project/ig.ini
+++ b/src/utils/init-project/ig.ini
@@ -1,3 +1,3 @@
 [IG]
 ig = fsh-generated/resources/ImplementationGuide-fhir.example.json
-template = fhir.base.template#current
+template = fhir2.base.template#current

--- a/test/ig/IGExporter.IG.test.ts
+++ b/test/ig/IGExporter.IG.test.ts
@@ -1123,7 +1123,7 @@ describe('IGExporter', () => {
           }
         ],
         status: 'active',
-        template: 'fhir.base.template',
+        template: 'fhir2.base.template',
         fhirVersion: ['4.0.1'],
         language: 'en',
         publisher: 'James Tuna',

--- a/test/import/fixtures/ig-JSON-with-ini/ig.ini
+++ b/test/import/fixtures/ig-JSON-with-ini/ig.ini
@@ -1,3 +1,3 @@
 [IG]
 ig = sneaky-input/ImplementationGuide.json
-template = fhir.base.template
+template = fhir2.base.template

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -2174,7 +2174,7 @@ describe('Processing', () => {
       expect(ensureDirSpy.mock.calls[0][0]).toMatch(/.*ExampleIG.*input.*pagecontent/);
       expect(ensureDirSpy.mock.calls[1][0]).toMatch(/.*ExampleIG.*input.*fsh/);
 
-      expect(writeSpy.mock.calls).toHaveLength(7);
+      expect(writeSpy.mock.calls).toHaveLength(5);
       expect(writeSpy.mock.calls[0][0]).toMatch(/.*index\.md/);
       expect(writeSpy.mock.calls[0][1]).toMatch(/# ExampleIG/);
       expect(writeSpy.mock.calls[1][0]).toMatch(/.*ig\.ini/);
@@ -2195,21 +2195,15 @@ describe('Processing', () => {
       expect(copyFileSpy.mock.calls[1][1]).toMatch(/.*ExampleIG.*\.gitignore/);
       expect(copyFileSpy.mock.calls[2][1]).toMatch(/.*ExampleIG.*input.*ignoreWarnings\.txt/);
 
-      expect(getSpy.mock.calls).toHaveLength(4);
+      expect(getSpy.mock.calls).toHaveLength(2);
       const base = 'https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
-      expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
-      expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
-      expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
-      expect(getSpy.mock.calls[3][0]).toBe(base + '_updatePublisher.sh');
+      expect(getSpy.mock.calls[0][0]).toBe(base + '_build.bat');
+      expect(getSpy.mock.calls[1][0]).toBe(base + '_build.sh');
 
-      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_genonce\.bat/);
-      expect(writeSpy.mock.calls[3][1]).toMatch(/_genonce\.bat/);
-      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_genonce\.sh/);
-      expect(writeSpy.mock.calls[4][1]).toMatch(/_genonce\.sh/);
-      expect(writeSpy.mock.calls[5][0]).toMatch(/.*_updatePublisher\.bat/);
-      expect(writeSpy.mock.calls[5][1]).toMatch(/_updatePublisher\.bat/);
-      expect(writeSpy.mock.calls[6][0]).toMatch(/.*_updatePublisher\.sh/);
-      expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
+      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_build\.bat/);
+      expect(writeSpy.mock.calls[3][1]).toMatch(/_build\.bat/);
+      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_build\.sh/);
+      expect(writeSpy.mock.calls[4][1]).toMatch(/_build\.sh/);
     });
 
     it('should initialize a project with user input', async () => {
@@ -2252,7 +2246,7 @@ describe('Processing', () => {
       expect(ensureDirSpy.mock.calls[0][0]).toMatch(/.*MyNonDefaultName.*input.*pagecontent/);
       expect(ensureDirSpy.mock.calls[1][0]).toMatch(/.*MyNonDefaultName.*input.*fsh/);
 
-      expect(writeSpy.mock.calls).toHaveLength(7);
+      expect(writeSpy.mock.calls).toHaveLength(5);
       expect(writeSpy.mock.calls[0][0]).toMatch(/.*index\.md/);
       expect(writeSpy.mock.calls[0][1]).toMatch(/# MyNonDefaultName/);
       expect(writeSpy.mock.calls[1][0]).toMatch(/.*ig\.ini/);
@@ -2274,21 +2268,15 @@ describe('Processing', () => {
         /.*MyNonDefaultName.*input.*ignoreWarnings\.txt/
       );
 
-      expect(getSpy.mock.calls).toHaveLength(4);
+      expect(getSpy.mock.calls).toHaveLength(2);
       const base = 'https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
-      expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
-      expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
-      expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
-      expect(getSpy.mock.calls[3][0]).toBe(base + '_updatePublisher.sh');
+      expect(getSpy.mock.calls[0][0]).toBe(base + '_build.bat');
+      expect(getSpy.mock.calls[1][0]).toBe(base + '_build.sh');
 
-      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_genonce\.bat/);
-      expect(writeSpy.mock.calls[3][1]).toMatch(/_genonce\.bat/);
-      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_genonce\.sh/);
-      expect(writeSpy.mock.calls[4][1]).toMatch(/_genonce\.sh/);
-      expect(writeSpy.mock.calls[5][0]).toMatch(/.*_updatePublisher\.bat/);
-      expect(writeSpy.mock.calls[5][1]).toMatch(/_updatePublisher\.bat/);
-      expect(writeSpy.mock.calls[6][0]).toMatch(/.*_updatePublisher\.sh/);
-      expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
+      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_build\.bat/);
+      expect(writeSpy.mock.calls[3][1]).toMatch(/_build\.bat/);
+      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_build\.sh/);
+      expect(writeSpy.mock.calls[4][1]).toMatch(/_build\.sh/);
     });
 
     it('should abort initializing a project when the user does not confirm', async () => {
@@ -2333,7 +2321,7 @@ describe('Processing', () => {
       expect(ensureDirSpy.mock.calls[0][0]).toMatch(/.*MyCLIOptionProject.*input.*pagecontent/);
       expect(ensureDirSpy.mock.calls[1][0]).toMatch(/.*MyCLIOptionProject.*input.*fsh/);
 
-      expect(writeSpy.mock.calls).toHaveLength(7);
+      expect(writeSpy.mock.calls).toHaveLength(5);
       expect(writeSpy.mock.calls[0][0]).toMatch(/.*index\.md/);
       expect(writeSpy.mock.calls[0][1]).toMatch(/# MyCLIOptionProject/);
       expect(writeSpy.mock.calls[1][0]).toMatch(/.*ig\.ini/);
@@ -2356,21 +2344,15 @@ describe('Processing', () => {
         /.*MyCLIOptionProject.*input.*ignoreWarnings\.txt/
       );
 
-      expect(getSpy.mock.calls).toHaveLength(4);
+      expect(getSpy.mock.calls).toHaveLength(2);
       const base = 'https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
-      expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
-      expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
-      expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
-      expect(getSpy.mock.calls[3][0]).toBe(base + '_updatePublisher.sh');
+      expect(getSpy.mock.calls[0][0]).toBe(base + '_build.bat');
+      expect(getSpy.mock.calls[1][0]).toBe(base + '_build.sh');
 
-      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_genonce\.bat/);
-      expect(writeSpy.mock.calls[3][1]).toMatch(/_genonce\.bat/);
-      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_genonce\.sh/);
-      expect(writeSpy.mock.calls[4][1]).toMatch(/_genonce\.sh/);
-      expect(writeSpy.mock.calls[5][0]).toMatch(/.*_updatePublisher\.bat/);
-      expect(writeSpy.mock.calls[5][1]).toMatch(/_updatePublisher\.bat/);
-      expect(writeSpy.mock.calls[6][0]).toMatch(/.*_updatePublisher\.sh/);
-      expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
+      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_build\.bat/);
+      expect(writeSpy.mock.calls[3][1]).toMatch(/_build\.bat/);
+      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_build\.sh/);
+      expect(writeSpy.mock.calls[4][1]).toMatch(/_build\.sh/);
     });
 
     it('should prompt for and accept inputs for any option not already set with a command line config option', async () => {
@@ -2412,7 +2394,7 @@ describe('Processing', () => {
       expect(ensureDirSpy.mock.calls[0][0]).toMatch(/.*MySemiCLIOptionProject.*input.*pagecontent/);
       expect(ensureDirSpy.mock.calls[1][0]).toMatch(/.*MySemiCLIOptionProject.*input.*fsh/);
 
-      expect(writeSpy.mock.calls).toHaveLength(7);
+      expect(writeSpy.mock.calls).toHaveLength(5);
       expect(writeSpy.mock.calls[0][0]).toMatch(/.*index\.md/);
       expect(writeSpy.mock.calls[0][1]).toMatch(/# MySemiCLIOptionProject/);
       expect(writeSpy.mock.calls[1][0]).toMatch(/.*ig\.ini/);
@@ -2435,21 +2417,15 @@ describe('Processing', () => {
         /.*MySemiCLIOptionProject.*input.*ignoreWarnings\.txt/
       );
 
-      expect(getSpy.mock.calls).toHaveLength(4);
+      expect(getSpy.mock.calls).toHaveLength(2);
       const base = 'https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
-      expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
-      expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
-      expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
-      expect(getSpy.mock.calls[3][0]).toBe(base + '_updatePublisher.sh');
+      expect(getSpy.mock.calls[0][0]).toBe(base + '_build.bat');
+      expect(getSpy.mock.calls[1][0]).toBe(base + '_build.sh');
 
-      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_genonce\.bat/);
-      expect(writeSpy.mock.calls[3][1]).toMatch(/_genonce\.bat/);
-      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_genonce\.sh/);
-      expect(writeSpy.mock.calls[4][1]).toMatch(/_genonce\.sh/);
-      expect(writeSpy.mock.calls[5][0]).toMatch(/.*_updatePublisher\.bat/);
-      expect(writeSpy.mock.calls[5][1]).toMatch(/_updatePublisher\.bat/);
-      expect(writeSpy.mock.calls[6][0]).toMatch(/.*_updatePublisher\.sh/);
-      expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
+      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_build\.bat/);
+      expect(writeSpy.mock.calls[3][1]).toMatch(/_build\.bat/);
+      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_build\.sh/);
+      expect(writeSpy.mock.calls[4][1]).toMatch(/_build\.sh/);
     });
 
     it('should accept remaining defaults without prompting for any options not already set with a command line config option when default option is used', async () => {
@@ -2473,7 +2449,7 @@ describe('Processing', () => {
       );
       expect(ensureDirSpy.mock.calls[1][0]).toMatch(/.*MyCLIOptionWithDefaultsProject.*input.*fsh/);
 
-      expect(writeSpy.mock.calls).toHaveLength(7);
+      expect(writeSpy.mock.calls).toHaveLength(5);
       expect(writeSpy.mock.calls[0][0]).toMatch(/.*index\.md/);
       expect(writeSpy.mock.calls[0][1]).toMatch(/# MyCLIOptionWithDefaultsProject/);
       expect(writeSpy.mock.calls[1][0]).toMatch(/.*ig\.ini/);
@@ -2498,21 +2474,15 @@ describe('Processing', () => {
         /.*MyCLIOptionWithDefaultsProject.*input.*ignoreWarnings\.txt/
       );
 
-      expect(getSpy.mock.calls).toHaveLength(4);
+      expect(getSpy.mock.calls).toHaveLength(2);
       const base = 'https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/';
-      expect(getSpy.mock.calls[0][0]).toBe(base + '_genonce.bat');
-      expect(getSpy.mock.calls[1][0]).toBe(base + '_genonce.sh');
-      expect(getSpy.mock.calls[2][0]).toBe(base + '_updatePublisher.bat');
-      expect(getSpy.mock.calls[3][0]).toBe(base + '_updatePublisher.sh');
+      expect(getSpy.mock.calls[0][0]).toBe(base + '_build.bat');
+      expect(getSpy.mock.calls[1][0]).toBe(base + '_build.sh');
 
-      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_genonce\.bat/);
-      expect(writeSpy.mock.calls[3][1]).toMatch(/_genonce\.bat/);
-      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_genonce\.sh/);
-      expect(writeSpy.mock.calls[4][1]).toMatch(/_genonce\.sh/);
-      expect(writeSpy.mock.calls[5][0]).toMatch(/.*_updatePublisher\.bat/);
-      expect(writeSpy.mock.calls[5][1]).toMatch(/_updatePublisher\.bat/);
-      expect(writeSpy.mock.calls[6][0]).toMatch(/.*_updatePublisher\.sh/);
-      expect(writeSpy.mock.calls[6][1]).toMatch(/_updatePublisher\.sh/);
+      expect(writeSpy.mock.calls[3][0]).toMatch(/.*_build\.bat/);
+      expect(writeSpy.mock.calls[3][1]).toMatch(/_build\.bat/);
+      expect(writeSpy.mock.calls[4][0]).toMatch(/.*_build\.sh/);
+      expect(writeSpy.mock.calls[4][1]).toMatch(/_build\.sh/);
     });
   });
 


### PR DESCRIPTION
**Description:** New IGs should use the _build.sh/_build.bat scripts now, as the other scripts are no longer maintained. This updates `sushi init` to download the _build scripts instead of the updatePublisher and _genonce scripts. It also updates the default template to fhir2.base.template (see: https://www.fhir.org/guides/security-notices/2026-03-npm-dependencies.html#actions-for-ig-authors).

**Testing Instructions:**
* Check out this branch
* Run `npm install`
* Run `npx ts-node src/app.ts init` to create a new SUSHI project
* Change directories into the new project and confirm `_build.sh` and `_build.bat` are present
* Run `./_build.sh` (mac) or `_build.bat` (win) and confirm you get the selection dialog
* Open `ig.ini` and confirm the template is `fhir2.base.template#current`.

After this PR is merged and SUSHI is released, the corresponding FSHSchool PR should also be merged. See https://github.com/FHIR/FSHSchool/pull/109.

**Related Issue:** n/a
