### PR TITLE
Update axios and lodash to address newly reported vulnerabilities

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "ajv": "^8.17.1",
         "antlr4": "^4.13.2",
-        "axios": "^1.13.2",
+        "axios": "^1.15.0",
         "chalk": "^4.1.2",
         "commander": "^13.1.0",
         "fhir-package-loader": "^2.2.3",
@@ -21,7 +21,7 @@
         "https-proxy-agent": "^7.0.5",
         "ini": "^5.0.0",
         "junk": "^3.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.24",
         "readline-sync": "^1.4.10",
         "sanitize-filename": "^1.6.3",
         "sax": "^1.5.0",
@@ -2794,14 +2794,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -4509,9 +4509,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -6330,9 +6330,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -7154,9 +7154,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "antlr4": "^4.13.2",
-    "axios": "^1.13.2",
+    "axios": "^1.15.0",
     "chalk": "^4.1.2",
     "commander": "^13.1.0",
     "fhir-package-loader": "^2.2.3",
@@ -99,7 +99,7 @@
     "https-proxy-agent": "^7.0.5",
     "ini": "^5.0.0",
     "junk": "^3.1.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.24",
     "readline-sync": "^1.4.10",
     "sanitize-filename": "^1.6.3",
     "sax": "^1.5.0",
@@ -110,5 +110,8 @@
     "valid-url": "^1.0.9",
     "winston": "^3.19.0",
     "yaml": "^1.10.2"
+  },
+  "overrides": {
+    "follow-redirects": "^1.15.12"
   }
 }


### PR DESCRIPTION
## Summary

`npm audit` on the current `master` reports three advisories against the
direct `axios` and `lodash` dependencies (plus `follow-redirects` transitively
through `axios`). All three were published *after* SUSHI 3.18.1 was cut, so
they are not covered by the resolution in #1611. This PR bumps the affected
direct dependencies to their first non-vulnerable versions and adds an
`overrides` entry for `follow-redirects`, because `axios@1.15.0` still pins
`follow-redirects@1.15.11` — the upper bound of the vulnerable range.

| Package            | From       | To          | Advisory                                                                                  | Severity |
| ------------------ | ---------- | ----------- | ----------------------------------------------------------------------------------------- | -------- |
| `axios`            | `^1.13.2`  | `^1.15.0`   | [GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx) — SSRF via header-injection chain | Critical |
| `axios`            | `^1.13.2`  | `^1.15.0`   | [GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5) — `NO_PROXY` bypass → SSRF        | Critical |
| `lodash`           | `^4.17.21` | `^4.17.24`  | [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) — code injection via `_.template` | High     |
| `lodash`           | `^4.17.21` | `^4.17.24`  | [GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh) — prototype pollution in `_.unset`/`_.omit` | Moderate |
| `follow-redirects` | `1.15.11`  | `1.16.0`    | [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) — auth-header leak on redirect    | Moderate |

\`lodash\` was bumped to \`^4.17.24\` (rather than the latest \`^4.18.x\`) as the
minimal-change floor that stays within the existing \`4.17\` caret range — npm
still resolves to the latest 4.x at install time (currently 4.18.1). This
matches the spirit of \`DEPENDENCY-NOTES.md\`, which prefers the smallest
effective bump.

Related: #1611 (the earlier post-3.17.0 transitive-vulnerability sweep, which
was resolved for 3.18.1).

## Test plan

- [x] \`npm install\` regenerates \`npm-shrinkwrap.json\` cleanly
- [x] \`npm audit\` reports **0 vulnerabilities** (previously 1 critical, 1 high, 1 moderate)
- [x] \`npm run check\` passes (3502 tests, lint, prettier)
- [x] \`npm ls axios lodash follow-redirects\` resolves to axios@1.15.0, lodash@4.18.1, follow-redirects@1.16.0
- [x] No source changes required; \`src/\` callers of \`lodash\` (no \`_.template\` usage) and \`axios\` (via \`fhir-package-loader\` and \`src/utils/axiosUtils.ts\`) remain API-compatible