### PR TITLE
Make copyrightYear and releaseLabel optional

### DIFF
--- a/src/import/importConfiguration.ts
+++ b/src/import/importConfiguration.ts
@@ -56,7 +56,7 @@ import { groupBy } from 'lodash';
 // Minimal properties needed for any FSH project
 const MINIMAL_CONFIG_PROPERTIES = ['canonical', 'fhirVersion'];
 // Additional minimal properties needed for an IG-producing project (i.e. FSHOnly === false)
-const MINIMAL_IG_ONLY_PROPERTIES = ['id', 'name', 'status', 'copyrightYear', 'releaseLabel'];
+const MINIMAL_IG_ONLY_PROPERTIES = ['id', 'name', 'status'];
 // Allowed properties for FSH Only projects (all other properties are irrelevant)
 const ALLOWED_FSH_ONLY_PROPERTIES = [
   ...MINIMAL_CONFIG_PROPERTIES,
@@ -102,14 +102,6 @@ export function importConfiguration(yaml: YAMLConfiguration | string, file: stri
     (p: keyof YAMLConfiguration) =>
       yaml[p] == null || (Array.isArray(yaml[p]) && (yaml[p] as any[]).length === 0)
   );
-  // the copyrightYear and releaseLabel properties permit alternate spellings as all lowercase,
-  // so if only those are missing, check for the lowercase version before logging an error.
-  if (missingProperties.includes('copyrightYear') && yaml.copyrightyear) {
-    missingProperties.splice(missingProperties.indexOf('copyrightYear'), 1);
-  }
-  if (missingProperties.includes('releaseLabel') && yaml.releaselabel) {
-    missingProperties.splice(missingProperties.indexOf('releaseLabel'), 1);
-  }
   if (missingProperties.length > 0) {
     logger.error(
       `SUSHI minimally requires the following configuration properties to ${
@@ -740,13 +732,20 @@ function parseParameters(
   file: string
 ): ImplementationGuideDefinitionParameter[] {
   const parameters: ImplementationGuideDefinitionParameter[] = [];
-  // copyrightYear and releaseLabel are only required when generating an IG
-  const copyrightYear = FSHOnly
-    ? (yamlConfig.copyrightYear ?? yamlConfig.copyrightyear)
-    : required(yamlConfig.copyrightYear ?? yamlConfig.copyrightyear, 'copyrightYear', file);
-  const releaseLabel = FSHOnly
-    ? (yamlConfig.releaseLabel ?? yamlConfig.releaselabel)
-    : required(yamlConfig.releaseLabel ?? yamlConfig.releaselabel, 'releaseLabel', file);
+  const copyrightYear = yamlConfig.copyrightYear ?? yamlConfig.copyrightyear;
+  if (!FSHOnly && !copyrightYear) {
+    logger.warn(
+      'The copyrightYear configuration property is not set. Some publishers (e.g., HL7 IG Publisher) require a copyright year.',
+      { file }
+    );
+  }
+  const releaseLabel = yamlConfig.releaseLabel ?? yamlConfig.releaselabel;
+  if (!FSHOnly && !releaseLabel) {
+    logger.warn(
+      'The releaseLabel configuration property is not set. Some publishers (e.g., HL7 IG Publisher) require a release label.',
+      { file }
+    );
+  }
   if (copyrightYear) {
     parameters.push({
       code: 'copyrightyear',

--- a/test/import/importConfiguration.test.ts
+++ b/test/import/importConfiguration.test.ts
@@ -572,7 +572,7 @@ describe('importConfiguration', () => {
         'Minimal config not met'
       );
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status, copyrightYear, releaseLabel\.\s*File: test-config\.yaml/
+        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status\.\s*File: test-config\.yaml/
       );
     });
 
@@ -764,7 +764,7 @@ describe('importConfiguration', () => {
         'Minimal config not met'
       );
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status, copyrightYear, releaseLabel\.\s*File: test-config\.yaml/
+        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status\.\s*File: test-config\.yaml/
       );
     });
   });
@@ -809,7 +809,7 @@ describe('importConfiguration', () => {
         'Minimal config not met'
       );
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status, copyrightYear, releaseLabel\.\s*File: test-config\.yaml/
+        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status\.\s*File: test-config\.yaml/
       );
     });
 
@@ -856,7 +856,7 @@ describe('importConfiguration', () => {
         'Minimal config not met'
       );
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status, copyrightYear, releaseLabel\.\s*File: test-config\.yaml/
+        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status\.\s*File: test-config\.yaml/
       );
     });
 
@@ -1733,7 +1733,7 @@ describe('importConfiguration', () => {
         'Minimal config not met'
       );
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status, copyrightYear, releaseLabel\.\s*File: test-config\.yaml/
+        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status\.\s*File: test-config\.yaml/
       );
     });
     it('should report an error and throw if fhirVersion is an empty array and FSHOnly is false', () => {
@@ -1742,7 +1742,7 @@ describe('importConfiguration', () => {
         'Minimal config not met'
       );
       expect(loggerSpy.getLastMessage('error')).toMatch(
-        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status, copyrightYear, releaseLabel\.\s*File: test-config\.yaml/
+        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status\.\s*File: test-config\.yaml/
       );
     });
   });
@@ -2447,21 +2447,20 @@ describe('importConfiguration', () => {
       config = importConfiguration(minYAML, 'test-config.yaml');
       expect(config.parameters[0]).toEqual({ code: 'copyrightyear', value: '2020' });
     });
-    it('should report an error and throw if copyrightYear/copyrightyear is missing and FSHOnly is false', () => {
+    it('should report a warning (not an error) if copyrightYear/copyrightyear is missing and FSHOnly is false', () => {
       delete minYAML.copyrightYear;
       minYAML.FSHOnly = false;
-      expect(() => importConfiguration(minYAML, 'test-config.yaml')).toThrow(
-        'Minimal config not met'
-      );
-      expect(loggerSpy.getLastMessage('error')).toMatch(
-        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status, copyrightYear, releaseLabel\.\s*File: test-config\.yaml/
-      );
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn').some(m => /copyrightYear/.test(m))).toBe(true);
+      expect(config.parameters?.find(p => p.code === 'copyrightyear')).toBeUndefined();
     });
-    it('should not report an error if copyrightYear/copyrightyear is missing and FSHOnly is true', () => {
+    it('should not report a copyrightYear warning if copyrightYear/copyrightyear is missing and FSHOnly is true', () => {
       delete minYAML.copyrightYear;
       minYAML.FSHOnly = true;
       importConfiguration(minYAML, 'test-config.yaml');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn').some(m => /copyrightYear/.test(m))).toBe(false);
     });
   });
 
@@ -2478,21 +2477,22 @@ describe('importConfiguration', () => {
       const config = importConfiguration(minYAML, 'test-config.yaml');
       expect(config.parameters[1]).toEqual({ code: 'releaselabel', value: 'STU2' });
     });
-    it('should report an error and throw if releaseLabel/releaselabel is missing and FSHOnly is false', () => {
+    it('should report a warning (not an error) if releaseLabel/releaselabel is missing and FSHOnly is false', () => {
       delete minYAML.releaseLabel;
       minYAML.FSHOnly = false;
-      expect(() => importConfiguration(minYAML, 'test-config.yaml')).toThrow(
-        'Minimal config not met'
+      const config = importConfiguration(minYAML, 'test-config.yaml');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /The releaseLabel configuration property is not set\./
       );
-      expect(loggerSpy.getLastMessage('error')).toMatch(
-        /SUSHI minimally requires the following configuration properties to generate an IG: canonical, fhirVersion, id, name, status, copyrightYear, releaseLabel\.\s*File: test-config\.yaml/
-      );
+      expect(config.parameters?.find(p => p.code === 'releaselabel')).toBeUndefined();
     });
-    it('should not report an error if releaseLabel/releaselabel is missing and and FSHOnly is true', () => {
+    it('should not report a releaseLabel warning if releaseLabel/releaselabel is missing and FSHOnly is true', () => {
       delete minYAML.releaseLabel;
       minYAML.FSHOnly = true;
       importConfiguration(minYAML, 'test-config.yaml');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      expect(loggerSpy.getAllMessages('warn').some(m => /releaseLabel/.test(m))).toBe(false);
     });
   });
 


### PR DESCRIPTION
**Description:** Make copyrightYear and releaseLabel configuration properties optional since not all publishing tools required them. Warn when they are missing, however, since the HL7 IG Publisher does require them.

**Testing Instructions:**
1. Create a new test FSH project (e.g., `sushi init TestPR`)
2. Run this branch's SUSHI against the test project (e.g., `ts-node src/app.ts build /path/to/TestPR`) and note that there are no errors or warnings
3. Edit the test project's `sushi-config.yaml` to delete the line that sets `copyrightYear`
4. Run this branch's SUSHI against the test project again and note that there is a warning (but no errors)
5. Edit the test project's `sushi-config.yaml` to delete the line that sets `releaseLabel`
6. Run this branch's SUSHI against the test project again and note that there are now two warnings (but no errors)
7. Add `FSHOnly: true` to the project's `sushi-config.yaml`
8. Run this branch's SUSHI against the test project again and note that there are no warnings or errors

**Related Issue:** #1625
