### PR TITLE
Fix processing of slices on choice elements

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -301,7 +301,12 @@ export class StructureDefinition {
             unfoldedElements = matchingElements[0].unfoldChoiceElementTypes(fisher);
             newMatchingElements = unfoldedElements.filter(e => e.path.startsWith(fhirPathString));
           }
-        } else if (matchingElements[0].id.endsWith('[x]')) {
+        } else if (
+          matchingElements[0].id.endsWith('[x]') ||
+          (matchingElements[0].path.endsWith('[x]') && matchingElements[0].sliceName != null)
+        ) {
+          // The element is a choice element or a slice of a choice element with multiple types.
+          // Find the common ancestor of all types to navigate into sub-paths (e.g., .extension).
           unfoldedElements = matchingElements[0].unfoldChoiceElementTypes(fisher);
           newMatchingElements = unfoldedElements.filter(e => e.path.startsWith(fhirPathString));
         }

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -954,13 +954,17 @@ export class StructureDefinition {
   findObsoleteChoices(baseElement: ElementDefinition, oldTypes: ElementDefinitionType[]): string[] {
     // first, find all the elements representing choices for the same choice element
     const parentSlice = baseElement.parent()?.sliceName;
+    const baseSliceName = baseElement.sliceName;
     const choiceElements = this.elements.filter(e => {
       const eParentSlice = e.parent()?.sliceName;
       return (
         e.path === baseElement.path &&
         (parentSlice == null ||
           parentSlice === eParentSlice ||
-          eParentSlice?.startsWith(`${parentSlice}/`))
+          eParentSlice?.startsWith(`${parentSlice}/`)) &&
+        // When baseElement is itself a named slice, only consider its sub-slices,
+        // not sibling slices at the same level
+        (baseSliceName == null || e.sliceName?.startsWith(`${baseSliceName}/`))
       );
     });
     const matchedThings: ElementDefinition[] = [];

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -5451,6 +5451,7 @@ describe('StructureDefinitionExporter R4', () => {
       // * value[x] ^slicing.rules = #open
       // * value[x] contains valueString 0..1  and valueOther 0..1
       // * value[x][valueString] only string
+      // * value[x][valueOther] only Quantity or CodeableConcept
       // * value[x][valueOther].extension 1..1
       const slicingType = new CaretValueRule('value[x]');
       slicingType.caretPath = 'slicing.discriminator[0].type';
@@ -5471,6 +5472,8 @@ describe('StructureDefinitionExporter R4', () => {
       otherCard.max = '1';
       const stringType = new OnlyRule('value[x][valueString]');
       stringType.types = [{ type: 'string' }];
+      const otherType = new OnlyRule('value[x][valueOther]');
+      otherType.types = [{ type: 'Quantity' }, { type: 'CodeableConcept' }];
       const otherExtensionCard = new CardRule('value[x][valueOther].extension');
       otherExtensionCard.min = 1;
       otherExtensionCard.max = '1';
@@ -5483,6 +5486,7 @@ describe('StructureDefinitionExporter R4', () => {
         stringCard,
         otherCard,
         stringType,
+        otherType,
         otherExtensionCard
       );
 

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -5442,6 +5442,56 @@ describe('StructureDefinitionExporter R4', () => {
       expect(loggerSpy.getAllLogs()).toHaveLength(0);
     });
 
+    it('should not log an error when a rule path has a subpath of a sliced choice element', () => {
+      loggerSpy.reset();
+      const profile = new Profile('ConstrainedObservation');
+      profile.parent = 'Observation';
+      // * value[x] ^slicing.discriminator[0].type = #type
+      // * value[x] ^slicing.discriminator[0].path = "$this"
+      // * value[x] ^slicing.rules = #open
+      // * value[x] contains valueString 0..1  and valueOther 0..1
+      // * value[x][valueString] only string
+      // * value[x][valueOther].extension 1..1
+      const slicingType = new CaretValueRule('value[x]');
+      slicingType.caretPath = 'slicing.discriminator[0].type';
+      slicingType.value = new FshCode('type');
+      const slicingPath = new CaretValueRule('value[x]');
+      slicingPath.caretPath = 'slicing.discriminator[0].path';
+      slicingPath.value = '$this';
+      const slicingRules = new CaretValueRule('value[x]');
+      slicingRules.caretPath = 'slicing.rules';
+      slicingRules.value = new FshCode('open');
+      const valueXSlices = new ContainsRule('value[x]');
+      valueXSlices.items = [{ name: 'valueString' }, { name: 'valueOther' }];
+      const stringCard = new CardRule('value[x][valueString]');
+      stringCard.min = 0;
+      stringCard.max = '1';
+      const otherCard = new CardRule('value[x][valueOther]');
+      otherCard.min = 0;
+      otherCard.max = '1';
+      const stringType = new OnlyRule('value[x][valueString]');
+      stringType.types = [{ type: 'string' }];
+      const otherExtensionCard = new CardRule('value[x][valueOther].extension');
+      otherExtensionCard.min = 1;
+      otherExtensionCard.max = '1';
+
+      profile.rules.push(
+        slicingType,
+        slicingPath,
+        slicingRules,
+        valueXSlices,
+        stringCard,
+        otherCard,
+        stringType,
+        otherExtensionCard
+      );
+
+      exporter.exportStructDef(profile);
+      const sd = pkg.profiles[0];
+      expect(sd).toBeTruthy();
+      expect(loggerSpy.getAllLogs()).toHaveLength(0);
+    });
+
     it('should log an error when extension is constrained with a modifier extension', () => {
       const extension = new Extension('StrangeExtension');
       const modifier = new FlagRule('.');

--- a/test/import/FSHImporter.SDRules.test.ts
+++ b/test/import/FSHImporter.SDRules.test.ts
@@ -1728,6 +1728,25 @@ describe('FSHImporter', () => {
           undefined
         );
       });
+
+      it('should parse contains rule on a choice with two items', () => {
+        const input = leftAlign(`
+        Profile: ObservationProfile
+        Parent: Observation
+        * value[x] contains valueString 0..1 and valueOther 0..1
+        * value[x][valueString] only string
+        * value[x][valueOther].extension 1..1
+        `);
+
+        const result = importSingleText(input);
+        const profile = result.profiles.get('ObservationProfile');
+        expect(profile.rules).toHaveLength(5);
+        assertContainsRule(profile.rules[0], 'value[x]', 'valueString', 'valueOther');
+        assertCardRule(profile.rules[1], 'value[x][valueString]', 0, 1);
+        assertCardRule(profile.rules[2], 'value[x][valueOther]', 0, 1);
+        assertOnlyRule(profile.rules[3], 'value[x][valueString]', { type: 'string' });
+        assertCardRule(profile.rules[4], 'value[x][valueOther].extension', 1, 1);
+      });
     });
 
     describe('#caretValueRule', () => {

--- a/test/import/FSHImporter.SDRules.test.ts
+++ b/test/import/FSHImporter.SDRules.test.ts
@@ -1735,17 +1735,24 @@ describe('FSHImporter', () => {
         Parent: Observation
         * value[x] contains valueString 0..1 and valueOther 0..1
         * value[x][valueString] only string
+        * value[x][valueOther] only Quantity or CodeableConcept
         * value[x][valueOther].extension 1..1
         `);
 
         const result = importSingleText(input);
         const profile = result.profiles.get('ObservationProfile');
-        expect(profile.rules).toHaveLength(5);
+        expect(profile.rules).toHaveLength(6);
         assertContainsRule(profile.rules[0], 'value[x]', 'valueString', 'valueOther');
         assertCardRule(profile.rules[1], 'value[x][valueString]', 0, 1);
         assertCardRule(profile.rules[2], 'value[x][valueOther]', 0, 1);
         assertOnlyRule(profile.rules[3], 'value[x][valueString]', { type: 'string' });
-        assertCardRule(profile.rules[4], 'value[x][valueOther].extension', 1, 1);
+        assertOnlyRule(
+          profile.rules[4],
+          'value[x][valueOther]',
+          { type: 'Quantity' },
+          { type: 'CodeableConcept' }
+        );
+        assertCardRule(profile.rules[5], 'value[x][valueOther].extension', 1, 1);
       });
     });
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,9 @@
 {
-  "extends": "../tsconfig",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "noEmit": true,
+    "types": ["jest", "node"]
   },
   "include": [
     "./**/*.ts"


### PR DESCRIPTION
**Description:** When manually creating slices on choice elements (e.g., `Observation.value[x]`), SUSHI runs into a few issues:

1. If you constrain a slice by type (using `only`) and then constrain another by type (also using `only`), in some cases SUSHI emits an error like this: _Type constraint on Observation.value[x] makes rules in ObservationWithValueAttachment obsolete for choices: valueString_.
2. If you attempt to traverse into a sub-element of a slice, in some cases SUSHI emits an error like this: _No element found at path value[x][valueAttachment].extension for ContainsRule in ObservationWithValueAttachment, skipping rule_. (NOTE: error depends on type of rule applied to the path).

These issues were discovered and discussed on Zulip: [#shorthand > Slicing and extending with a xver extension @ 💬](https://chat.fhir.org/#narrow/channel/215610-shorthand/topic/Slicing.20and.20extending.20with.20a.20xver.20extension/near/604137635).

This PR resolves both issues by improving handling for the special case of slices on choice elements.

**Testing Instructions:** The unit tests show the issue, but you may also test manually using this [XVerObsValueAttachment.zip](https://github.com/user-attachments/files/29293911/XVerObsValueAttachment.zip) project based on the Zulip thread use case. First run the release version of SUSHI to confirm the errors are being logged. Then run this PR branch (using `ts-node`) to confirm the errors go away and the resulting StructureDefinition looks correct.

**Related Issue:** See https://chat.fhir.org/#narrow/channel/215610-shorthand/topic/Slicing.20and.20extending.20with.20a.20xver.20extension/near/604137635.
