### PR TITLE
Cache type lookups in MasterFisher

### DIFF
--- a/src/utils/MasterFisher.ts
+++ b/src/utils/MasterFisher.ts
@@ -20,6 +20,7 @@ import { Instance } from '../fshtypes';
  */
 export class MasterFisher implements Fishable {
   public defaultFHIRVersion?: string;
+  private typeCache: Map<string, any> = new Map();
   constructor(
     public tank?: FSHTank,
     public fhir?: FHIRDefinitions,
@@ -39,8 +40,19 @@ export class MasterFisher implements Fishable {
     // Resolve the alias if necessary
     item = this.tank?.resolveAlias(item) ?? item;
 
+    // Only the FHIR definitions support Type.Type, and they don't change while fishing, so cache it
+    const cacheKey = types.length === 1 && types[0] === Type.Type ? item : null;
+    if (cacheKey != null && this.typeCache.has(cacheKey)) {
+      return this.typeCache.get(cacheKey);
+    }
+
     let result = this.fhir.fishForPredefinedResource(item, ...types);
-    if (result != null) return result;
+    if (result != null) {
+      if (cacheKey != null) {
+        this.typeCache.set(cacheKey, result);
+      }
+      return result;
+    }
 
     // First check for it in the package
     result = this.pkg?.fishForFHIR(item, ...types);
@@ -52,6 +64,9 @@ export class MasterFisher implements Fishable {
         return;
       }
       result = this.fhir?.fishForFHIR(item, ...types);
+    }
+    if (cacheKey != null) {
+      this.typeCache.set(cacheKey, result);
     }
     return result;
   }

--- a/test/utils/MasterFisher.test.ts
+++ b/test/utils/MasterFisher.test.ts
@@ -8,7 +8,7 @@ import { minimalConfig } from './minimalConfig';
 import { cloneDeep } from 'lodash';
 import { getTestFHIRDefinitions, testDefsPath, TestFHIRDefinitions } from '../testhelpers';
 import { PREDEFINED_PACKAGE_NAME, PREDEFINED_PACKAGE_VERSION } from '../../src/ig';
-import { Metadata } from '../../src/utils';
+import { Metadata, Type } from '../../src/utils';
 
 describe('MasterFisher', () => {
   let fisher: MasterFisher;
@@ -408,6 +408,39 @@ describe('MasterFisher', () => {
     const resultMDs = fisher.fishForMetadatas('FHIRPatient');
     expect(resultMDs).toHaveLength(1);
     expect(resultMDs[0].id).toBe('Patient');
+  });
+
+  describe('type caching', () => {
+    let fhirSpy: jest.SpyInstance;
+    let typeFisher: MasterFisher;
+
+    beforeAll(() => {
+      fhirSpy = jest.spyOn(defs, 'fishForFHIR');
+    });
+
+    beforeEach(() => {
+      // the MasterFisher constructor fishes for StructureDefinition, so clear the spy after it
+      typeFisher = new MasterFisher(undefined, defs, undefined);
+      fhirSpy.mockClear();
+    });
+
+    afterAll(() => {
+      fhirSpy.mockRestore();
+    });
+
+    it('should only look up a type once when fishing for it repeatedly with only Type.Type', () => {
+      const first = typeFisher.fishForFHIR('string', Type.Type);
+      const second = typeFisher.fishForFHIR('string', Type.Type);
+      expect(first.id).toBe('string');
+      expect(second).toBe(first);
+      expect(fhirSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not cache results when fishing for types other than Type.Type', () => {
+      typeFisher.fishForFHIR('Patient', Type.Resource);
+      typeFisher.fishForFHIR('Patient', Type.Resource);
+      expect(fhirSpy).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('should return undefined or empty list when fishing for something that is not in any locations', () => {


### PR DESCRIPTION
### Problem

`MasterFisher.fishForFHIR` is called with only `Type.Type` from some very hot paths. The biggest one is `ElementDefinition.isPrimitive`, which runs for every child element of every instance being validated and fishes the type's StructureDefinition just to read its `kind`. The same handful of type codes (`string`, `code`, `uri`, ...) end up being looked up thousands of times per run, and each lookup is a query against the package database plus a possible read of the resource JSON from disk.

In a CPU profile of a build of [HL7/fhir-mCODE-ig](https://github.com/HL7/fhir-mCODE-ig), `isPrimitive` accounted for 36% of the total run time and package database lookups for 47%.

### Change

Cache `fishForFHIR` results when the only requested type is `Type.Type`. That case can only ever be answered by the FHIR definitions — `Package.internalFish` has an explicit "Package doesn't currently support types" branch and `FSHTank.internalFish` skips the type as well — and the definitions don't change while fishing, so the answer is stable for the life of the fisher. Everything else is fished exactly as before, so results that can change as the package fills up are not cached.

### Effect

Best of five runs with a warm package cache, node 24:

| IG | before | after |
| --- | --- | --- |
| HL7/fhir-mCODE-ig | 17.4s | 11.3s |
| HL7/fhir-sdoh-clinicalcare | 19.6s | 14.6s |

For both IGs the generated `fsh-generated` tree is byte-identical to the one produced without this change.

### Tests

Two tests in `MasterFisher.test.ts`: repeated `Type.Type` fishing reaches the FHIR definitions only once, and fishing for other types is still not cached.
