### PR TITLE
Don't block the build on the SUSHI version check

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -192,19 +192,20 @@ async function runBuild(input: string, program: OptionValues, helpText: string) 
   }
   logger.info(`  ${path.resolve(input || '.')}`);
 
-  const sushiVersions = await checkSushiVersion();
-  if (
-    program.requireLatest &&
-    (sushiVersions.latest == null || sushiVersions.latest !== sushiVersions.current)
-  ) {
-    logger.error(
-      `Current SUSHI version (${
-        sushiVersions.current
-      }) is not the latest version. Upgrade to the latest version (${
-        sushiVersions.latest ?? 'undetermined'
-      }) or run SUSHI again without the --require-latest flag.`
-    );
-    process.exit(1);
+  // The version check hits the network, so only wait on it where the result is needed
+  const sushiVersionsPromise = checkSushiVersion();
+  if (program.requireLatest) {
+    const sushiVersions = await sushiVersionsPromise;
+    if (sushiVersions.latest == null || sushiVersions.latest !== sushiVersions.current) {
+      logger.error(
+        `Current SUSHI version (${
+          sushiVersions.current
+        }) is not the latest version. Upgrade to the latest version (${
+          sushiVersions.latest ?? 'undetermined'
+        }) or run SUSHI again without the --require-latest flag.`
+      );
+      process.exit(1);
+    }
   }
 
   input = ensureInputDir(input);
@@ -338,7 +339,7 @@ async function runBuild(input: string, program: OptionValues, helpText: string) 
   }
 
   console.log();
-  printResults(outPackage, sushiVersions);
+  printResults(outPackage, await sushiVersionsPromise);
 
   console.log();
 


### PR DESCRIPTION
### Problem

`checkSushiVersion()` is awaited before any FSH is read. It shells out to `npm view fsh-sushi version` (with an HTTP request to the npm registry as a fallback), which takes about half a second here and can take up to the full 5 second timeout on a slow or offline network. Nothing in the build needs the result until the results box is printed at the end.

### Change

Start the version check without awaiting it, then await it where it is used. `--require-latest` still awaits it up front so that it can fail before doing any work; everything else overlaps the check with the build.

No change to the output or to any of the messages.
