### PR TITLE
Improve performance with large CodeSystems

### DIFF
--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -293,13 +293,17 @@ export class CodeSystemExporter {
   }
 
   /**
-   * Finds the FSH path to the concept identified by codePath, e.g. ['#a', '#b'] becomes concept[2].concept[0].
+   * Finds the FSH path to the concept identified by codePath. For example, if #a is the third top-level
+   * concept and #b is its first child, ['#a', '#b'] becomes concept[2].concept[0]. An empty codePath
+   * (a caret rule that is not on a concept) returns an empty path.
    * @param {CodeSystem} codeSystem - The CodeSystem containing the concepts
    * @param {string[]} codePath - The codes (with a leading #) leading to the concept
-   * @param {Map<CodeSystemConcept[], Map<string, number>>} conceptIndices - Cache of the index of each code in
-   *   each concept list. Every code caret rule needs one of these lookups, so the concept lists are indexed once
-   *   rather than scanned for each rule.
+   * @param {Map<CodeSystemConcept[], Map<string, number>>} conceptIndices - Cache of the index of the first
+   *   concept with each code in each concept list. Every code caret rule needs one of these lookups, so the
+   *   concept lists are indexed once rather than scanned for each rule. The cache is only valid while the
+   *   concept lists are not modified, so callers should use a new Map for each set of rules they resolve.
    * @returns {string} the path to the concept
+   * @throws {CannotResolvePathError} when a code in codePath is not found
    */
   private findConceptPath(
     codeSystem: CodeSystem,

--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -98,11 +98,13 @@ export class CodeSystemExporter {
               return;
             }
           }
-          conceptContainer.push(newConcept);
-          if (!conceptsByCode.has(conceptContainer)) {
-            conceptsByCode.set(conceptContainer, new Map());
+          let siblingsByCode = conceptsByCode.get(conceptContainer);
+          if (siblingsByCode == null) {
+            siblingsByCode = new Map();
+            conceptsByCode.set(conceptContainer, siblingsByCode);
           }
-          conceptsByCode.get(conceptContainer).set(newConcept.code, newConcept);
+          conceptContainer.push(newConcept);
+          siblingsByCode.set(newConcept.code, newConcept);
           existingConcepts.set(concept.code, concept);
         }
       });
@@ -120,10 +122,10 @@ export class CodeSystemExporter {
     // Because this.findConceptPath can potentially throw an error,
     // build a list of successful rules that will actually be applied.
     const successfulRules: CaretValueRule[] = [];
-    const conceptIndices = new Map<CodeSystemConcept[], Map<string, number>>();
+    const conceptIndexCache = new Map<CodeSystemConcept[], Map<string, number>>();
     rules.forEach(rule => {
       try {
-        rule.path = this.findConceptPath(codeSystem, rule.pathArray, conceptIndices);
+        rule.path = this.findConceptPath(codeSystem, rule.pathArray, conceptIndexCache);
         successfulRules.push(rule);
         if (rule.path) {
           rule.isCodeCaretRule = true;
@@ -298,9 +300,9 @@ export class CodeSystemExporter {
    * (a caret rule that is not on a concept) returns an empty path.
    * @param {CodeSystem} codeSystem - The CodeSystem containing the concepts
    * @param {string[]} codePath - The codes (with a leading #) leading to the concept
-   * @param {Map<CodeSystemConcept[], Map<string, number>>} conceptIndices - Cache of the index of the first
-   *   concept with each code in each concept list. Every code caret rule needs one of these lookups, so the
-   *   concept lists are indexed once rather than scanned for each rule. The cache is only valid while the
+   * @param {Map<CodeSystemConcept[], Map<string, number>>} conceptIndexCache - Cache of the index of the
+   *   first concept with each code in each concept list. Every code caret rule needs one of these lookups, so
+   *   the concept lists are indexed once rather than scanned for each rule. The cache is only valid while the
    *   concept lists are not modified, so callers should use a new Map for each set of rules they resolve.
    * @returns {string} the path to the concept
    * @throws {CannotResolvePathError} when a code in codePath is not found
@@ -308,30 +310,31 @@ export class CodeSystemExporter {
   private findConceptPath(
     codeSystem: CodeSystem,
     codePath: string[],
-    conceptIndices: Map<CodeSystemConcept[], Map<string, number>>
+    conceptIndexCache: Map<CodeSystemConcept[], Map<string, number>>
   ): string {
-    const pathIndices: number[] = [];
+    const conceptIndices: number[] = [];
     let conceptList = codeSystem.concept ?? [];
     for (const codeStep of codePath) {
-      let indexByCode = conceptIndices.get(conceptList);
+      let indexByCode = conceptIndexCache.get(conceptList);
       if (indexByCode == null) {
         indexByCode = new Map();
+        // the first concept with a given code wins, matching the findIndex this replaced
         conceptList.forEach((concept, i) => {
           const key = `#${concept.code}`;
           if (!indexByCode.has(key)) {
             indexByCode.set(key, i);
           }
         });
-        conceptIndices.set(conceptList, indexByCode);
+        conceptIndexCache.set(conceptList, indexByCode);
       }
       const stepIndex = indexByCode.get(codeStep);
       if (stepIndex == null) {
         throw new CannotResolvePathError(codePath.join(' '));
       }
-      pathIndices.push(stepIndex);
+      conceptIndices.push(stepIndex);
       conceptList = conceptList[stepIndex].concept ?? [];
     }
-    return pathIndices.map(conceptIndex => `concept[${conceptIndex}]`).join('.');
+    return conceptIndices.map(conceptIndex => `concept[${conceptIndex}]`).join('.');
   }
 
   private countConcepts(concepts: CodeSystemConcept[]): number {

--- a/src/export/CodeSystemExporter.ts
+++ b/src/export/CodeSystemExporter.ts
@@ -53,6 +53,8 @@ export class CodeSystemExporter {
     if (concepts.length > 0) {
       codeSystem.concept = [];
       const existingConcepts = new Map<string, ConceptRule>();
+      // each list of concepts is indexed by code so that finding an ancestor does not require scanning the list
+      const conceptsByCode = new Map<CodeSystemConcept[], Map<string, CodeSystemConcept>>();
       concepts.forEach(concept => {
         const existingConcept = existingConcepts.get(concept.code);
         if (existingConcept) {
@@ -82,9 +84,7 @@ export class CodeSystemExporter {
             newConcept.definition = concept.definition;
           }
           for (const ancestorCode of concept.hierarchy) {
-            const ancestorConcept = conceptContainer.find(
-              ancestorConcept => ancestorConcept.code === ancestorCode
-            );
+            const ancestorConcept = conceptsByCode.get(conceptContainer)?.get(ancestorCode);
             if (ancestorConcept) {
               if (!ancestorConcept.concept) {
                 ancestorConcept.concept = [];
@@ -99,6 +99,10 @@ export class CodeSystemExporter {
             }
           }
           conceptContainer.push(newConcept);
+          if (!conceptsByCode.has(conceptContainer)) {
+            conceptsByCode.set(conceptContainer, new Map());
+          }
+          conceptsByCode.get(conceptContainer).set(newConcept.code, newConcept);
           existingConcepts.set(concept.code, concept);
         }
       });
@@ -116,9 +120,10 @@ export class CodeSystemExporter {
     // Because this.findConceptPath can potentially throw an error,
     // build a list of successful rules that will actually be applied.
     const successfulRules: CaretValueRule[] = [];
+    const conceptIndices = new Map<CodeSystemConcept[], Map<string, number>>();
     rules.forEach(rule => {
       try {
-        rule.path = this.findConceptPath(codeSystem, rule.pathArray);
+        rule.path = this.findConceptPath(codeSystem, rule.pathArray, conceptIndices);
         successfulRules.push(rule);
         if (rule.path) {
           rule.isCodeCaretRule = true;
@@ -275,7 +280,8 @@ export class CodeSystemExporter {
           rule.path.length > 1 ? `${rule.path}.${rule.caretPath}` : rule.caretPath,
           rule.value,
           this.fisher,
-          inlineResourceTypes
+          inlineResourceTypes,
+          codeSystemSD
         );
       } catch (err) {
         logger.error(err.message, rule.sourceInfo);
@@ -286,18 +292,42 @@ export class CodeSystemExporter {
     }
   }
 
-  private findConceptPath(codeSystem: CodeSystem, codePath: string[]): string {
-    const conceptIndices: number[] = [];
+  /**
+   * Finds the FSH path to the concept identified by codePath, e.g. ['#a', '#b'] becomes concept[2].concept[0].
+   * @param {CodeSystem} codeSystem - The CodeSystem containing the concepts
+   * @param {string[]} codePath - The codes (with a leading #) leading to the concept
+   * @param {Map<CodeSystemConcept[], Map<string, number>>} conceptIndices - Cache of the index of each code in
+   *   each concept list. Every code caret rule needs one of these lookups, so the concept lists are indexed once
+   *   rather than scanned for each rule.
+   * @returns {string} the path to the concept
+   */
+  private findConceptPath(
+    codeSystem: CodeSystem,
+    codePath: string[],
+    conceptIndices: Map<CodeSystemConcept[], Map<string, number>>
+  ): string {
+    const pathIndices: number[] = [];
     let conceptList = codeSystem.concept ?? [];
     for (const codeStep of codePath) {
-      const stepIndex = conceptList.findIndex(concept => `#${concept.code}` === codeStep);
-      if (stepIndex === -1) {
+      let indexByCode = conceptIndices.get(conceptList);
+      if (indexByCode == null) {
+        indexByCode = new Map();
+        conceptList.forEach((concept, i) => {
+          const key = `#${concept.code}`;
+          if (!indexByCode.has(key)) {
+            indexByCode.set(key, i);
+          }
+        });
+        conceptIndices.set(conceptList, indexByCode);
+      }
+      const stepIndex = indexByCode.get(codeStep);
+      if (stepIndex == null) {
         throw new CannotResolvePathError(codePath.join(' '));
       }
-      conceptIndices.push(stepIndex);
+      pathIndices.push(stepIndex);
       conceptList = conceptList[stepIndex].concept ?? [];
     }
-    return conceptIndices.map(conceptIndex => `concept[${conceptIndex}]`).join('.');
+    return pathIndices.map(conceptIndex => `concept[${conceptIndex}]`).join('.');
   }
 
   private countConcepts(concepts: CodeSystemConcept[]): number {

--- a/src/export/ValueSetExporter.ts
+++ b/src/export/ValueSetExporter.ts
@@ -427,7 +427,8 @@ export class ValueSetExporter {
           rule.caretPath,
           rule.value,
           this.fisher,
-          inlineResourceTypes
+          inlineResourceTypes,
+          valueSetSD
         );
       } catch (err) {
         logger.error(err.message, rule.sourceInfo);
@@ -539,7 +540,7 @@ export class ValueSetExporter {
     );
 
     for (const [path, { rule }] of ruleMap) {
-      setPropertyOnDefinitionInstance(vs, path, rule.value, this.fisher);
+      setPropertyOnDefinitionInstance(vs, path, rule.value, this.fisher, [], valueSetSD);
     }
   }
 

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -96,7 +96,8 @@ export function splitOnPathPeriods(path: string): string[] {
  * @param {Fishable} fisher - A fishable implementation for finding definitions and metadata
  * @param {string[]} inlineResourceTypes - Types that will be used to replace Resource elements
  * @param {StructureDefinition} instanceSD - The instance's own StructureDefinition, if the caller already has it.
- *   Building it is expensive, so callers applying many rules to one instance should pass it in.
+ *   CodeSystem and ValueSet rebuild theirs from JSON on every call to getOwnStructureDefinition, so callers
+ *   applying many rules to one such instance should pass it in.
  */
 export function setPropertyOnDefinitionInstance(
   instance: StructureDefinition | ElementDefinition | CodeSystem | ValueSet,
@@ -691,7 +692,7 @@ export function setPropertyOnInstance(
             index = sliceIndices[index];
           }
         }
-        // If the index doesn't exist in the array, add it and lesser indices
+        // If the index already exists but is empty, fill it in. Otherwise, add it and lesser indices.
         // Empty elements should be null, not undefined, according to https://www.hl7.org/fhir/json.html#primitive
         if (index < current[key].length) {
           if (current[key][index] == null) {
@@ -704,7 +705,7 @@ export function setPropertyOnInstance(
             }
           }
         } else {
-          // Start from the end of the array rather than 0 so that filling in a large array is not quadratic
+          // Only add the missing elements. Iterating from 0 on every call made filling a large array quadratic.
           for (let j = current[key].length; j <= index; j++) {
             if (sliceName) {
               // _sliceName is used to later differentiate which slice an element represents

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -692,20 +692,10 @@ export function setPropertyOnInstance(
             index = sliceIndices[index];
           }
         }
-        // If the index already exists but is empty, fill it in. Otherwise, add it and lesser indices.
-        // Empty elements should be null, not undefined, according to https://www.hl7.org/fhir/json.html#primitive
-        if (index < current[key].length) {
-          if (current[key][index] == null) {
-            if (pathPart.primitive) {
-              // a value may already exist on one of the arrays, so only assign an empty object if it is nullish
-              current[pathPart.base][index] ??= {};
-              current[`_${pathPart.base}`][index] ??= {};
-            } else {
-              current[key][index] = {};
-            }
-          }
-        } else {
-          // Only add the missing elements. Iterating from 0 on every call made filling a large array quadratic.
+        if (index >= current[key].length) {
+          // Add only the missing elements: iterating from 0 on every call made filling a large array
+          // quadratic. Empty elements should be null, not undefined, according to
+          // https://www.hl7.org/fhir/json.html#primitive
           for (let j = current[key].length; j <= index; j++) {
             if (sliceName) {
               // _sliceName is used to later differentiate which slice an element represents
@@ -730,6 +720,15 @@ export function setPropertyOnInstance(
                 current[key].push(null);
               }
             }
+          }
+        } else if (current[key][index] == null) {
+          // the index exists but is empty, so fill it in
+          if (pathPart.primitive) {
+            // a value may already exist on one of the arrays, so only assign an empty object if it is nullish
+            current[pathPart.base][index] ??= {};
+            current[`_${pathPart.base}`][index] ??= {};
+          } else {
+            current[key][index] = {};
           }
         }
         // If it isn't the last element, move on, if it is, set the value

--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -94,15 +94,18 @@ export function splitOnPathPeriods(path: string): string[] {
  * @param {string} path - The path to assign a value at
  * @param {any} value - The value to assign
  * @param {Fishable} fisher - A fishable implementation for finding definitions and metadata
+ * @param {string[]} inlineResourceTypes - Types that will be used to replace Resource elements
+ * @param {StructureDefinition} instanceSD - The instance's own StructureDefinition, if the caller already has it.
+ *   Building it is expensive, so callers applying many rules to one instance should pass it in.
  */
 export function setPropertyOnDefinitionInstance(
   instance: StructureDefinition | ElementDefinition | CodeSystem | ValueSet,
   path: string,
   value: any,
   fisher: Fishable,
-  inlineResourceTypes: string[] = []
+  inlineResourceTypes: string[] = [],
+  instanceSD: StructureDefinition = instance.getOwnStructureDefinition(fisher)
 ): void {
-  const instanceSD = instance.getOwnStructureDefinition(fisher);
   const { assignedValue, pathParts } = instanceSD.validateValueAtPath(
     path,
     value,
@@ -690,8 +693,8 @@ export function setPropertyOnInstance(
         }
         // If the index doesn't exist in the array, add it and lesser indices
         // Empty elements should be null, not undefined, according to https://www.hl7.org/fhir/json.html#primitive
-        for (let j = 0; j <= index; j++) {
-          if (j < current[key].length && j === index && current[key][index] == null) {
+        if (index < current[key].length) {
+          if (current[key][index] == null) {
             if (pathPart.primitive) {
               // a value may already exist on one of the arrays, so only assign an empty object if it is nullish
               current[pathPart.base][index] ??= {};
@@ -699,7 +702,10 @@ export function setPropertyOnInstance(
             } else {
               current[key][index] = {};
             }
-          } else if (j >= current[key].length) {
+          }
+        } else {
+          // Start from the end of the array rather than 0 so that filling in a large array is not quadratic
+          for (let j = current[key].length; j <= index; j++) {
             if (sliceName) {
               // _sliceName is used to later differentiate which slice an element represents
               if (pathPart.primitive) {

--- a/src/fshtypes/common.ts
+++ b/src/fshtypes/common.ts
@@ -8,7 +8,7 @@ import { Mapping } from './Mapping';
 import { Profile } from './Profile';
 import { Resource } from './Resource';
 import { RuleSet } from './RuleSet';
-import { CaretValueRule, OnlyRuleType, AssignmentRule } from './rules';
+import { CaretValueRule, OnlyRuleType, AssignmentRule, Rule } from './rules';
 import { findLast } from 'lodash';
 
 export function typeString(types: OnlyRuleType[]): string {
@@ -52,6 +52,16 @@ export function fshifyString(input: string): string {
     .replace(/\t/g, '\\t');
 }
 
+// Looking up an id, url, name, or version scans every rule on the definition, and the FSHTank does this for
+// every entity on every fish. For definitions with many rules (e.g., large code systems) that scan dominates
+// the build, so the result of each lookup is cached against the definition's rules array. The cache is keyed
+// on the array itself and checked against the array's length and last rule, so it is invalidated when rules
+// are added or removed and when the array is replaced (as applyInsertRules does).
+const assignmentCache = new WeakMap<
+  Rule[],
+  { length: number; lastRule: Rule; found: Map<string, AssignmentRule | CaretValueRule> }
+>();
+
 export function findAssignmentByPath(
   fshDefinition:
     | Profile
@@ -67,20 +77,43 @@ export function findAssignmentByPath(
   caretRulePath: string,
   caretRuleCaretPath: string
 ) {
-  if (fshDefinition instanceof Instance || fshDefinition instanceof Invariant) {
-    return findLast(
-      fshDefinition.rules,
-      rule => rule instanceof AssignmentRule && rule.path === assignmentRulePath
-    ) as AssignmentRule;
-  } else {
-    return findLast(
-      fshDefinition.rules,
-      rule =>
-        rule instanceof CaretValueRule &&
-        rule.path === caretRulePath &&
-        rule.caretPath === caretRuleCaretPath
-    ) as CaretValueRule;
+  const rules: Rule[] = fshDefinition.rules;
+  let cache = assignmentCache.get(rules);
+  if (
+    cache == null ||
+    cache.length !== rules.length ||
+    cache.lastRule !== rules[rules.length - 1]
+  ) {
+    cache = { length: rules.length, lastRule: rules[rules.length - 1], found: new Map() };
+    assignmentCache.set(rules, cache);
   }
+  const isInstanceRule = fshDefinition instanceof Instance || fshDefinition instanceof Invariant;
+  const key = isInstanceRule
+    ? `assignment|${assignmentRulePath}`
+    : `caret|${caretRulePath}|${caretRuleCaretPath}`;
+  if (!cache.found.has(key)) {
+    if (isInstanceRule) {
+      cache.found.set(
+        key,
+        findLast(
+          rules,
+          rule => rule instanceof AssignmentRule && rule.path === assignmentRulePath
+        ) as AssignmentRule
+      );
+    } else {
+      cache.found.set(
+        key,
+        findLast(
+          rules,
+          rule =>
+            rule instanceof CaretValueRule &&
+            rule.path === caretRulePath &&
+            rule.caretPath === caretRuleCaretPath
+        ) as CaretValueRule
+      );
+    }
+  }
+  return cache.found.get(key);
 }
 
 /**

--- a/src/fshtypes/common.ts
+++ b/src/fshtypes/common.ts
@@ -61,10 +61,12 @@ export function fshifyString(input: string): string {
 // against the lookup in case its path was changed in place (as CodeSystemExporter does to code caret rules).
 // Replacing a rule in the middle of the array, or changing a rule so that it newly matches a lookup, would
 // not be seen; no code does either.
-const assignmentCache = new WeakMap<
-  Rule[],
-  { length: number; lastRule: Rule; found: Map<string, AssignmentRule | CaretValueRule> }
->();
+type RuleLookupCache = {
+  length: number;
+  lastRule: Rule;
+  rulesByLookup: Map<string, AssignmentRule | CaretValueRule>;
+};
+const ruleLookupCache = new WeakMap<Rule[], RuleLookupCache>();
 
 export function findAssignmentByPath(
   fshDefinition:
@@ -82,14 +84,11 @@ export function findAssignmentByPath(
   caretRuleCaretPath: string
 ) {
   const rules: Rule[] = fshDefinition.rules;
-  let cache = assignmentCache.get(rules);
-  if (
-    cache == null ||
-    cache.length !== rules.length ||
-    cache.lastRule !== rules[rules.length - 1]
-  ) {
-    cache = { length: rules.length, lastRule: rules[rules.length - 1], found: new Map() };
-    assignmentCache.set(rules, cache);
+  const lastRule = rules[rules.length - 1];
+  let cache = ruleLookupCache.get(rules);
+  if (cache == null || cache.length !== rules.length || cache.lastRule !== lastRule) {
+    cache = { length: rules.length, lastRule, rulesByLookup: new Map() };
+    ruleLookupCache.set(rules, cache);
   }
   let key: string;
   let matches: (rule: Rule) => boolean;
@@ -103,12 +102,14 @@ export function findAssignmentByPath(
       rule.path === caretRulePath &&
       rule.caretPath === caretRuleCaretPath;
   }
-  let found = cache.found.get(key);
-  if (!cache.found.has(key) || (found != null && !matches(found))) {
-    found = findLast(rules, matches) as AssignmentRule | CaretValueRule;
-    cache.found.set(key, found);
+  const cachedRule = cache.rulesByLookup.get(key);
+  // a cached rule is re-checked in case its path changed in place; a cached miss is trusted as-is
+  if (cache.rulesByLookup.has(key) && (cachedRule == null || matches(cachedRule))) {
+    return cachedRule;
   }
-  return found;
+  const foundRule = findLast(rules, matches) as AssignmentRule | CaretValueRule;
+  cache.rulesByLookup.set(key, foundRule);
+  return foundRule;
 }
 
 /**

--- a/src/fshtypes/common.ts
+++ b/src/fshtypes/common.ts
@@ -52,11 +52,15 @@ export function fshifyString(input: string): string {
     .replace(/\t/g, '\\t');
 }
 
-// Looking up an id, url, name, or version scans every rule on the definition, and the FSHTank does this for
-// every entity on every fish. For definitions with many rules (e.g., large code systems) that scan dominates
-// the build, so the result of each lookup is cached against the definition's rules array. The cache is keyed
-// on the array itself and checked against the array's length and last rule, so it is invalidated when rules
-// are added or removed and when the array is replaced (as applyInsertRules does).
+// Looking up a rule by path (e.g., a definition's id, url, name, or version) scans every rule on the
+// definition, and the FSHTank does this for every entity it checks on every fish. For definitions with many
+// rules (e.g., large code systems) that scan dominated the build, so the rule found by each lookup is cached
+// against the definition's rules array. Rules arrays are only appended to or replaced wholesale (as
+// applyInsertRules does), so the cache is checked against the array's length and last rule. The rule rather
+// than its value is cached, so a change to the rule's value is still seen, and a cached rule is re-checked
+// against the lookup in case its path was changed in place (as CodeSystemExporter does to code caret rules).
+// Replacing a rule in the middle of the array, or changing a rule so that it newly matches a lookup, would
+// not be seen; no code does either.
 const assignmentCache = new WeakMap<
   Rule[],
   { length: number; lastRule: Rule; found: Map<string, AssignmentRule | CaretValueRule> }
@@ -87,33 +91,24 @@ export function findAssignmentByPath(
     cache = { length: rules.length, lastRule: rules[rules.length - 1], found: new Map() };
     assignmentCache.set(rules, cache);
   }
-  const isInstanceRule = fshDefinition instanceof Instance || fshDefinition instanceof Invariant;
-  const key = isInstanceRule
-    ? `assignment|${assignmentRulePath}`
-    : `caret|${caretRulePath}|${caretRuleCaretPath}`;
-  if (!cache.found.has(key)) {
-    if (isInstanceRule) {
-      cache.found.set(
-        key,
-        findLast(
-          rules,
-          rule => rule instanceof AssignmentRule && rule.path === assignmentRulePath
-        ) as AssignmentRule
-      );
-    } else {
-      cache.found.set(
-        key,
-        findLast(
-          rules,
-          rule =>
-            rule instanceof CaretValueRule &&
-            rule.path === caretRulePath &&
-            rule.caretPath === caretRuleCaretPath
-        ) as CaretValueRule
-      );
-    }
+  let key: string;
+  let matches: (rule: Rule) => boolean;
+  if (fshDefinition instanceof Instance || fshDefinition instanceof Invariant) {
+    key = `assignment|${assignmentRulePath}`;
+    matches = rule => rule instanceof AssignmentRule && rule.path === assignmentRulePath;
+  } else {
+    key = `caret|${caretRulePath}|${caretRuleCaretPath}`;
+    matches = rule =>
+      rule instanceof CaretValueRule &&
+      rule.path === caretRulePath &&
+      rule.caretPath === caretRuleCaretPath;
   }
-  return cache.found.get(key);
+  let found = cache.found.get(key);
+  if (!cache.found.has(key) || (found != null && !matches(found))) {
+    found = findLast(rules, matches) as AssignmentRule | CaretValueRule;
+    cache.found.set(key, found);
+  }
+  return found;
 }
 
 /**

--- a/test/export/CodeSystemExporter.test.ts
+++ b/test/export/CodeSystemExporter.test.ts
@@ -1211,6 +1211,87 @@ describe('CodeSystemExporter', () => {
     });
   });
 
+  it('should apply several caret rules to the same extension slice and to a numerically indexed extension', () => {
+    // CodeSystem: ExtensionSystem
+    // * ^extension[structuredefinition-fmm].valueInteger = 1
+    // * ^extension[structuredefinition-fmm].id = "fmm"
+    // * ^extension[1].url = "http://example.org/StructureDefinition/plain"
+    // * ^extension[1].valueString = "plain"
+    // * #bar "Bar"
+    // * #bar ^extension[structuredefinition-fmm].valueInteger = 2
+    // * #bar ^extension[structuredefinition-fmm].id = "concept-fmm"
+    // * #bar ^extension[1].url = "http://example.org/StructureDefinition/plain"
+    // * #bar ^extension[1].valueString = "concept plain"
+    const codeSystem = new FshCodeSystem('ExtensionSystem');
+    const fmmRule = new CaretValueRule('');
+    fmmRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
+    fmmRule.value = 1;
+    const fmmIdRule = new CaretValueRule('');
+    fmmIdRule.caretPath = 'extension[structuredefinition-fmm].id';
+    fmmIdRule.value = 'fmm';
+    const plainUrlRule = new CaretValueRule('');
+    plainUrlRule.caretPath = 'extension[1].url';
+    plainUrlRule.value = 'http://example.org/StructureDefinition/plain';
+    const plainValueRule = new CaretValueRule('');
+    plainValueRule.caretPath = 'extension[1].valueString';
+    plainValueRule.value = 'plain';
+    const conceptRule = new ConceptRule('bar', 'Bar');
+    const conceptFmmRule = new CaretValueRule('');
+    conceptFmmRule.pathArray = ['#bar'];
+    conceptFmmRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
+    conceptFmmRule.value = 2;
+    const conceptFmmIdRule = new CaretValueRule('');
+    conceptFmmIdRule.pathArray = ['#bar'];
+    conceptFmmIdRule.caretPath = 'extension[structuredefinition-fmm].id';
+    conceptFmmIdRule.value = 'concept-fmm';
+    const conceptPlainUrlRule = new CaretValueRule('');
+    conceptPlainUrlRule.pathArray = ['#bar'];
+    conceptPlainUrlRule.caretPath = 'extension[1].url';
+    conceptPlainUrlRule.value = 'http://example.org/StructureDefinition/plain';
+    const conceptPlainValueRule = new CaretValueRule('');
+    conceptPlainValueRule.pathArray = ['#bar'];
+    conceptPlainValueRule.caretPath = 'extension[1].valueString';
+    conceptPlainValueRule.value = 'concept plain';
+    codeSystem.rules.push(
+      fmmRule,
+      fmmIdRule,
+      plainUrlRule,
+      plainValueRule,
+      conceptRule,
+      conceptFmmRule,
+      conceptFmmIdRule,
+      conceptPlainUrlRule,
+      conceptPlainValueRule
+    );
+    doc.codeSystems.set(codeSystem.name, codeSystem);
+    const exported = exporter.export().codeSystems;
+    expect(exported.length).toBe(1);
+    expect(exported[0].extension).toEqual([
+      {
+        id: 'fmm',
+        url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
+        valueInteger: 1
+      },
+      {
+        url: 'http://example.org/StructureDefinition/plain',
+        valueString: 'plain'
+      }
+    ]);
+    expect(exported[0].concept[0].extension).toEqual([
+      {
+        id: 'concept-fmm',
+        url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
+        valueInteger: 2
+      },
+      {
+        url: 'http://example.org/StructureDefinition/plain',
+        valueString: 'concept plain'
+      }
+    ]);
+    expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+    expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+  });
+
   it('should output an error when a choice element has values assigned to more than one choice type', () => {
     const codeSystem = new FshCodeSystem('MultiChoiceSystem')
       .withFile('MultipleChoice.fsh')

--- a/test/export/ValueSetExporter.test.ts
+++ b/test/export/ValueSetExporter.test.ts
@@ -2659,6 +2659,44 @@ describe('ValueSetExporter', () => {
     expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
   });
 
+  it('should apply several caret rules to the same extension slice and to a numerically indexed extension', () => {
+    // ValueSet: ExtensionVS
+    // * ^extension[structuredefinition-fmm].valueInteger = 1
+    // * ^extension[structuredefinition-fmm].id = "fmm"
+    // * ^extension[1].url = "http://example.org/StructureDefinition/plain"
+    // * ^extension[1].valueString = "plain"
+    const valueSet = new FshValueSet('ExtensionVS');
+    const fmmRule = new CaretValueRule('');
+    fmmRule.caretPath = 'extension[structuredefinition-fmm].valueInteger';
+    fmmRule.value = 1;
+    const fmmIdRule = new CaretValueRule('');
+    fmmIdRule.caretPath = 'extension[structuredefinition-fmm].id';
+    fmmIdRule.value = 'fmm';
+    const plainUrlRule = new CaretValueRule('');
+    plainUrlRule.caretPath = 'extension[1].url';
+    plainUrlRule.value = 'http://example.org/StructureDefinition/plain';
+    const plainValueRule = new CaretValueRule('');
+    plainValueRule.caretPath = 'extension[1].valueString';
+    plainValueRule.value = 'plain';
+    valueSet.rules.push(fmmRule, fmmIdRule, plainUrlRule, plainValueRule);
+    doc.valueSets.set(valueSet.name, valueSet);
+    const exported = exporter.export().valueSets;
+    expect(exported.length).toBe(1);
+    expect(exported[0].extension).toEqual([
+      {
+        id: 'fmm',
+        url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm',
+        valueInteger: 1
+      },
+      {
+        url: 'http://example.org/StructureDefinition/plain',
+        valueString: 'plain'
+      }
+    ]);
+    expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+    expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
+  });
+
   it('should apply a CaretValueRule that assigns an inline Instance', () => {
     // ValueSet: BreakfastVS
     // Title: "Breakfast Values"

--- a/test/fshtypes/FshCodeSystem.test.ts
+++ b/test/fshtypes/FshCodeSystem.test.ts
@@ -86,6 +86,23 @@ describe('FshCodeSystem', () => {
       p.rules = [secondIdRule];
       expect(p.id).toBe('second-id');
     });
+
+    it('should not return an id set by a code caret rule after its path is resolved', () => {
+      const p = new FshCodeSystem('MyCodeSystem');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = 'different-id';
+      // a code caret rule has an empty path until the exporter resolves it to the concept's path
+      const conceptIdRule = new CaretValueRule('');
+      conceptIdRule.pathArray = ['#foo'];
+      conceptIdRule.caretPath = 'id';
+      conceptIdRule.value = 'foo-element-id';
+      p.rules.push(idRule, conceptIdRule);
+      // reading the id here caches the rule that was found
+      expect(p.id).toBeDefined();
+      conceptIdRule.path = 'concept[0]';
+      expect(p.id).toBe('different-id');
+    });
   });
 
   describe('#toFSH', () => {

--- a/test/fshtypes/FshCodeSystem.test.ts
+++ b/test/fshtypes/FshCodeSystem.test.ts
@@ -44,6 +44,48 @@ describe('FshCodeSystem', () => {
       p.rules.push(idRule);
       expect(p.id).toBe('MyCodeSystem');
     });
+
+    it('should return an id set by a caret rule added after the id was read', () => {
+      const p = new FshCodeSystem('MyCodeSystem');
+      expect(p.id).toBe('MyCodeSystem');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = 'different-id';
+      p.rules.push(idRule);
+      expect(p.id).toBe('different-id');
+    });
+
+    it('should return the last id set by caret rules as the rules change', () => {
+      const p = new FshCodeSystem('MyCodeSystem');
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = 'first-id';
+      p.rules.push(idRule);
+      expect(p.id).toBe('first-id');
+      // a rule pushed after the first read must be found
+      const secondIdRule = new CaretValueRule('');
+      secondIdRule.caretPath = 'id';
+      secondIdRule.value = 'second-id';
+      p.rules.push(secondIdRule);
+      expect(p.id).toBe('second-id');
+      // a rule that replaces the last rule must be found
+      const thirdIdRule = new CaretValueRule('');
+      thirdIdRule.caretPath = 'id';
+      thirdIdRule.value = 'third-id';
+      p.rules.pop();
+      p.rules.push(thirdIdRule);
+      expect(p.id).toBe('third-id');
+      // a change to the rule's value must be reflected
+      thirdIdRule.value = 'changed-id';
+      expect(p.id).toBe('changed-id');
+      // removing the rules must be reflected
+      p.rules.pop();
+      p.rules.pop();
+      expect(p.id).toBe('MyCodeSystem');
+      // replacing the rules array (as applyInsertRules does) must be reflected
+      p.rules = [secondIdRule];
+      expect(p.id).toBe('second-id');
+    });
   });
 
   describe('#toFSH', () => {

--- a/test/fshtypes/Instance.test.ts
+++ b/test/fshtypes/Instance.test.ts
@@ -43,6 +43,36 @@ describe('Instance', () => {
       // the id is still the default
       expect(p.id).toBe('MyInstance');
     });
+
+    it('should return the last id set by assignment rules as the rules change', () => {
+      const p = new Instance('MyInstance');
+      expect(p.id).toBe('MyInstance');
+      const idRule = new AssignmentRule('id');
+      idRule.value = 'first-id';
+      p.rules.push(idRule);
+      expect(p.id).toBe('first-id');
+      // a rule pushed after the first read must be found
+      const secondIdRule = new AssignmentRule('id');
+      secondIdRule.value = 'second-id';
+      p.rules.push(secondIdRule);
+      expect(p.id).toBe('second-id');
+      // a rule that replaces the last rule must be found
+      const thirdIdRule = new AssignmentRule('id');
+      thirdIdRule.value = 'third-id';
+      p.rules.pop();
+      p.rules.push(thirdIdRule);
+      expect(p.id).toBe('third-id');
+      // a change to the rule's value must be reflected
+      thirdIdRule.value = 'changed-id';
+      expect(p.id).toBe('changed-id');
+      // removing the rules must be reflected
+      p.rules.pop();
+      p.rules.pop();
+      expect(p.id).toBe('MyInstance');
+      // replacing the rules array (as applyInsertRules does) must be reflected
+      p.rules = [secondIdRule];
+      expect(p.id).toBe('second-id');
+    });
   });
 
   describe('#toFSH', () => {

--- a/test/import/FSHTank.test.ts
+++ b/test/import/FSHTank.test.ts
@@ -332,6 +332,31 @@ describe('FSHTank', () => {
       // not applicable for Instance or Invariant or RuleSet or Mapping
     });
 
+    it('should find valid fish by id, name, or url after the rules change', () => {
+      expect(tank.fish('cs1').name).toBe('CodeSystem1');
+      expect(tank.fish('new-cs1')).toBeUndefined();
+      expect(tank.fish('http://foo.org/CodeSystem/new-cs1')).toBeUndefined();
+      expect(tank.fish('NewCodeSystem1')).toBeUndefined();
+      const cs1 = tank.fish('cs1') as FshCodeSystem;
+      const idRule = new CaretValueRule('');
+      idRule.caretPath = 'id';
+      idRule.value = 'new-cs1';
+      const urlRule = new CaretValueRule('');
+      urlRule.caretPath = 'url';
+      urlRule.value = 'http://foo.org/CodeSystem/new-cs1';
+      const nameRule = new CaretValueRule('');
+      nameRule.caretPath = 'name';
+      nameRule.value = 'NewCodeSystem1';
+      cs1.rules.push(idRule, urlRule, nameRule);
+      expect(tank.fish('cs1', Type.CodeSystem)).toBeUndefined();
+      expect(tank.fish('new-cs1').name).toBe('CodeSystem1');
+      expect(tank.fish('http://foo.org/CodeSystem/new-cs1').name).toBe('CodeSystem1');
+      expect(tank.fish('NewCodeSystem1').name).toBe('CodeSystem1');
+      cs1.rules = [];
+      expect(tank.fish('cs1').name).toBe('CodeSystem1');
+      expect(tank.fish('new-cs1')).toBeUndefined();
+    });
+
     it('should not find fish when fishing by invalid name/id/url', () => {
       expect(tank.fish('ProfileFake')).toBeUndefined();
     });


### PR DESCRIPTION
**Description:**

SUSHI slows down sharply as a CodeSystem grows. Profiling a 9,347-concept CodeSystem (about 56,000 code caret rules for designations and properties) showed two costs that grow with the number of rules, so this PR fixes both:

1. **Rebuilding the StructureDefinition for every caret rule.** `setPropertyOnDefinitionInstance` called `instance.getOwnStructureDefinition(fisher)` (a package lookup plus `StructureDefinition.fromJSON`) on each call. For a CodeSystem that is once per code caret rule, and it was 83% of the build. The function now takes the StructureDefinition as an optional final parameter (default unchanged), and `CodeSystemExporter` and `ValueSetExporter` pass in the one they already built. Sharing one StructureDefinition across an entity's rules has precedent: the validation pass in these exporters already did it, and `InstanceExporter` reuses cached StructureDefinitions across all of an instance's rules. In the same code path, `findConceptPath` and `setConcepts` index concepts by code instead of scanning the concept list for every rule, and `setPropertyOnInstance` fills a large array from its current end instead of from index 0 (the old loop re-read the array length each iteration, and each iteration pushed one element, so starting at the current length adds exactly the same elements).

2. **Scanning every rule to find a definition's id, url, name, or version.** `findAssignmentByPath` did a `findLast` over all rules, and `FSHTank.fish` does that for every entity it checks on every fish. In an IG with several large CodeSystems, every lookup of a Reference or code system walked tens of thousands of rules, which was 63% of what remained after fix 1. The found rule is now cached per rules array. Rules arrays are only appended to or replaced wholesale (as `applyInsertRules` does), so the cache is invalidated when the array is replaced, when its length changes, or when its last rule changes. Because the rule rather than its value is cached, changes to a rule's value are still seen, and a cached rule is re-checked against the lookup on each hit because `CodeSystemExporter` rewrites a code caret rule's `path` in place once it resolves the concept.

Measurements (Node 22, `sushi` on the same machine):

| Build | master | fix 1 | fix 1 + 2 |
|---|---|---|---|
| One CodeSystem with 9,347 concepts, FSHOnly | 147 s, 750 MB | 15 s, 594 MB | 8 s, 598 MB |
| IG with 32 large CodeSystems written in FSH | not measured (many minutes) | 142 s | 52 s |

For comparison, the same IG with those 32 CodeSystems pre-rendered to JSON in `input/` (the workaround the project uses today) builds in 31 s. Most of the remaining gap is ANTLR parsing of the large FSH files.

Output is unchanged: the generated JSON for the 9,347-concept CodeSystem is byte-identical to master, and every other resource in the IG is identical to the pre-rendered build.

Developed with AI assistance (Claude Code). The diff, tests, and measurements were reviewed before submitting.

**Testing Instructions:**

Run `npm run check`. New tests in `test/fshtypes/FshCodeSystem.test.ts`, `test/fshtypes/Instance.test.ts` and `test/import/FSHTank.test.ts` cover the cache being invalidated when rules are added, removed, replaced, their values change, or a code caret rule's path is resolved. New tests in `test/export/CodeSystemExporter.test.ts` and `test/export/ValueSetExporter.test.ts` pin the output when several caret rules target the same extension slice and a numerically indexed extension, since the shared StructureDefinition now carries the slices added by earlier rules.

To see the performance difference, run `sushi` on a project containing a CodeSystem with a few thousand concepts that each have a designation or property.

**Related Issue:**

None.

https://claude.ai/code/session_01AKNbxASp6vABedSLJMGW97
