### PR TITLE
Fix missing null-padded value arrays on repeating primitives

### DIFF
--- a/src/fhirtypes/common.ts
+++ b/src/fhirtypes/common.ts
@@ -1170,9 +1170,19 @@ export function replaceField(
     } else if (typeof object[prop] === 'object' && !skipFn(prop)) {
       replaceField(object[prop], matchFn, replaceFn, skipFn);
 
-      // If the object[prop] was an array and all items were replaced by null using the replaceFn, get rid of the whole array
+      // If the object[prop] was an array and all items were replaced by null using the replaceFn, get rid of the whole array.
+      // Repeating FHIR primitives are two parallel arrays (value and _value). Keep a null-padded value array when the
+      // companion _value array still has id or extension data so the arrays stay aligned.
+      // See https://hl7.org/fhir/json.html#primitive and https://github.com/FHIR/sushi/issues/1631.
+      // Empty objects are not companion data; they become null in this same pass.
       if (Array.isArray(object[prop]) && object[prop].every((v: any) => v == null)) {
-        delete object[prop];
+        const companion = prop.startsWith('_') ? undefined : object[`_${prop}`];
+        const companionHasData =
+          Array.isArray(companion) &&
+          companion.some((v: any) => v != null && (typeof v !== 'object' || !isEmpty(v)));
+        if (!companionHasData) {
+          delete object[prop];
+        }
       }
 
       // Since an array could have been deleted, the whole object[prop] could have ended up as empty.

--- a/test/export/InstanceExporter.test.ts
+++ b/test/export/InstanceExporter.test.ts
@@ -5777,6 +5777,112 @@ describe('InstanceExporter', () => {
       ]);
     });
 
+    // Issue #1631: repeating primitives with only id/extension must keep a null-padded value array
+    describe('Issue #1631', () => {
+      const displayUrl = 'http://hl7.org/fhir/StructureDefinition/display';
+
+      it('should keep a null-padded value array when a repeating primitive has only an extension', () => {
+        // Instance: NoValues
+        // InstanceOf: Patient
+        // * name[0].given[0].extension[0].url = http://hl7.org/fhir/StructureDefinition/display
+        // * name[0].given[0].extension[0].valueString = "ext on given[0]"
+        const instance = new Instance('NoValues');
+        instance.instanceOf = 'Patient';
+        const urlRule = new AssignmentRule('name[0].given[0].extension[0].url');
+        urlRule.value = displayUrl;
+        const valueRule = new AssignmentRule('name[0].given[0].extension[0].valueString');
+        valueRule.value = 'ext on given[0]';
+        instance.rules.push(urlRule, valueRule);
+        const exported = exportInstance(instance);
+        expect(exported.name[0]).toEqual({
+          given: [null],
+          _given: [
+            {
+              extension: [
+                {
+                  url: displayUrl,
+                  valueString: 'ext on given[0]'
+                }
+              ]
+            }
+          ]
+        });
+      });
+
+      it('should keep aligned value and underscore arrays when a repeating primitive has mixed values and extensions', () => {
+        // Instance: SomeValues
+        // InstanceOf: Patient
+        // * name[0].given[0] = "Xavier"
+        // * name[0].given[1].extension[0].url = http://hl7.org/fhir/StructureDefinition/display
+        // * name[0].given[1].extension[0].valueString = "ext on given[1]"
+        const instance = new Instance('SomeValues');
+        instance.instanceOf = 'Patient';
+        const givenRule = new AssignmentRule('name[0].given[0]');
+        givenRule.value = 'Xavier';
+        const urlRule = new AssignmentRule('name[0].given[1].extension[0].url');
+        urlRule.value = displayUrl;
+        const valueRule = new AssignmentRule('name[0].given[1].extension[0].valueString');
+        valueRule.value = 'ext on given[1]';
+        instance.rules.push(givenRule, urlRule, valueRule);
+        const exported = exportInstance(instance);
+        expect(exported.name[0]).toEqual({
+          given: ['Xavier', null],
+          _given: [
+            null,
+            {
+              extension: [
+                {
+                  url: displayUrl,
+                  valueString: 'ext on given[1]'
+                }
+              ]
+            }
+          ]
+        });
+      });
+
+      it('should not add a dummy null value on a non-repeating primitive that has only an extension', () => {
+        // Instance: NonRepeating
+        // InstanceOf: Patient
+        // * name[0].family.extension[0].url = http://hl7.org/fhir/StructureDefinition/display
+        // * name[0].family.extension[0].valueString = "ext on family"
+        const instance = new Instance('NonRepeating');
+        instance.instanceOf = 'Patient';
+        const urlRule = new AssignmentRule('name[0].family.extension[0].url');
+        urlRule.value = displayUrl;
+        const valueRule = new AssignmentRule('name[0].family.extension[0].valueString');
+        valueRule.value = 'ext on family';
+        instance.rules.push(urlRule, valueRule);
+        const exported = exportInstance(instance);
+        expect(exported.name[0]).toEqual({
+          _family: {
+            extension: [
+              {
+                url: displayUrl,
+                valueString: 'ext on family'
+              }
+            ]
+          }
+        });
+      });
+
+      it('should keep a null-padded value array when a repeating primitive has only an id', () => {
+        // Instance: NoValuesId
+        // InstanceOf: Patient
+        // * name[0].given[0].id = "given-0"
+        const instance = new Instance('NoValuesId');
+        instance.instanceOf = 'Patient';
+        const idRule = new AssignmentRule('name[0].given[0].id');
+        idRule.value = 'given-0';
+        instance.rules.push(idRule);
+        const exported = exportInstance(instance);
+        expect(exported.name[0]).toEqual({
+          given: [null],
+          _given: [{ id: 'given-0' }]
+        });
+      });
+    });
+
     // Assigning References
     it('should assign a reference while resolving the Instance of a resource being referred to', () => {
       const orgInstance = new Instance('TestOrganization');
@@ -10342,7 +10448,7 @@ describe('InstanceExporter', () => {
       // In-memory result should be correct
       const result = exportInstance(patientInstance);
       expect(result.address).toHaveLength(1);
-      expect(result.address[0].line).toBeUndefined();
+      expect(result.address[0].line).toEqual([null, null]);
       expect(result.address[0]._line).toHaveLength(2);
       expect(result.address[0]._line[0]).toBeNull();
       expect(result.address[0]._line[1].extension).toEqual([
@@ -10355,7 +10461,7 @@ describe('InstanceExporter', () => {
       // JSON representation should be correct
       const json = result.toJSON();
       expect(json.address).toHaveLength(1);
-      expect(json.address[0].line).toBeUndefined();
+      expect(json.address[0].line).toEqual([null, null]);
       expect(json.address[0]._line).toHaveLength(2);
       expect(json.address[0]._line[0]).toBeNull();
       expect(json.address[0]._line[1].extension).toEqual([

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -8981,7 +8981,7 @@ describe('StructureDefinitionExporter R4', () => {
       exporter.export();
       const parentSd = pkg.profiles[0];
       const parentComponent = parentSd.elements.find(el => el.id === 'Observation.component');
-      expect(parentComponent.type[0].aggregation).toBeUndefined();
+      expect(parentComponent.type[0].aggregation).toEqual([null, null]);
       expect(parentComponent.type[0]._aggregation).toEqual([
         null,
         {


### PR DESCRIPTION
**Description:**

Keep a null-padded value array next to `_element` when every entry of a repeating primitive has only an `id` or `extension` and no value. FHIR JSON requires the value array to stay, null-filled, so the two arrays align (https://hl7.org/fhir/json.html#primitive). Mixed arrays (`"given": ["Xavier", null]` next to `"_given"`) already did this; the all-values-absent case did not.

`setPropertyOnInstance` already builds both arrays. `cleanResource` → `replaceField` then turned empty `{}` placeholders into `null` and deleted any array that was all null. That deletion now leaves the value array in place when the companion `_` array still has id or extension data. All-null `_` arrays are still dropped. Non-repeating primitives (`family` + `_family` only) are unchanged.

The same cleanup runs for StructureDefinitions, so a caret rule that puts only extensions on a repeating primitive such as `type.aggregation` now keeps `"aggregation": [null, null]` next to `_aggregation`. An existing test had encoded the old omission and was updated.

Keep an all-null value array only when `_${name}` has a non-empty element. Empty `{}` on the companion is not treated as data, because those objects become `null` in the same pass. The alternative (keep whenever the sibling is `!= null`) would leave `searchInclude: [null]` on PathRule-only primitives and break the existing CapabilityStatement instance test. A two-pass clean (recurse first, then drop all-null arrays) would also work.

Fixes #1631.

**Testing Instructions:**

- `npm test -- test/export/InstanceExporter.test.ts test/export/StructureDefinitionExporter.test.ts`
- `npm run check`
- Or in FSH Online / a local FSHOnly project, the four instances from #1631: `NoValues` and `NoValuesId` should now emit `"given": [null]` next to `"_given"`; `SomeValues` and `NonRepeating` should stay as they are.

**Related Issue:**

https://github.com/FHIR/sushi/issues/1631
